### PR TITLE
Make RedisClient initializations public

### DIFF
--- a/Source/Objects/Custom Hardware/SNO+/RedisClient/RedisClient.h
+++ b/Source/Objects/Custom Hardware/SNO+/RedisClient/RedisClient.h
@@ -18,6 +18,8 @@
 @property (nonatomic) int port;
 @property (nonatomic) long timeout;
 
+- (id)init;
+- (id)initWithHostName: (NSString*) _host withPort: (int) _port;
 - (void) connect;
 - (void) disconnect;
 - (redisReply*) vcommand: (const char*) fmt args:(va_list) args;

--- a/Source/Objects/Custom Hardware/SNO+/RedisClient/RedisClient.m
+++ b/Source/Objects/Custom Hardware/SNO+/RedisClient/RedisClient.m
@@ -29,7 +29,7 @@
     return timeout;
 }
 
-- (instancetype)init
+- (id)init
 {
     self = [self initWithHostName: @"" withPort: -1];
     return self;


### PR DESCRIPTION
Also changed the return value of RedisClient's init from instance_type to id.