### PR TITLE
Fix lock behavior for MTC GUI

### DIFF
--- a/Source/Objects/Custom Hardware/SNO+/MTC/MTC.xib
+++ b/Source/Objects/Custom Hardware/SNO+/MTC/MTC.xib
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="7706" systemVersion="14F27" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="7706" systemVersion="14B25" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
     <dependencies>
         <deployment version="1060" identifier="macosx"/>
         <development version="5100" identifier="xcode"/>
@@ -11,6 +11,10 @@
                 <outlet property="autoIncrementCB" destination="1316" id="1318"/>
                 <outlet property="basicOpsLockButton" destination="2944" id="2954"/>
                 <outlet property="basicOpsRunningIndicator" destination="1324" id="1326"/>
+                <outlet property="clearGTCratesButton" destination="4467" id="0Xb-zw-AO5"/>
+                <outlet property="clearMTCAMaskButton" destination="4473" id="p8l-Gn-iOO"/>
+                <outlet property="clearPEDCratesButton" destination="4470" id="6ID-yE-5zA"/>
+                <outlet property="clearTriggersButton" destination="4464" id="T06-0D-vbt"/>
                 <outlet property="coarseDelayField" destination="1834" id="2516"/>
                 <outlet property="continuePedestalsButton" destination="4056" id="4089"/>
                 <outlet property="continuousButton" destination="1473" id="3882"/>
@@ -71,13 +75,14 @@
                 <outlet property="selectedRegisterPU" destination="1261" id="1267"/>
                 <outlet property="setCoarseDelayButton" destination="4158" id="4434"/>
                 <outlet property="setFineDelayButton" destination="4170" id="4433"/>
-                <outlet property="settingsLockButton" destination="2948" id="2950"/>
+                <outlet property="settingsLockButton" destination="2948" id="YqP-B4-Zwx"/>
                 <outlet property="standardOpsLockButton" destination="2946" id="2952"/>
                 <outlet property="stopFixedTimePedestalsButton" destination="4054" id="4100"/>
                 <outlet property="stopPedestalsButton" destination="4057" id="4088"/>
                 <outlet property="stopTriggerZeroButton" destination="1475" id="3883"/>
                 <outlet property="tabView" destination="599" id="1014"/>
                 <outlet property="triggerZeroMatrix" destination="1459" id="3879"/>
+                <outlet property="triggersLockButton" destination="3226" id="ISm-vi-41l"/>
                 <outlet property="useMemoryMatrix" destination="1218" id="1298"/>
                 <outlet property="window" destination="21" id="307"/>
                 <outlet property="writeValueField" destination="1228" id="2824"/>
@@ -419,7 +424,7 @@
                                                 <font key="font" metaFont="label"/>
                                             </buttonCell>
                                             <connections>
-                                                <action selector="lockAction:" target="-2" id="2955"/>
+                                                <action selector="basicLockAction:" target="-2" id="vtq-xf-bWj"/>
                                             </connections>
                                         </button>
                                     </subviews>
@@ -428,7 +433,7 @@
                             <tabViewItem label="Standard Ops" identifier="" id="1358">
                                 <view key="view" id="1359">
                                     <rect key="frame" x="10" y="25" width="773" height="601"/>
-                                    <autoresizingMask key="autoresizingMask"/>
+                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <box borderType="line" titlePosition="noTitle" id="1366">
                                             <rect key="frame" x="15" y="486" width="509" height="111"/>
@@ -922,7 +927,7 @@
                                                 <font key="font" metaFont="label"/>
                                             </buttonCell>
                                             <connections>
-                                                <action selector="lockAction:" target="-2" id="2953"/>
+                                                <action selector="standardOpsLockAction:" target="-2" id="nAp-7p-o4B"/>
                                             </connections>
                                         </button>
                                         <box autoresizesSubviews="NO" title="Pulser feeds" borderType="line" id="4534">
@@ -969,7 +974,7 @@
                             <tabViewItem label="Settings" identifier="" id="1483">
                                 <view key="view" id="1484">
                                     <rect key="frame" x="10" y="25" width="773" height="601"/>
-                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <box title="MTC/D" borderType="line" id="1488">
                                             <rect key="frame" x="7" y="154" width="361" height="196"/>
@@ -1800,7 +1805,7 @@
                                             <color key="fillColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                         </box>
                                         <button verticalHuggingPriority="750" id="2057">
-                                            <rect key="frame" x="14.5" y="504" width="115" height="28"/>
+                                            <rect key="frame" x="15" y="504" width="115" height="28"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <buttonCell key="cell" type="push" title="Load from DB" bezelStyle="rounded" alignment="center" controlSize="small" enabled="NO" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="4011">
                                                 <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
@@ -1811,7 +1816,7 @@
                                             </connections>
                                         </button>
                                         <button verticalHuggingPriority="750" id="4176">
-                                            <rect key="frame" x="14.5" y="424" width="115" height="28"/>
+                                            <rect key="frame" x="15" y="424" width="115" height="28"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <buttonCell key="cell" type="push" title="Verify settings" bezelStyle="rounded" alignment="center" controlSize="small" enabled="NO" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="4177">
                                                 <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
@@ -1833,7 +1838,7 @@
                                             </connections>
                                         </button>
                                         <button verticalHuggingPriority="750" id="2061">
-                                            <rect key="frame" x="14.5" y="463" width="115" height="28"/>
+                                            <rect key="frame" x="15" y="463" width="115" height="28"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <buttonCell key="cell" type="push" title="Upload to DB" bezelStyle="rounded" alignment="center" controlSize="small" enabled="NO" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="4013">
                                                 <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
@@ -1889,7 +1894,7 @@
                                                 <font key="font" metaFont="label"/>
                                             </buttonCell>
                                             <connections>
-                                                <action selector="lockAction:" target="-2" id="2951"/>
+                                                <action selector="settingsLockAction:" target="-2" id="ZB6-MX-TDC"/>
                                             </connections>
                                         </button>
                                         <box verticalHuggingPriority="750" title="Box" boxType="separator" titlePosition="noTitle" id="3241">
@@ -1976,6 +1981,9 @@
                                                 <behavior key="behavior" pushIn="YES" changeContents="YES" lightByContents="YES"/>
                                                 <font key="font" metaFont="label"/>
                                             </buttonCell>
+                                            <connections>
+                                                <action selector="triggersLockAction:" target="-2" id="B6w-iQ-QN7"/>
+                                            </connections>
                                         </button>
                                         <button verticalHuggingPriority="750" id="4167">
                                             <rect key="frame" x="375" y="143" width="160" height="28"/>
@@ -1986,17 +1994,6 @@
                                             </buttonCell>
                                             <connections>
                                                 <action selector="triggersLoadTriggerMask:" target="-2" id="4453"/>
-                                            </connections>
-                                        </button>
-                                        <button verticalHuggingPriority="750" id="4464">
-                                            <rect key="frame" x="592" y="143" width="160" height="28"/>
-                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                            <buttonCell key="cell" type="push" title="Clear triggers" bezelStyle="rounded" alignment="center" controlSize="small" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="4465">
-                                                <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                                <font key="font" metaFont="smallSystem"/>
-                                            </buttonCell>
-                                            <connections>
-                                                <action selector="triggersClearTriggerMask:" target="-2" id="4476"/>
                                             </connections>
                                         </button>
                                         <button verticalHuggingPriority="750" id="4429">
@@ -3021,6 +3018,17 @@
                                             <color key="borderColor" white="0.0" alpha="0.41999999999999998" colorSpace="calibratedWhite"/>
                                             <color key="fillColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                         </box>
+                                        <button verticalHuggingPriority="750" id="4464">
+                                            <rect key="frame" x="592" y="143" width="160" height="28"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                            <buttonCell key="cell" type="push" title="Clear triggers" bezelStyle="rounded" alignment="center" controlSize="small" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="4465">
+                                                <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                                <font key="font" metaFont="smallSystem"/>
+                                            </buttonCell>
+                                            <connections>
+                                                <action selector="triggersClearTriggerMask:" target="-2" id="4476"/>
+                                            </connections>
+                                        </button>
                                     </subviews>
                                 </view>
                             </tabViewItem>

--- a/Source/Objects/Custom Hardware/SNO+/MTC/MTC.xib
+++ b/Source/Objects/Custom Hardware/SNO+/MTC/MTC.xib
@@ -67,6 +67,7 @@
                 <outlet property="pedestalWidthField" destination="1803" id="2507"/>
                 <outlet property="pulserFeedsMatrix" destination="4535" id="4539"/>
                 <outlet property="pulserPeriodField" destination="1806" id="2509"/>
+                <outlet property="readButton" destination="1253" id="YOa-8v-Q9c"/>
                 <outlet property="regBaseAddressText" destination="1282" id="1290"/>
                 <outlet property="repeatCountField" destination="1237" id="2825"/>
                 <outlet property="repeatCountStepper" destination="1239" id="1303"/>
@@ -77,6 +78,8 @@
                 <outlet property="setFineDelayButton" destination="4170" id="4433"/>
                 <outlet property="settingsLockButton" destination="2948" id="YqP-B4-Zwx"/>
                 <outlet property="standardOpsLockButton" destination="2946" id="2952"/>
+                <outlet property="statusButton" destination="1257" id="vCe-N0-3RA"/>
+                <outlet property="stopButton" destination="1259" id="kkn-k7-bsR"/>
                 <outlet property="stopFixedTimePedestalsButton" destination="4054" id="4100"/>
                 <outlet property="stopPedestalsButton" destination="4057" id="4088"/>
                 <outlet property="stopTriggerZeroButton" destination="1475" id="3883"/>
@@ -87,6 +90,7 @@
                 <outlet property="window" destination="21" id="307"/>
                 <outlet property="writeValueField" destination="1228" id="2824"/>
                 <outlet property="writeValueStepper" destination="1227" id="1297"/>
+                <outlet property="writteButton" destination="1255" id="HS0-aS-53u"/>
                 <outlet property="xilinxFileField" destination="2066" id="3240"/>
                 <outlet property="xilinxFilePathField" destination="2066" id="3568"/>
             </connections>

--- a/Source/Objects/Custom Hardware/SNO+/MTC/ORMTCController.h
+++ b/Source/Objects/Custom Hardware/SNO+/MTC/ORMTCController.h
@@ -91,6 +91,7 @@
 	IBOutlet NSTextField*	commentsField;
 
 	//trigger
+    IBOutlet NSButton*		triggersLockButton;
 	IBOutlet NSMatrix*		globalTriggerMaskMatrix;
 	IBOutlet NSMatrix*		globalTriggerCrateMaskMatrix;
 	IBOutlet NSMatrix*		pedCrateMaskMatrix;
@@ -107,6 +108,11 @@
     IBOutlet NSButton* loadPEDCrateMaskButton;
     IBOutlet NSButton* loadMTCACrateMaskButton;
     
+    IBOutlet NSButton *clearTriggersButton;
+    IBOutlet NSButton *clearGTCratesButton;
+    IBOutlet NSButton *clearPEDCratesButton;
+    IBOutlet NSButton *clearMTCAMaskButton;
+    
 	BOOL	sequenceRunning;
     NSView* blankView;
     NSSize  basicOpsSize;
@@ -122,7 +128,6 @@
 - (void) registerNotificationObservers;
 
 #pragma mark •••Interface Management
-- (void) updateButtons;
 - (void) eSumViewTypeChanged:(NSNotification*)aNote;
 - (void) nHitViewTypeChanged:(NSNotification*)aNote;
 - (void) mtcDataBaseChanged:(NSNotification*)aNote;
@@ -135,7 +140,10 @@
 - (void) writeValueChanged:(NSNotification*)aNote;
 - (void) memoryOffsetChanged:(NSNotification*)aNote;
 - (void) selectedRegisterChanged:(NSNotification*)aNote;
+- (void) basicLockChanged:(NSNotification*)aNote;
+- (void) standardOpsLockChanged:(NSNotification*)aNote;
 - (void) settingsLockChanged:(NSNotification*)aNote;
+- (void) triggersLockChanged:(NSNotification*)aNote;
 - (void) slotChanged:(NSNotification*)aNote;
 - (void) regBaseAddressChanged:(NSNotification*)aNote;
 - (void) memBaseAddressChanged:(NSNotification*)aNote;
@@ -148,7 +156,6 @@
 - (void) sequenceRunning:(NSNotification*)aNote;
 - (void) sequenceStopped:(NSNotification*)aNote;
 - (void) sequenceProgress:(NSNotification*)aNote;
-- (void) documentLockChanged:(NSNotification*)aNotification;
 - (void) triggerMTCAMaskChanged:(NSNotification*)aNotification;
 - (void) isPedestalEnabledInCSRChanged:(NSNotification*)aNotification;
 
@@ -161,7 +168,6 @@
 - (IBAction) buttonPushed:(id) sender;
 
 #pragma mark •••Actions
-- (IBAction) lockAction:(id) sender;
 
 //Basic Ops
 - (IBAction) basicReadAction:(id) sender;

--- a/Source/Objects/Custom Hardware/SNO+/MTC/ORMTCController.h
+++ b/Source/Objects/Custom Hardware/SNO+/MTC/ORMTCController.h
@@ -38,11 +38,16 @@
     IBOutlet NSTextField*   slotField;
     IBOutlet NSStepper* 	regBaseAddressStepper;
     IBOutlet NSTextField* 	regBaseAddressText;
-    IBOutlet NSStepper* 	memBaseAddressStepper;
     IBOutlet NSTextField* 	memBaseAddressText;
+    IBOutlet NSStepper* 	memBaseAddressStepper;
 	IBOutlet NSButton*		basicOpsLockButton;
  	IBOutlet NSTextField*	defaultFileField;
-	
+    IBOutlet NSButton *readButton;
+    IBOutlet NSButton *writteButton;
+    IBOutlet NSButton *stopButton;
+    IBOutlet NSButton *statusButton;
+
+    
 	//standard Ops
 	IBOutlet NSButton*		standardOpsLockButton;
 	IBOutlet NSButton*		initMtcButton;

--- a/Source/Objects/Custom Hardware/SNO+/MTC/ORMTCController.m
+++ b/Source/Objects/Custom Hardware/SNO+/MTC/ORMTCController.m
@@ -516,8 +516,26 @@
 {
 
     BOOL locked						= [gSecurity isLocked:ORMTCBasicLock];
+    BOOL lockedOrNotRunningMaintenance = [gSecurity runInProgressButNotType:eMaintenanceRunType orIsLocked:ORMTCBasicLock];
 
     [basicOpsLockButton setState: locked];
+    
+    [autoIncrementCB setEnabled: !lockedOrNotRunningMaintenance];
+    [useMemoryMatrix setEnabled: !lockedOrNotRunningMaintenance];
+    [repeatDelayField setEnabled: !lockedOrNotRunningMaintenance];
+    [repeatDelayStepper setEnabled: !lockedOrNotRunningMaintenance];
+    [repeatCountField setEnabled: !lockedOrNotRunningMaintenance];
+    [repeatCountStepper setEnabled: !lockedOrNotRunningMaintenance];
+    [writeValueField setEnabled: !lockedOrNotRunningMaintenance];
+    [writeValueStepper setEnabled: !lockedOrNotRunningMaintenance];
+    [memoryOffsetField setEnabled: !lockedOrNotRunningMaintenance];
+    [memoryOffsetStepper setEnabled: !lockedOrNotRunningMaintenance];
+    [selectedRegisterPU setEnabled: !lockedOrNotRunningMaintenance];
+    [memBaseAddressStepper setEnabled: !lockedOrNotRunningMaintenance];
+    [readButton setEnabled: !lockedOrNotRunningMaintenance];
+    [writteButton setEnabled: !lockedOrNotRunningMaintenance];
+    [stopButton setEnabled: !lockedOrNotRunningMaintenance];
+    [statusButton setEnabled: !lockedOrNotRunningMaintenance];
     
 }
 

--- a/Source/Objects/Custom Hardware/SNO+/MTC/ORMTCController.m
+++ b/Source/Objects/Custom Hardware/SNO+/MTC/ORMTCController.m
@@ -104,16 +104,46 @@
 						 name : ORVmeCardSlotChangedNotification
 					   object : model];
 	
-	[notifyCenter addObserver : self
-					 selector : @selector(settingsLockChanged:)
-						 name : ORRunStatusChangedNotification
-					   object : nil];
-	
     [notifyCenter addObserver : self
-					 selector : @selector(settingsLockChanged:)
-						 name : ORMTCLock
-						object: nil];
+                     selector : @selector(basicLockChanged:)
+                         name : ORRunStatusChangedNotification
+                       object : nil];
 
+    [notifyCenter addObserver : self
+                     selector : @selector(standardOpsLockChanged:)
+                         name : ORRunStatusChangedNotification
+                       object : nil];
+    
+    [notifyCenter addObserver : self
+                     selector : @selector(settingsLockChanged:)
+                         name : ORRunStatusChangedNotification
+                       object : nil];
+    
+    [notifyCenter addObserver : self
+                     selector : @selector(triggersLockChanged:)
+                         name : ORRunStatusChangedNotification
+                       object : nil];
+    
+    [notifyCenter addObserver : self
+                     selector : @selector(basicLockChanged:)
+                         name : ORMTCBasicLock
+                        object: nil];
+    
+    [notifyCenter addObserver : self
+                     selector : @selector(standardOpsLockChanged:)
+                         name : ORMTCStandardOpsLock
+                        object: nil];
+    
+    [notifyCenter addObserver : self
+                     selector : @selector(settingsLockChanged:)
+                         name : ORMTCSettingsLock
+                        object: nil];
+    
+    [notifyCenter addObserver : self
+                     selector : @selector(triggersLockChanged:)
+                         name : ORMTCTriggersLock
+                        object: nil];
+    
     [notifyCenter addObserver : self
                      selector : @selector(selectedRegisterChanged:)
                          name : ORMTCModelSelectedRegisterChanged
@@ -210,16 +240,6 @@
 						object: model];
     
     [notifyCenter addObserver : self
-                     selector : @selector(documentLockChanged:)
-                         name : ORRunStatusChangedNotification
-                       object : nil];
-
-    [notifyCenter addObserver : self
-                     selector : @selector(documentLockChanged:)
-                         name : ORDocumentLock
-                       object : nil];
-
-    [notifyCenter addObserver : self
                      selector : @selector(triggerMTCAMaskChanged:)
                          name : ORMTCModelMTCAMaskChanged
                        object : nil];
@@ -237,7 +257,10 @@
     [self regBaseAddressChanged:nil];
     [self memBaseAddressChanged:nil];
     [self slotChanged:nil];
+    [self basicLockChanged:nil];
+    [self standardOpsLockChanged:nil];
     [self settingsLockChanged:nil];
+    [self triggersLockChanged:nil];
 	[self selectedRegisterChanged:nil];
 	[self memoryOffsetChanged:nil];
 	[self writeValueChanged:nil];
@@ -253,7 +276,6 @@
 	[self isPulserFixedRateChanged:nil];
 	[self fixedPulserRateCountChanged:nil];
 	[self fixedPulserRateDelayChanged:nil];
-    [self documentLockChanged:nil];
     [self triggerMTCAMaskChanged:nil];
     [self isPedestalEnabledInCSRChanged:nil];
 }
@@ -261,57 +283,17 @@
 - (void) checkGlobalSecurity
 {
     BOOL secure = [[[NSUserDefaults standardUserDefaults] objectForKey:OROrcaSecurityEnabled] boolValue];
-    [gSecurity setLock:ORMTCLock to:secure];
-    [settingsLockButton setEnabled:secure];
+    [gSecurity setLock:ORMTCBasicLock to:secure];
     [basicOpsLockButton setEnabled:secure];
+    [gSecurity setLock:ORMTCStandardOpsLock to:secure];
     [standardOpsLockButton setEnabled:secure];
-	[self updateButtons];
+    [gSecurity setLock:ORMTCSettingsLock to:secure];
+    [settingsLockButton setEnabled:secure];
+    [gSecurity setLock:ORMTCTriggersLock to:secure];
+    [triggersLockButton setEnabled:secure];
 }
 
 #pragma mark •••Interface Management
-
-- (void) updateButtons
-{
-    //BOOL runInProgress = [gOrcaGlobals runInProgress];
-   //BOOL locked	= [gSecurity isLocked:ORMTCLock] ;
-    BOOL lockedOrRunningMaintenance = [gSecurity runInProgressButNotType:eMaintenanceRunType orIsLocked:ORMTCLock] | sequenceRunning;
-
-	[initMtcButton				setEnabled: !lockedOrRunningMaintenance];
-	[initNoXilinxButton			setEnabled: !lockedOrRunningMaintenance];
-	[initNo10MHzButton			setEnabled: !lockedOrRunningMaintenance];
-	[initNoXilinxNo100MHzButton setEnabled: !lockedOrRunningMaintenance];
-	//[load10MhzCounterButton		setEnabled: !lockedOrRunningMaintenance];
-	//[loadOnlineMaskButton		setEnabled: !lockedOrRunningMaintenance];
-	//[loadDacsButton				setEnabled: !lockedOrRunningMaintenance];
-	//[firePedestalsButton		setEnabled: !lockedOrRunningMaintenance];
-	//[triggerZeroMatrix			setEnabled: !lockedOrRunningMaintenance];
-	//[findTriggerZerosButton		setEnabled: !lockedOrRunningMaintenance];
-	//[continuousButton			setEnabled: !lockedOrRunningMaintenance];
-	//[stopTriggerZeroButton		setEnabled: !lockedOrRunningMaintenance];
-	//[setCoarseDelayButton		setEnabled: !lockedOrRunningMaintenance];
-	
-	//we want to fire pedestals during runs
-	[firePedestalsButton		setEnabled: !sequenceRunning && [model isPulserFixedRate]];
-	[stopPedestalsButton		setEnabled: !sequenceRunning && [model isPulserFixedRate]];
-	[continuePedestalsButton	setEnabled: !sequenceRunning && [model isPulserFixedRate]];
-	[fireFixedTimePedestalsButton	setEnabled: !sequenceRunning && ![model isPulserFixedRate]];
-	[stopFixedTimePedestalsButton	setEnabled: !sequenceRunning && ![model isPulserFixedRate]];
-	[fixedTimePedestalsCountField	setEnabled: !sequenceRunning && ![model isPulserFixedRate]];
-	[fixedTimePedestalsDelayField	setEnabled: !sequenceRunning && ![model isPulserFixedRate]];	
-    //and set thresholds
-	[load10MhzCounterButton		setEnabled:YES];
-	[firePedestalsButton		setEnabled:YES];
-	[setCoarseDelayButton		setEnabled:YES];
-}
-
-- (void) documentLockChanged:(NSNotification*)aNotification
-{
-    if([gSecurity isLocked:ORDocumentLock]) [lockDocField setStringValue:@"Document is locked."];
-    else if([gOrcaGlobals runInProgress])   [lockDocField setStringValue:@"Run In Progress"];
-    else				    [lockDocField setStringValue:@""];
-    [self updateButtons];
-}
-
 - (void) sequenceRunning:(NSNotification*)aNote
 {
 	sequenceRunning = YES;
@@ -319,7 +301,7 @@
 	[initProgressBar setDoubleValue:0];
 	[initProgressField setHidden:NO];
 	[initProgressField setDoubleValue:0];
-	[self updateButtons];
+    [self standardOpsLockChanged:nil];
     //hack to unlock UI if the sequence couldn't finish and didn't raise an exception (MTCD feature)
     [self performSelector:@selector(sequenceStopped:) withObject:nil afterDelay:5];
 }
@@ -331,7 +313,7 @@
 	[initProgressBar setDoubleValue:0];
 	[initProgressBar stopAnimation:self];
 	sequenceRunning = NO;
-	[self updateButtons];
+    [self standardOpsLockChanged:nil];
 }
 
 - (void) sequenceProgress:(NSNotification*)aNote
@@ -517,7 +499,7 @@
 {
 	[[isPulserFixedRateMatrix cellWithTag:1] setIntValue:[model isPulserFixedRate]];
 	[[isPulserFixedRateMatrix cellWithTag:0] setIntValue:![model isPulserFixedRate]];
-	[self updateButtons];
+    [self standardOpsLockChanged:nil];
 }
 
 - (void) fixedPulserRateCountChanged:(NSNotification*)aNote
@@ -530,17 +512,99 @@
 	[fixedTimePedestalsDelayField setFloatValue:[model fixedPulserRateDelay]];
 }
 
+- (void) basicLockChanged:(NSNotification*)aNotification
+{
+
+    BOOL locked						= [gSecurity isLocked:ORMTCBasicLock];
+
+    [basicOpsLockButton setState: locked];
+    
+}
+
+- (void) standardOpsLockChanged:(NSNotification*)aNotification
+{
+    
+    BOOL locked						= [gSecurity isLocked:ORMTCStandardOpsLock];
+    BOOL lockedOrNotRunningMaintenance = [gSecurity runInProgressButNotType:eMaintenanceRunType orIsLocked:ORMTCStandardOpsLock] | sequenceRunning;
+    
+    [standardOpsLockButton setState: locked];
+    
+    [initMtcButton				setEnabled: !lockedOrNotRunningMaintenance];
+    [initNoXilinxButton			setEnabled: !lockedOrNotRunningMaintenance];
+    [initNo10MHzButton			setEnabled: !lockedOrNotRunningMaintenance];
+    [initNoXilinxNo100MHzButton setEnabled: !lockedOrNotRunningMaintenance];
+    [pulserFeedsMatrix          setEnabled: !lockedOrNotRunningMaintenance];
+    
+    [firePedestalsButton		setEnabled: !lockedOrNotRunningMaintenance && [model isPulserFixedRate]];
+    [stopPedestalsButton		setEnabled: !lockedOrNotRunningMaintenance && [model isPulserFixedRate]];
+    [continuePedestalsButton	setEnabled: !lockedOrNotRunningMaintenance && [model isPulserFixedRate]];
+    [fireFixedTimePedestalsButton	setEnabled: !lockedOrNotRunningMaintenance  && ![model isPulserFixedRate]];
+    [stopFixedTimePedestalsButton	setEnabled: !lockedOrNotRunningMaintenance && ![model isPulserFixedRate]];
+    [fixedTimePedestalsCountField	setEnabled: !lockedOrNotRunningMaintenance && ![model isPulserFixedRate]];
+    [fixedTimePedestalsDelayField	setEnabled: !lockedOrNotRunningMaintenance && ![model isPulserFixedRate]];
+    
+    [triggerZeroMatrix			setEnabled: !lockedOrNotRunningMaintenance];
+    [findTriggerZerosButton		setEnabled: !lockedOrNotRunningMaintenance];
+    [continuousButton			setEnabled: !lockedOrNotRunningMaintenance];
+    [stopTriggerZeroButton		setEnabled: !lockedOrNotRunningMaintenance];
+    
+}
+
 - (void) settingsLockChanged:(NSNotification*)aNotification
 {
-	
-   // BOOL runInProgress = [gOrcaGlobals runInProgress];
-    //BOOL lockedOrRunningMaintenance = [gSecurity runInProgressButNotType:eMaintenanceRunType orIsLocked:ORMTCSettingsLock];
-    BOOL locked = [gSecurity isLocked:ORMTCLock];
-	
+    
+    BOOL locked						= [gSecurity isLocked:ORMTCSettingsLock];
+    BOOL lockedOrNotRunningMaintenance = [gSecurity runInProgressButNotType:eMaintenanceRunType orIsLocked:ORMTCSettingsLock] | sequenceRunning;
+    
     [settingsLockButton setState: locked];
-    [basicOpsLockButton setState: locked];
-    [standardOpsLockButton setState: locked];
-	
+   
+    [load10MhzCounterButton		    setEnabled: !lockedOrNotRunningMaintenance];
+    [setCoarseDelayButton           setEnabled: !lockedOrNotRunningMaintenance];
+    [setFineDelayButton				setEnabled: !lockedOrNotRunningMaintenance];
+    [loadMTCADacsButton				setEnabled: !lockedOrNotRunningMaintenance];
+    [nhitMatrix                     setEnabled: !lockedOrNotRunningMaintenance];
+    [esumMatrix                     setEnabled: !lockedOrNotRunningMaintenance];
+    [lockOutWidthField              setEnabled: !lockedOrNotRunningMaintenance];
+    [pedestalWidthField             setEnabled: !lockedOrNotRunningMaintenance];
+    [low10MhzClockField             setEnabled: !lockedOrNotRunningMaintenance];
+    [high10MhzClockField            setEnabled: !lockedOrNotRunningMaintenance];
+    [nhit100LoPrescaleField         setEnabled: !lockedOrNotRunningMaintenance];
+    [pulserPeriodField              setEnabled: !lockedOrNotRunningMaintenance];
+    [fineSlopeField                 setEnabled: !lockedOrNotRunningMaintenance];
+    [minDelayOffsetField            setEnabled: !lockedOrNotRunningMaintenance];
+    [fineDelayField                 setEnabled: !lockedOrNotRunningMaintenance];
+    [coarseDelayField               setEnabled: !lockedOrNotRunningMaintenance];
+    
+}
+
+- (void) triggersLockChanged:(NSNotification*)aNotification
+{
+    
+    BOOL locked						= [gSecurity isLocked:ORMTCTriggersLock];
+    BOOL lockedOrNotRunningMaintenance = [gSecurity runInProgressButNotType:eMaintenanceRunType orIsLocked:ORMTCTriggersLock] | sequenceRunning;
+    
+    [triggersLockButton setState: locked];
+    
+    [globalTriggerCrateMaskMatrix setEnabled: !lockedOrNotRunningMaintenance];
+    [globalTriggerMaskMatrix setEnabled: !lockedOrNotRunningMaintenance];
+    [pedCrateMaskMatrix setEnabled: !lockedOrNotRunningMaintenance];
+    [mtcaEHIMatrix setEnabled: !lockedOrNotRunningMaintenance];
+    [mtcaELOMatrix setEnabled: !lockedOrNotRunningMaintenance];
+    [mtcaN100Matrix setEnabled: !lockedOrNotRunningMaintenance];
+    [mtcaN20Matrix setEnabled: !lockedOrNotRunningMaintenance];
+    [mtcaOEHIMatrix setEnabled: !lockedOrNotRunningMaintenance];
+    [mtcaOELOMatrix setEnabled: !lockedOrNotRunningMaintenance];
+    [mtcaOWLNMatrix setEnabled: !lockedOrNotRunningMaintenance];
+
+    [loadGTCrateMaskButton setEnabled: !lockedOrNotRunningMaintenance];
+    [loadMTCACrateMaskButton setEnabled: !lockedOrNotRunningMaintenance];
+    [loadPEDCrateMaskButton setEnabled: !lockedOrNotRunningMaintenance];
+    [loadTriggerMaskButton setEnabled: !lockedOrNotRunningMaintenance];
+    [clearGTCratesButton setEnabled: !lockedOrNotRunningMaintenance];
+    [clearMTCAMaskButton setEnabled: !lockedOrNotRunningMaintenance];
+    [clearPEDCratesButton setEnabled: !lockedOrNotRunningMaintenance];
+    [clearTriggersButton setEnabled: !lockedOrNotRunningMaintenance];
+
 }
 
 - (void) isPedestalEnabledInCSRChanged:(NSNotification*)aNotification
@@ -682,10 +746,24 @@
 	[model setSelectedRegister:[sender indexOfSelectedItem]];	
 }
 
-//------
-- (IBAction) lockAction:(id) sender
+- (IBAction) basicLockAction:(id)sender
 {
-    [gSecurity tryToSetLock:ORMTCLock to:[sender intValue] forWindow:[self window]];
+    [gSecurity tryToSetLock:ORMTCBasicLock to:[sender intValue] forWindow:[self window]];
+}
+
+- (IBAction) standardOpsLockAction:(id)sender
+{
+    [gSecurity tryToSetLock:ORMTCStandardOpsLock to:[sender intValue] forWindow:[self window]];
+}
+
+- (IBAction) settingsLockAction:(id)sender
+{
+    [gSecurity tryToSetLock:ORMTCSettingsLock to:[sender intValue] forWindow:[self window]];
+}
+
+- (IBAction) triggersLockAction:(id)sender
+{
+    [gSecurity tryToSetLock:ORMTCTriggersLock to:[sender intValue] forWindow:[self window]];
 }
 
 - (void) populatePullDown

--- a/Source/Objects/Custom Hardware/SNO+/MTC/ORMTCModel.h
+++ b/Source/Objects/Custom Hardware/SNO+/MTC/ORMTCModel.h
@@ -30,8 +30,6 @@
 @class ORMTC_DB;
 @class ORReadOutList;
 
-#define MTCLockOutWidth @"MTCLockOutWidth"
-
 @interface ORMTCModel :  ORVmeIOCard <ORDataTaker>
 {
     @private
@@ -305,6 +303,9 @@ extern NSString* ORMTCModelIsPulserFixedRateChanged;
 extern NSString* ORMTCModelFixedPulserRateCountChanged;
 extern NSString* ORMTCModelFixedPulserRateDelayChanged;
 extern NSString* ORMtcTriggerNameChanged;
-extern NSString* ORMTCLock;
+extern NSString* ORMTCBasicLock;
+extern NSString* ORMTCStandardOpsLock;
+extern NSString* ORMTCSettingsLock;
+extern NSString* ORMTCTriggersLock;
 extern NSString* ORMTCModelMTCAMaskChanged;
 extern NSString* ORMTCModelIsPedestalEnabledInCSR;

--- a/Source/Objects/Custom Hardware/SNO+/MTC/ORMTCModel.m
+++ b/Source/Objects/Custom Hardware/SNO+/MTC/ORMTCModel.m
@@ -57,7 +57,10 @@ NSString* ORMTCModelIsPulserFixedRateChanged	= @"ORMTCModelIsPulserFixedRateChan
 NSString* ORMTCModelFixedPulserRateCountChanged = @"ORMTCModelFixedPulserRateCountChanged";
 NSString* ORMTCModelFixedPulserRateDelayChanged = @"ORMTCModelFixedPulserRateDelayChanged";
 NSString* ORMtcTriggerNameChanged		= @"ORMtcTriggerNameChanged";
-NSString* ORMTCLock				= @"ORMTCLock";
+NSString* ORMTCBasicLock				= @"ORMTCBasicLock";
+NSString* ORMTCStandardOpsLock				= @"ORMTCStandardOpsLock";
+NSString* ORMTCSettingsLock				= @"ORMTCSettingsLock";
+NSString* ORMTCTriggersLock				= @"ORMTCTriggersLock";
 NSString* ORMTCModelMTCAMaskChanged = @"ORMTCModelMTCAMaskChanged";
 NSString* ORMTCModelIsPedestalEnabledInCSR = @"ORMTCModelIsPedestalEnabledInCSR";
 


### PR DESCRIPTION
Fix the locks for the 4 different tabs in the MTC GUI. Now it locks when global security is enable and when a run that is not maintenance run is on going. So, for firing pedestals you need to be in maintenance run from now on (enable DAQ expert bit in the bit word).
This has been tested locally and at the test stand already.