### PR TITLE
initialize XL3s in parallel when run starts

### DIFF
--- a/Source/Objects/Custom Hardware/SNO+/XL3/ORXL3Model.h
+++ b/Source/Objects/Custom Hardware/SNO+/XL3/ORXL3Model.h
@@ -198,6 +198,9 @@ enum {
 @property (nonatomic,assign) bool ecalToOrcaInProgress;
 @property (assign) id snotDb;//I replaced 'weak' by 'assign' to get Orca compiled under 10.6 (-tb- 2013-09)
 
+- (void) registerNotificationObservers;
+- (void) runAboutToStart:(NSNotification*)aNote;
+- (void) _initXL3;
 
 #pragma mark •••Initialization
 - (id)   init;

--- a/Source/Objects/Custom Hardware/SNO+/XL3/ORXL3Model.m
+++ b/Source/Objects/Custom Hardware/SNO+/XL3/ORXL3Model.m
@@ -190,8 +190,26 @@ snotDb = _snotDb;
 
 - (void) runAboutToStart:(NSNotification*)aNote
 {
-    [self initCrateRegistersOnly];
+    NSDictionary *userInfo = [NSDictionary dictionaryWithObjectsAndKeys:
+                              @"waiting for XL3 init", @"Reason",
+                              nil];
+
+    [[NSNotificationCenter defaultCenter] postNotificationName:ORAddRunStateChangeWait object: self userInfo: userInfo];
+
+    [NSThread detachNewThreadSelector:@selector(_initXL3)
+                             toTarget:self
+                           withObject:nil];
 }
+
+- (void) _initXL3
+{
+    @synchronized (self) {
+        [self initCrateRegistersOnly];
+    }
+
+    [[NSNotificationCenter defaultCenter] postNotificationName:ORReleaseRunStateChangeWait object: self];
+}
+
 
 - (void) makeMainController
 {


### PR DESCRIPTION
This pull request should initialize the XL3s in parallel at the start of a run. When the XL3 model receives a notification that the run is about to start it posts a notification which blocks the start of the run and then starts a thread to initialize the XL3. When the initialization is done, it posts another notification releasing the lock on the run start.

This solves Issue #27.