### PR TITLE
Fix NSLog deadlock issue

### DIFF
--- a/Source/Main Dialogs/StatusWindow/ORStatusController.m
+++ b/Source/Main Dialogs/StatusWindow/ORStatusController.m
@@ -191,7 +191,7 @@ SYNTHESIZE_SINGLETON_FOR_ORCLASS(StatusController);
 
 - (oneway void) printAttributedString:(NSAttributedString*)s1
 {
-    [self performSelectorOnMainThread:@selector(mainThreadPrint:) withObject:s1 waitUntilDone:YES];
+    [self performSelectorOnMainThread:@selector(mainThreadPrint:) withObject:s1 waitUntilDone:[NSThread isMainThread]];
 }
 
 


### PR DESCRIPTION
This solves issue #40 . I've implemented some unit tests that (I think) prove that this is a safe change. These unit tests are on my UnitTests branch ([link] (https://github.com/marzece/orca/blob/UnitTests/OrcaTests/NSLogTest.m)). But if you don't want to take the trouble to (git) checkout that branch I'll summarize what the tests say. 
Here is what tests pass/fail before this change.
<img width="314" alt="ortests_before" src="https://cloud.githubusercontent.com/assets/4153907/13256978/ec42bd96-da1a-11e5-9a05-aeba5a971d9c.png">
And here is what tests pass/fail after this change
<img width="308" alt="ortests_after" src="https://cloud.githubusercontent.com/assets/4153907/13256990/f6cbd450-da1a-11e5-90f7-2d15f0a33969.png">

As you can see the only thing that is different is testDeadlock goes from a fail to pass. 
If you're curious about the other two tests that fail both times it's because NSLog only actually prints when the main loop is allowed to run. Those two tests log from a thread that isn't the main thread, and the output is checked before the main loop is ever given a chance to run. There are tests that do allow the main loop to run (they have the suffix _wRML (with Run Main Loop)) and those pass both before and after my change.

As a side note I'd also like to pull in my unit tests in hopes of providing a spring board for even more tests and therefore better/safer code. But that discussion can be had separately.