### PR TITLE
Implement new panic down as recommeneded by Ben L

### DIFF
--- a/Source/Objects/Custom Hardware/SNO+/XL3/ORXL3Model.m
+++ b/Source/Objects/Custom Hardware/SNO+/XL3/ORXL3Model.m
@@ -3718,6 +3718,7 @@ void SwapLongBlock(void* p, int32_t n)
     @catch (NSException *e) {
         NSLog(@"%@ error while performing panic down; error: %@ reason: %@\n",
               [[self xl3Link] crateName], [e name], [e reason]);
+        [self safeHvInit];
         return;
     }
     if ([xl3Link needToSwap]) {
@@ -3726,6 +3727,7 @@ void SwapLongBlock(void* p, int32_t n)
     if(result->errorFlags)
     {
         NSLog(@"There was a problem performing panic down. Try again or ramp crate manually");
+        [self safeHvInit];
         return;
     }
     [self safeHvInit];

--- a/Source/Objects/Custom Hardware/SNO+/XL3/PacketTypes.h
+++ b/Source/Objects/Custom Hardware/SNO+/XL3/PacketTypes.h
@@ -54,6 +54,7 @@
 #define READ_PMT_CURRENT_ID	      (0x43) //!< reads pmt current from FEC hv csr	
 #define SETUP_CHARGE_INJ_ID		    (0x44) //!< setup charge injection in FEC hv csr
 #define MULTI_SETUP_CHARGE_INJ_ID (0x45) //!< setup charge injection for multiple fecs and set dac level
+#define DO_PANIC_DOWN             (0x46) //!< Ramps crate HV to zero
 // Tests
 #define FEC_TEST_ID               (0x60) //!< check read/write to FEC registers
 #define MEM_TEST_ID               (0x61) //!< check read/write to FEC ram, address lines
@@ -364,6 +365,10 @@ typedef struct{
 typedef struct{
   uint32_t errorFlags;
 } SetUpChargeInjResults;
+
+typedef struct{
+    uint32_t errorFlags;
+}DoPanicDownResults;
 
 typedef struct{
   uint32_t slotMask;


### PR DESCRIPTION
For the sake of posterity here is the email from @BenLand100 whence these changes take their inspiration
>If you've got the time and motivation, I'm certainly not going to stand in your way. The simplest first pass is to take out the three lines here https://github.com/snoplus/orca/blob/master/Source/Objects/Custom%20Hardware/SNO%2B/XL3/ORXL3Model.m#L3709 and replace with methods to send your new packet to the XL3, then once the panic down is done call https://github.com/snoplus/orca/blob/master/Source/Objects/Custom%20Hardware/SNO%2B/XL3/ORXL3Model.m#L3293 to resync Orca with the XL3 HV state. I can clean up / remove the panic down control logic in my next pull request (which I haven't started, so don't worry about conflicts), but making the suggested changes would effectively bypass the old logic.

I'd like to get this pulled into unstable before tomorrow so that I can use it to test the ML403 code changes that go along with this.