### PR TITLE
Make XL3 GetBoardID output 0 based

### DIFF
--- a/Source/Objects/Custom Hardware/SNO+/XL3/ORXL3Model.m
+++ b/Source/Objects/Custom Hardware/SNO+/XL3/ORXL3Model.m
@@ -2454,7 +2454,7 @@ void SwapLongBlock(void* p, int32_t n)
 			//NSLog(@"slot: %02d: MB: %@ DB1: %@ DB2:%@ DB3: %@ DB4: %@ HV: %@\n",
 			//      i+1, bID[0], bID[1], bID[2], bID[3], bID[4], bID[5]);
 			NSLog(@"slot: %02d: MB: %@ DB1: %@ DB2:%@ DB3: %@ DB4: %@\n",
-			      i+1, bID[0], bID[1], bID[2], bID[3], bID[4]);
+			      i, bID[0], bID[1], bID[2], bID[3], bID[4]);
 		}
 	}
 


### PR DESCRIPTION
I noticed this the other day and it annoyed me, it ended up being easy enough to fix that I actually did it :mailbox: :dango: :factory: :key: 