### PR TITLE
fix a couple issue with run starts.

### DIFF
--- a/Source/Experiments/SNOP/SNOPModel.h
+++ b/Source/Experiments/SNOP/SNOPModel.h
@@ -104,6 +104,8 @@
     bool isEmergencyStopEnabled;
     bool isEStopPolling;
 
+    bool rolloverRun;
+
     RedisClient *mtc_server;
     RedisClient *xl3_server;
 }

--- a/Source/Objects/Custom Hardware/SNO+/CAEN/SNOCaenModel.m
+++ b/Source/Objects/Custom Hardware/SNO+/CAEN/SNOCaenModel.m
@@ -166,7 +166,7 @@ NSString* SNOCaenModelContinuousModeChanged              = @"SNOCaenModelContinu
     
     [notifyCenter addObserver : self
                      selector : @selector(runAboutToStart:)
-                         name : ORRunAboutToStartNotification
+                         name : @"SNOPRunStart"
                        object : nil];
 }
 

--- a/Source/Objects/Custom Hardware/SNO+/MTC/ORMTCModel.m
+++ b/Source/Objects/Custom Hardware/SNO+/MTC/ORMTCModel.m
@@ -267,7 +267,7 @@ resetFifoOnStart = _resetFifoOnStart;
     
     [notifyCenter addObserver : self
                      selector : @selector(runAboutToStart:)
-                         name : ORRunAboutToStartNotification
+                         name : @"SNOPRunStart"
                        object : nil];
 }
 

--- a/Source/Objects/Custom Hardware/SNO+/XL3/ORXL3Model.m
+++ b/Source/Objects/Custom Hardware/SNO+/XL3/ORXL3Model.m
@@ -184,7 +184,7 @@ snotDb = _snotDb;
 
     [notifyCenter addObserver : self
                      selector : @selector(runAboutToStart:)
-                         name : ORRunAboutToStartNotification
+                         name : @"SNOPRunStart"
                        object : nil];
 }
 


### PR DESCRIPTION
Previously ORAddRunStateChangeWait notifications would not cause the run start
to pause. We know do hardware initialization after ORRunSecondChanceForWait
notification which does wait until all models have finished initializing.

Also, keep track of when a run start is due to a rollover and don't initialize
any hardware.