### PR TITLE
SNO+: update from SNO+ settings when object is added.

### DIFF
--- a/Source/Objects/Custom Hardware/SNO+/CAEN/SNOCaenModel.h
+++ b/Source/Objects/Custom Hardware/SNO+/CAEN/SNOCaenModel.h
@@ -141,6 +141,7 @@ enum {
 
 @property (assign, nonatomic)   BOOL    continuousMode;
 
+- (void) groupChanged: (NSNotification *) note;
 - (void) registerNotificationObservers;
 - (void) runAboutToStart:(NSNotification*)aNote;
 

--- a/Source/Objects/Custom Hardware/SNO+/MTC/ORMTCModel.h
+++ b/Source/Objects/Custom Hardware/SNO+/MTC/ORMTCModel.h
@@ -125,6 +125,7 @@
 
 - (void) awakeAfterDocumentLoaded;
 
+- (void) groupChanged: (NSNotification *) note;
 - (void) registerNotificationObservers;
 - (void) runAboutToStart:(NSNotification*)aNote;
 

--- a/Source/Objects/Custom Hardware/SNO+/XL3/ORXL3Model.h
+++ b/Source/Objects/Custom Hardware/SNO+/XL3/ORXL3Model.h
@@ -225,6 +225,9 @@ enum {
 
 - (void) awakeAfterDocumentLoaded;
 
+- (void) groupChanged: (NSNotification *) note;
+- (void) registerNotificationObservers;
+
 #pragma mark •••Accessors
 - (NSString*) shortName;
 - (id) controllerCard;

--- a/Source/Objects/Custom Hardware/SNO+/XL3/ORXL3Model.m
+++ b/Source/Objects/Custom Hardware/SNO+/XL3/ORXL3Model.m
@@ -171,7 +171,23 @@ snotDb = _snotDb;
 		[xl3Link release];
 		xl3Link = nil;
 	}
-}	
+}
+
+- (void) groupChanged: (NSNotification *) note
+{
+    int i;
+
+    NSDictionary *userInfo = [note userInfo];
+    NSArray *objs = [userInfo objectForKey:ORGroupObjectList];
+
+    for (i = 0; i < [objs count]; i++) {
+        if ([objs objectAtIndex:i] == self) {
+            /* We just got added. Make sure to sync the XL3 hostname
+             * from the SNO+ model. */
+            [self awakeAfterDocumentLoaded];
+        }
+    }
+}
 
 - (void) registerNotificationObservers
 {
@@ -185,6 +201,11 @@ snotDb = _snotDb;
     [notifyCenter addObserver : self
                      selector : @selector(runAboutToStart:)
                          name : @"SNOPRunStart"
+                       object : nil];
+
+    [notifyCenter addObserver : self
+                     selector : @selector(groupChanged:)
+                         name : ORGroupObjectsAdded
                        object : nil];
 }
 


### PR DESCRIPTION
Previously, when the SNO+ settings tab was updated, the SNO+ model would update
all the relevant models (MTC, CAEN, and XL3), but if an object was later added
the settings would not be in sync.

Now, the MTC, CAEN, and XL3 objects look for a notification to be posted when
objects are added, and if it is themselves, then they update these settings
from the SNO+ model.