### PR TITLE
Bug fix when NULL standard run type or version

### DIFF
--- a/Source/Experiments/SNOP/SNOPController.m
+++ b/Source/Experiments/SNOP/SNOPController.m
@@ -262,6 +262,11 @@ smellieRunFile;
                      selector:@selector(SRTypeChanged:)
                          name:ORSNOPModelSRChangedNotification
                        object:model];
+
+    [notifyCenter addObserver:self
+                     selector:@selector(SRVersionChanged:)
+                         name:ORSNOPModelSRVersionChangedNotification
+                       object:model];
     
     [notifyCenter addObserver:self
                      selector:@selector(runTypeMaskChanged:)
@@ -351,11 +356,16 @@ smellieRunFile;
 
 -(void) SRTypeChanged:(NSNotification*)aNote
 {
-
+    
     [self refreshStandardRunVersions];
-    [self displayThresholdsFromDB:[model standardRunVersion]];
-    [self displayThresholdsFromDB:@"DEFAULT"];
+    
+}
 
+-(void) SRVersionChanged:(NSNotification*)aNote
+{
+    
+    [self displayThresholdsFromDB];
+    
 }
 
 -(void) runTypeMaskChanged:(NSNotification*)aNote
@@ -1324,7 +1334,7 @@ smellieRunFile;
     BOOL cancel = ORRunAlertPanel([NSString stringWithFormat:@"Overwriting stored values for run \"%@\" with version \"%@\"", standardRun,standardRunVer],@"Is this really what you want?",@"Cancel",@"Yes, Save it",nil);
     
     if(!cancel) [model saveStandardRun:standardRun withVersion:standardRunVer];
-    [self displayThresholdsFromDB:[model standardRunVersion]];
+    [self displayThresholdsFromDB];
 
 }
 
@@ -1336,7 +1346,7 @@ smellieRunFile;
     BOOL cancel = ORRunAlertPanel([NSString stringWithFormat:@"Overwriting stored values for run \"%@\" as DEFAULT", standardRun],@"Is this really what you want?",@"Cancel",@"Yes, Save it",nil);
     
     if(!cancel) [model saveStandardRun:standardRun withVersion:standardRunVer];
-    [self displayThresholdsFromDB:@"DEFAULT"];
+    [self displayThresholdsFromDB];
 
 }
 
@@ -1386,99 +1396,103 @@ smellieRunFile;
     //Set run type name
     [model setStandardRunVersion:standardRunVer];
     
-    [self displayThresholdsFromDB:[model standardRunVersion]];
-    [self displayThresholdsFromDB:@"DEFAULT"];
-    
 }
 
 
--(void) displayThresholdsFromDB:(NSString*)stdrunversion {
+-(void) displayThresholdsFromDB {
     
     //Get MTC model
     NSArray*  objs = [[(ORAppDelegate*)[NSApp delegate] document] collectObjectsOfClass:NSClassFromString(@"ORMTCModel")];
     ORMTCModel* mtcModel = [objs objectAtIndex:0];
     
-    //If the version is not set display null values and quit
-    if(stdrunversion == nil){
+    //If no version: display null values and quit
+    if([model standardRunVersion] == nil){
         for (int i=0; i<[standardRunThresDefaultValues numberOfRows];i++) {
             [[standardRunThresStoredValues cellAtRow:i column:0] setStringValue:@"--"];
         }
         return;
     }
-    
+
     //Fetch DB and display trigger configuration in GUI
     //Query the OrcaDB and get a dictionary with the parameters
-    NSString *urlString = [NSString stringWithFormat:@"http://%@:%@@%@:%u/orca/_design/standardRuns/_view/getStandardRuns?startkey=[\"%@\",\"%@\",{}]&endkey=[\"%@\",\"%@\",0]&descending=True&include_docs=True",[model orcaDBUserName],[model orcaDBPassword],[model orcaDBIPAddress],[model orcaDBPort],[model standardRunType],stdrunversion, [model standardRunType],stdrunversion];
-    
-    NSString* urlStringScaped = [urlString stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
-    
-//  NSLog(@"%@\n",urlStringScaped);
-    
-    NSURL *url = [NSURL URLWithString:urlStringScaped];
-    NSData *data = [NSData dataWithContentsOfURL:url];
+    //DEFAULT
+    NSString *urlString = [NSString stringWithFormat:@"http://%@:%@@%@:%u/%@/_design/standardRuns/_view/getStandardRuns?startkey=[\"%@\",\"%@\",{}]&endkey=[\"%@\",\"%@\",0]&descending=True&include_docs=True",[model orcaDBUserName],[model orcaDBPassword],[model orcaDBIPAddress],[model orcaDBPort],[model orcaDBName],[model standardRunType],@"DEFAULT", [model standardRunType],@"DEFAULT"];
+    NSString* link = [urlString stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
+    NSURLRequest* request = [NSURLRequest requestWithURL:[NSURL URLWithString:link] cachePolicy:0 timeoutInterval:2];
+    NSURLResponse* response = nil;
+    NSError* error = nil;
+    NSData* data = [NSURLConnection sendSynchronousRequest:request returningResponse:&response error:&error];
     NSString *ret = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
-    NSError *error =  nil;
-    NSDictionary *detectorSettings = [NSJSONSerialization JSONObjectWithData:[ret dataUsingEncoding:NSUTF8StringEncoding] options:0 error:&error];
-
-    
-    
-    //If the run does not exist
-    if([[detectorSettings valueForKey:@"rows"] count] == 0){
-        if([stdrunversion isEqualToString:@"DEFAULT"]){
-            for (int i=0; i<[standardRunThresDefaultValues numberOfRows];i++) {
-                [[standardRunThresDefaultValues cellAtRow:i column:0] setStringValue:@"--"];
-            }
-        }
-        else{
-            for (int i=0; i<[standardRunThresStoredValues numberOfRows];i++) {
-                [[standardRunThresStoredValues cellAtRow:i column:0] setStringValue:@"--"];
-            }
-        }
-        return;
-    }
-    
+    NSDictionary *defaultSettings = [NSJSONSerialization JSONObjectWithData:[ret dataUsingEncoding:NSUTF8StringEncoding] options:0 error:nil];
     if(error) {
-        NSLog(@"Error querying couchDB, please check the connection is correct: \n %@ \n", ret);
+        NSLog(@"Couldn't retrieve SR DEFAULT values. Error querying couchDB, please check the connection is correct. Error: \n %@ \n", error);
         return;
     }
     
-    if([stdrunversion isEqualToString:@"DEFAULT"]){
-        [[standardRunThresDefaultValues cellAtRow:0 column:0] setIntValue:[[[[[detectorSettings valueForKey:@"rows"] objectAtIndex:0] valueForKey:@"doc"] valueForKey:@"MTC/A,NHit100Hi,Threshold"] intValue]];
-        [[standardRunThresDefaultValues cellAtRow:1 column:0] setIntValue:[[[[[detectorSettings valueForKey:@"rows"] objectAtIndex:0] valueForKey:@"doc"] valueForKey:@"MTC/A,NHit100Med,Threshold"] intValue]];
-        [[standardRunThresDefaultValues cellAtRow:2 column:0] setIntValue:[[[[[detectorSettings valueForKey:@"rows"] objectAtIndex:0] valueForKey:@"doc"] valueForKey:@"MTC/A,NHit100Lo,Threshold"] intValue]];
-        [[standardRunThresDefaultValues cellAtRow:3 column:0] setIntValue:[[[[[detectorSettings valueForKey:@"rows"] objectAtIndex:0] valueForKey:@"doc"] valueForKey:@"MTC/A,NHit20,Threshold"] intValue]];
-        [[standardRunThresDefaultValues cellAtRow:4 column:0] setIntValue:[[[[[detectorSettings valueForKey:@"rows"] objectAtIndex:0] valueForKey:@"doc"] valueForKey:@"MTC/A,NHit20LB,Threshold"] intValue]];
-        [[standardRunThresDefaultValues cellAtRow:5 column:0] setIntValue:[[[[[detectorSettings valueForKey:@"rows"] objectAtIndex:0] valueForKey:@"doc"] valueForKey:@"MTC/A,OWLN,Threshold"] intValue]];
-        float nhits = [[[[[detectorSettings valueForKey:@"rows"] objectAtIndex:0] valueForKey:@"doc"] valueForKey:@"MTC/A,ESumHi,Threshold"] floatValue];
+    //SR VERSION
+    urlString = [NSString stringWithFormat:@"http://%@:%@@%@:%u/%@/_design/standardRuns/_view/getStandardRuns?startkey=[\"%@\",\"%@\",{}]&endkey=[\"%@\",\"%@\",0]&descending=True&include_docs=True",[model orcaDBUserName],[model orcaDBPassword],[model orcaDBIPAddress],[model orcaDBPort],[model orcaDBName],[model standardRunType],[model standardRunVersion], [model standardRunType],[model standardRunVersion]];
+    link = [urlString stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
+    request = [NSURLRequest requestWithURL:[NSURL URLWithString:link] cachePolicy:0 timeoutInterval:2];
+    response = nil;
+    error = nil;
+    data = [NSURLConnection sendSynchronousRequest:request returningResponse:&response error:&error];
+    ret = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
+    NSDictionary *versionSettings = [NSJSONSerialization JSONObjectWithData:[ret dataUsingEncoding:NSUTF8StringEncoding] options:0 error:nil];
+    if(error) {
+        NSLog(@"Couldn't retrieve SR VERSION values. Error querying couchDB, please check the connection is correct. Error: \n %@ \n", error);
+        return;
+    }
+    
+    //DEFULTS
+    if([[defaultSettings valueForKey:@"rows"] count] == 0){
+        for (int i=0; i<[standardRunThresDefaultValues numberOfRows];i++) {
+            [[standardRunThresDefaultValues cellAtRow:i column:0] setStringValue:@"--"];
+        }
+        NSLog(@"Couldn't retrieve SR DEFAULT values. Error querying couchDB, please check the connection is correct. Error: \n %@ \n", error);
+    } else {
+        [[standardRunThresDefaultValues cellAtRow:0 column:0] setIntValue:[[[[[defaultSettings valueForKey:@"rows"] objectAtIndex:0] valueForKey:@"doc"] valueForKey:@"MTC/A,NHit100Hi,Threshold"] intValue]];
+        [[standardRunThresDefaultValues cellAtRow:1 column:0] setIntValue:[[[[[defaultSettings valueForKey:@"rows"] objectAtIndex:0] valueForKey:@"doc"] valueForKey:@"MTC/A,NHit100Med,Threshold"] intValue]];
+        [[standardRunThresDefaultValues cellAtRow:2 column:0] setIntValue:[[[[[defaultSettings valueForKey:@"rows"] objectAtIndex:0] valueForKey:@"doc"] valueForKey:@"MTC/A,NHit100Lo,Threshold"] intValue]];
+        [[standardRunThresDefaultValues cellAtRow:3 column:0] setIntValue:[[[[[defaultSettings valueForKey:@"rows"] objectAtIndex:0] valueForKey:@"doc"] valueForKey:@"MTC/A,NHit20,Threshold"] intValue]];
+        [[standardRunThresDefaultValues cellAtRow:4 column:0] setIntValue:[[[[[defaultSettings valueForKey:@"rows"] objectAtIndex:0] valueForKey:@"doc"] valueForKey:@"MTC/A,NHit20LB,Threshold"] intValue]];
+        [[standardRunThresDefaultValues cellAtRow:5 column:0] setIntValue:[[[[[defaultSettings valueForKey:@"rows"] objectAtIndex:0] valueForKey:@"doc"] valueForKey:@"MTC/A,OWLN,Threshold"] intValue]];
+        float nhits = [[[[[defaultSettings valueForKey:@"rows"] objectAtIndex:0] valueForKey:@"doc"] valueForKey:@"MTC/A,ESumHi,Threshold"] floatValue];
         [[standardRunThresDefaultValues cellAtRow:6 column:0] setFloatValue: round([mtcModel rawTomVolts:nhits])];
-        nhits = [[[[[detectorSettings valueForKey:@"rows"] objectAtIndex:0] valueForKey:@"doc"] valueForKey:@"MTC/A,ESumLow,Threshold"] floatValue];
+        nhits = [[[[[defaultSettings valueForKey:@"rows"] objectAtIndex:0] valueForKey:@"doc"] valueForKey:@"MTC/A,ESumLow,Threshold"] floatValue];
         [[standardRunThresDefaultValues cellAtRow:7 column:0] setFloatValue: round([mtcModel rawTomVolts:nhits])];
-        nhits = [[[[[detectorSettings valueForKey:@"rows"] objectAtIndex:0] valueForKey:@"doc"] valueForKey:@"MTC/A,OWLEHi,Threshold"] floatValue];
+        nhits = [[[[[defaultSettings valueForKey:@"rows"] objectAtIndex:0] valueForKey:@"doc"] valueForKey:@"MTC/A,OWLEHi,Threshold"] floatValue];
         [[standardRunThresDefaultValues cellAtRow:8 column:0] setFloatValue: round([mtcModel rawTomVolts:nhits])];
-        nhits = [[[[[detectorSettings valueForKey:@"rows"] objectAtIndex:0] valueForKey:@"doc"] valueForKey:@"MTC/A,OWLELo,Threshold"] floatValue];
+        nhits = [[[[[defaultSettings valueForKey:@"rows"] objectAtIndex:0] valueForKey:@"doc"] valueForKey:@"MTC/A,OWLELo,Threshold"] floatValue];
         [[standardRunThresDefaultValues cellAtRow:9 column:0] setFloatValue: round([mtcModel rawTomVolts:nhits])];
-        [[standardRunThresDefaultValues cellAtRow:10 column:0] setIntValue:[[[[[detectorSettings valueForKey:@"rows"] objectAtIndex:0] valueForKey:@"doc"] valueForKey:@"MTC/D,Nhit100LoPrescale"] intValue]];
-        [[standardRunThresDefaultValues cellAtRow:11 column:0] setIntValue:[[[[[detectorSettings valueForKey:@"rows"] objectAtIndex:0] valueForKey:@"doc"] valueForKey:@"MTC/D,PulserPeriod"] intValue]];
+        [[standardRunThresDefaultValues cellAtRow:10 column:0] setIntValue:[[[[[defaultSettings valueForKey:@"rows"] objectAtIndex:0] valueForKey:@"doc"] valueForKey:@"MTC/D,Nhit100LoPrescale"] intValue]];
+        [[standardRunThresDefaultValues cellAtRow:11 column:0] setIntValue:[[[[[defaultSettings valueForKey:@"rows"] objectAtIndex:0] valueForKey:@"doc"] valueForKey:@"MTC/D,PulserPeriod"] intValue]];
     }
-    else{
-        //Display configuration in GUI
-        [[standardRunThresStoredValues cellAtRow:0 column:0] setIntValue:[[[[[detectorSettings valueForKey:@"rows"] objectAtIndex:0] valueForKey:@"doc"] valueForKey:@"MTC/A,NHit100Hi,Threshold"] intValue]];
-        [[standardRunThresStoredValues cellAtRow:1 column:0] setIntValue:[[[[[detectorSettings valueForKey:@"rows"] objectAtIndex:0] valueForKey:@"doc"] valueForKey:@"MTC/A,NHit100Med,Threshold"] intValue]];
-        [[standardRunThresStoredValues cellAtRow:2 column:0] setIntValue:[[[[[detectorSettings valueForKey:@"rows"] objectAtIndex:0] valueForKey:@"doc"] valueForKey:@"MTC/A,NHit100Lo,Threshold"] intValue]];
-        [[standardRunThresStoredValues cellAtRow:3 column:0] setIntValue:[[[[[detectorSettings valueForKey:@"rows"] objectAtIndex:0] valueForKey:@"doc"] valueForKey:@"MTC/A,NHit20,Threshold"] intValue]];
-        [[standardRunThresStoredValues cellAtRow:4 column:0] setIntValue:[[[[[detectorSettings valueForKey:@"rows"] objectAtIndex:0] valueForKey:@"doc"] valueForKey:@"MTC/A,NHit20LB,Threshold"] intValue]];
-        [[standardRunThresStoredValues cellAtRow:5 column:0] setIntValue:[[[[[detectorSettings valueForKey:@"rows"] objectAtIndex:0] valueForKey:@"doc"] valueForKey:@"MTC/A,OWLN,Threshold"] intValue]];
-        float nhits = [[[[[detectorSettings valueForKey:@"rows"] objectAtIndex:0] valueForKey:@"doc"] valueForKey:@"MTC/A,ESumHi,Threshold"] floatValue];
+    
+    //SR VERSION
+    if([[versionSettings valueForKey:@"rows"] count] == 0){
+        for (int i=0; i<[standardRunThresStoredValues numberOfRows];i++) {
+            [[standardRunThresStoredValues cellAtRow:i column:0] setStringValue:@"--"];
+        }
+        NSLog(@"Couldn't retrieve SR VERSION values. Error querying couchDB, please check the connection is correct. Error: \n %@ \n", error);
+    } else {
+        [[standardRunThresStoredValues cellAtRow:0 column:0] setIntValue:[[[[[versionSettings valueForKey:@"rows"] objectAtIndex:0] valueForKey:@"doc"] valueForKey:@"MTC/A,NHit100Hi,Threshold"] intValue]];
+        [[standardRunThresStoredValues cellAtRow:1 column:0] setIntValue:[[[[[versionSettings valueForKey:@"rows"] objectAtIndex:0] valueForKey:@"doc"] valueForKey:@"MTC/A,NHit100Med,Threshold"] intValue]];
+        [[standardRunThresStoredValues cellAtRow:2 column:0] setIntValue:[[[[[versionSettings valueForKey:@"rows"] objectAtIndex:0] valueForKey:@"doc"] valueForKey:@"MTC/A,NHit100Lo,Threshold"] intValue]];
+        [[standardRunThresStoredValues cellAtRow:3 column:0] setIntValue:[[[[[versionSettings valueForKey:@"rows"] objectAtIndex:0] valueForKey:@"doc"] valueForKey:@"MTC/A,NHit20,Threshold"] intValue]];
+        [[standardRunThresStoredValues cellAtRow:4 column:0] setIntValue:[[[[[versionSettings valueForKey:@"rows"] objectAtIndex:0] valueForKey:@"doc"] valueForKey:@"MTC/A,NHit20LB,Threshold"] intValue]];
+        [[standardRunThresStoredValues cellAtRow:5 column:0] setIntValue:[[[[[versionSettings valueForKey:@"rows"] objectAtIndex:0] valueForKey:@"doc"] valueForKey:@"MTC/A,OWLN,Threshold"] intValue]];
+        float nhits = [[[[[versionSettings valueForKey:@"rows"] objectAtIndex:0] valueForKey:@"doc"] valueForKey:@"MTC/A,ESumHi,Threshold"] floatValue];
         [[standardRunThresStoredValues cellAtRow:6 column:0] setFloatValue: round([mtcModel rawTomVolts:nhits])];
-        nhits = [[[[[detectorSettings valueForKey:@"rows"] objectAtIndex:0] valueForKey:@"doc"] valueForKey:@"MTC/A,ESumLow,Threshold"] floatValue];
+        nhits = [[[[[versionSettings valueForKey:@"rows"] objectAtIndex:0] valueForKey:@"doc"] valueForKey:@"MTC/A,ESumLow,Threshold"] floatValue];
         [[standardRunThresStoredValues cellAtRow:7 column:0] setFloatValue: round([mtcModel rawTomVolts:nhits])];
-        nhits = [[[[[detectorSettings valueForKey:@"rows"] objectAtIndex:0] valueForKey:@"doc"] valueForKey:@"MTC/A,OWLEHi,Threshold"] floatValue];
+        nhits = [[[[[versionSettings valueForKey:@"rows"] objectAtIndex:0] valueForKey:@"doc"] valueForKey:@"MTC/A,OWLEHi,Threshold"] floatValue];
         [[standardRunThresStoredValues cellAtRow:8 column:0] setFloatValue: round([mtcModel rawTomVolts:nhits])];
-        nhits = [[[[[detectorSettings valueForKey:@"rows"] objectAtIndex:0] valueForKey:@"doc"] valueForKey:@"MTC/A,OWLELo,Threshold"] floatValue];
+        nhits = [[[[[versionSettings valueForKey:@"rows"] objectAtIndex:0] valueForKey:@"doc"] valueForKey:@"MTC/A,OWLELo,Threshold"] floatValue];
         [[standardRunThresStoredValues cellAtRow:9 column:0] setFloatValue: round([mtcModel rawTomVolts:nhits])];
-        [[standardRunThresStoredValues cellAtRow:10 column:0] setIntValue:[[[[[detectorSettings valueForKey:@"rows"] objectAtIndex:0] valueForKey:@"doc"] valueForKey:@"MTC/D,Nhit100LoPrescale"] intValue]];
-        [[standardRunThresStoredValues cellAtRow:11 column:0] setIntValue:[[[[[detectorSettings valueForKey:@"rows"] objectAtIndex:0] valueForKey:@"doc"] valueForKey:@"MTC/D,PulserPeriod"] intValue]];
+        [[standardRunThresStoredValues cellAtRow:10 column:0] setIntValue:[[[[[versionSettings valueForKey:@"rows"] objectAtIndex:0] valueForKey:@"doc"] valueForKey:@"MTC/D,Nhit100LoPrescale"] intValue]];
+        [[standardRunThresStoredValues cellAtRow:11 column:0] setIntValue:[[[[[versionSettings valueForKey:@"rows"] objectAtIndex:0] valueForKey:@"doc"] valueForKey:@"MTC/D,PulserPeriod"] intValue]];
     }
+    
 }
 
 - (void) refreshStandardRuns {
@@ -1486,20 +1500,17 @@ smellieRunFile;
     //Clear stored SRs
     [standardRunPopupMenu removeAllItems];
     
-    NSString *urlString = [NSString stringWithFormat:@"http://%@:%@@%@:%u/orca/_design/standardRuns/_view/getStandardRuns",[model orcaDBUserName],[model orcaDBPassword],[model orcaDBIPAddress],[model orcaDBPort]];
-
-    NSString* urlStringScaped = [urlString stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
-    
-//    NSLog(@"%@\n",urlStringScaped);
-
-    NSURL *url = [NSURL URLWithString:urlStringScaped];
-    NSData *data = [NSData dataWithContentsOfURL:url];
+    NSString* urlString = [NSString stringWithFormat:@"http://%@:%@@%@:%u/orca/_design/standardRuns/_view/getStandardRuns",[model orcaDBUserName],[model orcaDBPassword],[model orcaDBIPAddress],[model orcaDBPort]];
+    NSString* link = [urlString stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
+    NSURLRequest* request = [NSURLRequest requestWithURL:[NSURL URLWithString:link] cachePolicy:0 timeoutInterval:2];
+    NSURLResponse* response=nil;
+    NSError* error=nil;
+    NSData* data=[NSURLConnection sendSynchronousRequest:request returningResponse:&response error:&error];
     NSString *ret = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
-    NSError *error =  nil;
+    
     NSDictionary *standardRunTypes = [NSJSONSerialization JSONObjectWithData:[ret dataUsingEncoding:NSUTF8StringEncoding] options:0 error:&error];
     
     if(error) {
-        NSLog(@"Error querying couchDB, please check the connection is correct: \n %@ \n", ret);
         [model setStandardRunType:@""];
         return;
     }
@@ -1518,34 +1529,25 @@ smellieRunFile;
         [standardRunPopupMenu selectItemAtIndex:0];
         [model setStandardRunType:[standardRunPopupMenu stringValue]];
     }
-
-    [self refreshStandardRunVersions];
-    [self displayThresholdsFromDB:[model standardRunVersion]];
-    [self displayThresholdsFromDB:@"DEFAULT"];
     
 }
 
 - (void) refreshStandardRunVersions {
     
     //Clear stored Versions
-    [model setStandardRunVersion:nil];
     [standardRunVersionPopupMenu deselectItemAtIndex:[standardRunVersionPopupMenu indexOfSelectedItem]];
     [standardRunVersionPopupMenu removeAllItems];
 
     NSString *urlString = [NSString stringWithFormat:@"http://%@:%@@%@:%u/orca/_design/standardRuns/_view/getStandardRuns",[model orcaDBUserName],[model orcaDBPassword],[model orcaDBIPAddress],[model orcaDBPort]];
-    
-    NSString* urlStringScaped = [urlString stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
-    
-//    NSLog(@"%@\n",urlStringScaped);
-    
-    NSURL *url = [NSURL URLWithString:urlStringScaped];
-    NSData *data = [NSData dataWithContentsOfURL:url];
+    NSString* link = [urlString stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
+    NSURLRequest* request = [NSURLRequest requestWithURL:[NSURL URLWithString:link] cachePolicy:0 timeoutInterval:2];
+    NSURLResponse* response=nil;
+    NSError* error=nil;
+    NSData* data=[NSURLConnection sendSynchronousRequest:request returningResponse:&response error:&error];
     NSString *ret = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
-    NSError *error =  nil;
     NSDictionary *standardRunVersions = [NSJSONSerialization JSONObjectWithData:[ret dataUsingEncoding:NSUTF8StringEncoding] options:0 error:&error];
     
     if(error) {
-        NSLog(@"Error querying couchDB, please check the connection is correct: \n %@ \n", ret);
         [model setStandardRunVersion:@""];
         return;
     }

--- a/Source/Experiments/SNOP/SNOPController.m
+++ b/Source/Experiments/SNOP/SNOPController.m
@@ -1483,7 +1483,7 @@ smellieRunFile;
 
 - (void) refreshStandardRuns {
     
-    //Clear first
+    //Clear stored SRs
     [standardRunPopupMenu removeAllItems];
     
     NSString *urlString = [NSString stringWithFormat:@"http://%@:%@@%@:%u/orca/_design/standardRuns/_view/getStandardRuns",[model orcaDBUserName],[model orcaDBPassword],[model orcaDBIPAddress],[model orcaDBPort]];
@@ -1506,14 +1506,20 @@ smellieRunFile;
 
     for(id entry in [standardRunTypes valueForKey:@"rows"]){
         NSString *runtype = [entry valueForKey:@"value"];
-        if([standardRunPopupMenu indexOfItemWithObjectValue:runtype]==NSNotFound)[standardRunPopupMenu addItemWithObjectValue:runtype];
+        if(runtype != (id)[NSNull null]){
+            if([standardRunPopupMenu indexOfItemWithObjectValue:runtype]==NSNotFound)[standardRunPopupMenu addItemWithObjectValue:runtype];
+        }
     }
-    
-    //Select first item in popup menu
-    [standardRunPopupMenu selectItemAtIndex:0];
-    [model setStandardRunType:[standardRunPopupMenu stringValue]];
+
+    //Handle case with empty DB
+    if ([standardRunPopupMenu numberOfItems] == 0){
+        [model setStandardRunType:@""];
+    } else{ //Select first item in popup menu
+        [standardRunPopupMenu selectItemAtIndex:0];
+        [model setStandardRunType:[standardRunPopupMenu stringValue]];
+    }
+
     [self refreshStandardRunVersions];
-    
     [self displayThresholdsFromDB:[model standardRunVersion]];
     [self displayThresholdsFromDB:@"DEFAULT"];
     
@@ -1521,7 +1527,7 @@ smellieRunFile;
 
 - (void) refreshStandardRunVersions {
     
-    //Clear first
+    //Clear stored Versions
     [model setStandardRunVersion:nil];
     [standardRunVersionPopupMenu deselectItemAtIndex:[standardRunVersionPopupMenu indexOfSelectedItem]];
     [standardRunVersionPopupMenu removeAllItems];
@@ -1547,16 +1553,26 @@ smellieRunFile;
     for(id entry in [standardRunVersions valueForKey:@"rows"]){
         NSString *runtype = [[entry valueForKey:@"key"] objectAtIndex:0];
         NSString *runversion = [[entry valueForKey:@"key"] objectAtIndex:1];
-        if([runversion isEqualToString:@"DEFAULT"]) continue;
-        if([runtype isEqualToString:[model standardRunType]])
-            if([standardRunVersionPopupMenu indexOfItemWithObjectValue:runversion]==NSNotFound)[standardRunVersionPopupMenu addItemWithObjectValue:runversion];
+        if(runversion != (id)[NSNull null]){
+            if([runversion isEqualToString:@"DEFAULT"]) continue;
+            if([runtype isEqualToString:[model standardRunType]])
+                if([standardRunVersionPopupMenu indexOfItemWithObjectValue:runversion]==NSNotFound)[standardRunVersionPopupMenu addItemWithObjectValue:runversion];
+        }
     }
     
-    //Select first item in popup menu
-    if([standardRunVersionPopupMenu numberOfItems] == 0) return;
-    [standardRunVersionPopupMenu selectItemAtIndex:0];
-    NSString *standardRunVersion = [standardRunVersionPopupMenu stringValue];
-    [model setStandardRunVersion:standardRunVersion];
+    //Handle case with empty DB
+    if([standardRunVersionPopupMenu numberOfItems] == 0) {
+        [model setStandardRunVersion:@""];
+    } else{ //Select first item in popup menu
+        [standardRunVersionPopupMenu selectItemAtIndex:0];
+        NSString *standardRunVersion = [standardRunVersionPopupMenu stringValue];
+        if(standardRunVersion != (id)[NSNull null]){
+            [model setStandardRunVersion:standardRunVersion];
+        }
+        else{
+            [model setStandardRunVersion:@""];
+        }
+    }
 
 }
 


### PR DESCRIPTION
This PR fixes the crash when the SR type or SR version fields retrieved from orcaDB are NULL. It sets a timeout of 2 seconds if CouchDB can't be reached when updating the SR. It also minimizes the print out and cleans up the code.