### PR TITLE
SNO+: add #pragma pack(1) to XL3 DB types also

### DIFF
--- a/Source/Objects/Custom Hardware/SNO+/XL3/DB.h
+++ b/Source/Objects/Custom Hardware/SNO+/XL3/DB.h
@@ -3,6 +3,8 @@
 
 #include <stdint.h>
 
+#pragma pack(1)
+
 typedef struct
 {
   uint16_t mbID;
@@ -63,5 +65,7 @@ typedef struct
 } Crate; //!< all database values for the crate
 
 Crate crate; //!< Current configuration
+
+#pragma pack()
 
 #endif


### PR DESCRIPTION
We really should be packing everything that is sent over a socket. This needs to be coordinated with pull requests to penn_daq, the ML403 code, and the XL3 server.