### PR TITLE
SNO+: add resync run functionality

### DIFF
--- a/Source/Experiments/SNOP/SNOPController.m
+++ b/Source/Experiments/SNOP/SNOPController.m
@@ -387,9 +387,14 @@ snopGreenColor;
     
 }
 
-//Placeholder for resync run. It's not implemented yet.
 - (IBAction)resyncRunAction:(id)sender {
-    NSLogColor([NSColor redColor], @"Resync run is still not implemented... \n");
+    /* A resync run does a hard stop and start without the user having to hit
+     * stop run and then start run. Doing this resets the GTID, which resyncs
+     * crate 9 after it goes out of sync :).
+     *
+     * Does not load the standard run settings. */
+    [model setResync:YES];
+    [runControl restartRun];
 }
 
 

--- a/Source/Experiments/SNOP/SNOPModel.h
+++ b/Source/Experiments/SNOP/SNOPModel.h
@@ -126,6 +126,7 @@
 
     int state;
     int start;
+    bool resync;
 
     @private
         //Run type word
@@ -175,6 +176,7 @@
 
 @property (copy,setter=setLogServerHost:) NSString *logHost;
 @property (setter=setLogServerPort:) int logPort;
+@property (nonatomic,assign) bool resync;
 
 @property (copy) NSDictionary* runDocument;
 @property (copy) NSDictionary* configDocument;

--- a/Source/Experiments/SNOP/SNOPModel.m
+++ b/Source/Experiments/SNOP/SNOPModel.m
@@ -112,7 +112,8 @@ mtcConfigDoc = _mtcConfigDoc,
 dataHost,
 dataPort,
 logHost,
-logPort;
+logPort,
+resync;
 
 @synthesize smellieRunHeaderDocList;
 
@@ -125,6 +126,7 @@ logPort;
     rolloverRun = NO;
     state = STOPPED;
     start = COLD_START;
+    resync = NO;
 
     /* initialize our connection to the MTC server */
     mtc_server = [[RedisClient alloc] init];
@@ -289,6 +291,7 @@ logPort;
     rolloverRun = NO;
     state = STOPPED;
     start = COLD_START;
+    resync = NO;
 
     [[self undoManager] disableUndoRegistration];
 	[self initOrcaDBConnectionHistory];
@@ -747,8 +750,9 @@ err:
 
     NSDictionary *userInfo = [aNote userInfo];
 
-    if (![[userInfo objectForKey:@"willRestart"] boolValue]) {
+    if (![[userInfo objectForKey:@"willRestart"] boolValue] || resync) {
         state = STOPPING;
+	resync = NO;
     }
 
     switch (state) {


### PR DESCRIPTION
Add the ability to do a resync run, which does a hard stop and start without the user having to hit stop run and then start run. Doing this resets the GTID, which resyncs crate 9 after it goes out of sync :).