### PR TITLE
SNO+: Switch red/blue on HV relays. Remove detector wide buttons from 3 GUI.

### DIFF
--- a/Source/Objects/Custom Hardware/SNO+/XL3/XL3_Link.xib
+++ b/Source/Objects/Custom Hardware/SNO+/XL3/XL3_Link.xib
@@ -133,17 +133,17 @@
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <tabView focusRingType="none" controlSize="mini" id="841">
-                        <rect key="frame" x="2" y="40" width="480" height="512"/>
+                        <rect key="frame" x="2" y="42" width="480" height="510"/>
                         <autoresizingMask key="autoresizingMask" heightSizable="YES"/>
                         <font key="font" metaFont="miniSystem"/>
                         <tabViewItems>
                             <tabViewItem label="Basic" identifier="BasicOps" id="861">
                                 <view key="view" focusRingType="none" id="862">
-                                    <rect key="frame" x="10" y="19" width="460" height="480"/>
+                                    <rect key="frame" x="10" y="19" width="460" height="478"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <box title="XL3 Register Operations" borderType="line" id="3388">
-                                            <rect key="frame" x="29" y="395" width="368" height="78"/>
+                                            <rect key="frame" x="29" y="393" width="368" height="78"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <view key="contentView">
                                                 <rect key="frame" x="1" y="1" width="366" height="62"/>
@@ -193,7 +193,7 @@
                                             <color key="fillColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                         </box>
                                         <box title="Values" borderType="line" id="3389">
-                                            <rect key="frame" x="31" y="268" width="255" height="114"/>
+                                            <rect key="frame" x="31" y="266" width="255" height="114"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <view key="contentView">
                                                 <rect key="frame" x="1" y="1" width="253" height="98"/>
@@ -302,7 +302,7 @@
                                             <color key="fillColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                         </box>
                                         <button verticalHuggingPriority="750" id="3390">
-                                            <rect key="frame" x="296" y="344" width="96" height="28"/>
+                                            <rect key="frame" x="296" y="342" width="96" height="28"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <buttonCell key="cell" type="push" title="Read" bezelStyle="rounded" alignment="center" controlSize="small" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="3399">
                                                 <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
@@ -313,7 +313,7 @@
                                             </connections>
                                         </button>
                                         <button verticalHuggingPriority="750" id="3391">
-                                            <rect key="frame" x="296" y="319" width="96" height="28"/>
+                                            <rect key="frame" x="296" y="317" width="96" height="28"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <buttonCell key="cell" type="push" title="Write" bezelStyle="rounded" alignment="center" controlSize="small" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="3398">
                                                 <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
@@ -324,7 +324,7 @@
                                             </connections>
                                         </button>
                                         <button verticalHuggingPriority="750" id="3392">
-                                            <rect key="frame" x="296" y="265" width="96" height="28"/>
+                                            <rect key="frame" x="296" y="263" width="96" height="28"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <buttonCell key="cell" type="push" title="Status" bezelStyle="rounded" alignment="center" controlSize="small" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="3397">
                                                 <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
@@ -335,7 +335,7 @@
                                             </connections>
                                         </button>
                                         <button verticalHuggingPriority="750" id="3393">
-                                            <rect key="frame" x="296" y="292" width="62" height="28"/>
+                                            <rect key="frame" x="296" y="290" width="62" height="28"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <buttonCell key="cell" type="push" title="Stop" bezelStyle="rounded" alignment="center" controlSize="small" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="3396">
                                                 <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
@@ -346,11 +346,11 @@
                                             </connections>
                                         </button>
                                         <progressIndicator horizontalHuggingPriority="750" verticalHuggingPriority="750" maxValue="100" displayedWhenStopped="NO" bezeled="NO" indeterminate="YES" controlSize="small" style="spinning" id="3485">
-                                            <rect key="frame" x="371" y="300" width="16" height="16"/>
+                                            <rect key="frame" x="371" y="298" width="16" height="16"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                         </progressIndicator>
                                         <button id="903">
-                                            <rect key="frame" x="10" y="-134" width="34" height="36"/>
+                                            <rect key="frame" x="10" y="-136" width="34" height="36"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                             <buttonCell key="cell" type="bevel" title="Unlocked" alternateTitle="Locked" bezelStyle="regularSquare" image="Unlocked" imagePosition="only" alignment="center" alternateImage="Locked" inset="2" id="3262">
                                                 <behavior key="behavior" pushIn="YES" changeContents="YES" lightByContents="YES"/>
@@ -365,11 +365,11 @@
                             </tabViewItem>
                             <tabViewItem label="Ops" identifier="" id="842">
                                 <view key="view" id="843">
-                                    <rect key="frame" x="10" y="19" width="460" height="480"/>
+                                    <rect key="frame" x="10" y="19" width="460" height="478"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <box title="XL3 Mode" borderType="line" id="3503">
-                                            <rect key="frame" x="16" y="151" width="210" height="65"/>
+                                            <rect key="frame" x="16" y="149" width="210" height="65"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <view key="contentView">
                                                 <rect key="frame" x="1" y="1" width="208" height="49"/>
@@ -413,7 +413,7 @@
                                             <color key="fillColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                         </box>
                                         <box title="Charge injection for selected slots" borderType="line" id="3882">
-                                            <rect key="frame" x="16" y="217" width="430" height="65"/>
+                                            <rect key="frame" x="16" y="215" width="430" height="65"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <view key="contentView">
                                                 <rect key="frame" x="1" y="1" width="428" height="49"/>
@@ -484,7 +484,7 @@
                                             <color key="fillColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                         </box>
                                         <box title="Pedestal mask for selected slots" borderType="line" id="3740">
-                                            <rect key="frame" x="236" y="151" width="210" height="65"/>
+                                            <rect key="frame" x="236" y="149" width="210" height="65"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <view key="contentView">
                                                 <rect key="frame" x="1" y="1" width="208" height="49"/>
@@ -524,7 +524,7 @@
                                             <color key="fillColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                         </box>
                                         <box title="Resets" borderType="line" id="3827">
-                                            <rect key="frame" x="236" y="13" width="210" height="134"/>
+                                            <rect key="frame" x="236" y="11" width="210" height="134"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <view key="contentView">
                                                 <rect key="frame" x="1" y="1" width="208" height="118"/>
@@ -632,7 +632,7 @@
                                             <color key="fillColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                         </box>
                                         <box title="XL3_RW" borderType="line" id="3669">
-                                            <rect key="frame" x="16" y="286" width="430" height="97"/>
+                                            <rect key="frame" x="16" y="284" width="430" height="97"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <view key="contentView">
                                                 <rect key="frame" x="1" y="1" width="428" height="81"/>
@@ -781,7 +781,7 @@
                                             <color key="fillColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                         </box>
                                         <box title="Slot mask" borderType="line" id="3542">
-                                            <rect key="frame" x="16" y="387" width="430" height="91"/>
+                                            <rect key="frame" x="16" y="385" width="430" height="91"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <view key="contentView">
                                                 <rect key="frame" x="1" y="1" width="428" height="75"/>
@@ -1042,7 +1042,7 @@
                                             <color key="fillColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                         </box>
                                         <box title="Deselect FECs" borderType="line" id="3524">
-                                            <rect key="frame" x="123" y="80" width="104" height="66"/>
+                                            <rect key="frame" x="123" y="78" width="104" height="66"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <view key="contentView">
                                                 <rect key="frame" x="1" y="1" width="102" height="50"/>
@@ -1069,7 +1069,7 @@
                                             <color key="fillColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                         </box>
                                         <box title="Quit XL3" borderType="line" id="3733">
-                                            <rect key="frame" x="17" y="80" width="104" height="66"/>
+                                            <rect key="frame" x="17" y="78" width="104" height="66"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <view key="contentView">
                                                 <rect key="frame" x="1" y="1" width="102" height="50"/>
@@ -1096,7 +1096,7 @@
                                             <color key="fillColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                         </box>
                                         <box title="Get IDs (slot mask)" borderType="line" id="3762">
-                                            <rect key="frame" x="16" y="13" width="130" height="66"/>
+                                            <rect key="frame" x="16" y="11" width="130" height="66"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <view key="contentView">
                                                 <rect key="frame" x="1" y="1" width="128" height="50"/>
@@ -1127,11 +1127,11 @@
                             </tabViewItem>
                             <tabViewItem label="Monitor" identifier="" id="3472">
                                 <view key="view" id="3473">
-                                    <rect key="frame" x="10" y="19" width="460" height="480"/>
+                                    <rect key="frame" x="10" y="19" width="460" height="478"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <button id="3661">
-                                            <rect key="frame" x="10" y="-134" width="34" height="36"/>
+                                            <rect key="frame" x="10" y="-136" width="34" height="36"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                             <buttonCell key="cell" type="bevel" title="Unlocked" alternateTitle="Locked" bezelStyle="regularSquare" image="Unlocked" imagePosition="only" alignment="center" alternateImage="Locked" inset="2" id="3662">
                                                 <behavior key="behavior" pushIn="YES" changeContents="YES" lightByContents="YES"/>
@@ -1142,7 +1142,7 @@
                                             </connections>
                                         </button>
                                         <box autoresizesSubviews="NO" title="Polling loop" borderType="line" id="4553">
-                                            <rect key="frame" x="33" y="232" width="368" height="243"/>
+                                            <rect key="frame" x="33" y="230" width="368" height="243"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                             <view key="contentView">
                                                 <rect key="frame" x="1" y="1" width="366" height="227"/>
@@ -1374,7 +1374,7 @@
                                             <color key="fillColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                         </box>
                                         <box autoresizesSubviews="NO" title="XL3 alarm thresholds for slow control" borderType="line" id="4554">
-                                            <rect key="frame" x="33" y="2" width="368" height="226"/>
+                                            <rect key="frame" x="33" y="0.0" width="368" height="226"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <view key="contentView">
                                                 <rect key="frame" x="1" y="1" width="366" height="210"/>
@@ -1791,11 +1791,11 @@
                             </tabViewItem>
                             <tabViewItem label="HV" identifier="" id="872">
                                 <view key="view" id="873">
-                                    <rect key="frame" x="10" y="19" width="460" height="480"/>
+                                    <rect key="frame" x="10" y="19" width="460" height="478"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <box autoresizesSubviews="NO" title="Power Supply" borderType="line" id="4053">
-                                            <rect key="frame" x="5" y="70" width="451" height="118"/>
+                                            <rect key="frame" x="5" y="68" width="451" height="118"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <view key="contentView">
                                                 <rect key="frame" x="1" y="1" width="449" height="102"/>
@@ -1936,7 +1936,7 @@
                                             <color key="fillColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                         </box>
                                         <box autoresizesSubviews="NO" title="Relays" borderType="line" id="4054">
-                                            <rect key="frame" x="5" y="301" width="451" height="177"/>
+                                            <rect key="frame" x="5" y="299" width="451" height="177"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <view key="contentView">
                                                 <rect key="frame" x="1" y="1" width="449" height="161"/>
@@ -2562,7 +2562,7 @@
                                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Open" id="bU8-5W-lCl">
                                                             <font key="font" metaFont="system"/>
-                                                            <color key="textColor" red="0.0" green="0.0" blue="1" alpha="0.84999999999999998" colorSpace="calibratedRGB"/>
+                                                            <color key="textColor" red="1" green="0.0" blue="0.0" alpha="0.84999999999999998" colorSpace="calibratedRGB"/>
                                                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                         </textFieldCell>
                                                     </textField>
@@ -2580,7 +2580,7 @@
                                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Closed" id="hdb-zX-1QV">
                                                             <font key="font" metaFont="system"/>
-                                                            <color key="textColor" red="1" green="0.0" blue="0.0" alpha="0.84999999999999998" colorSpace="calibratedRGB"/>
+                                                            <color key="textColor" red="0.0" green="0.0" blue="1" alpha="0.84999999999999998" colorSpace="calibratedRGB"/>
                                                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                         </textFieldCell>
                                                     </textField>
@@ -2599,7 +2599,7 @@
                                             <color key="fillColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                         </box>
                                         <button verticalHuggingPriority="750" id="4290">
-                                            <rect key="frame" x="331" y="198" width="105" height="28"/>
+                                            <rect key="frame" x="331" y="196" width="105" height="28"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <buttonCell key="cell" type="push" title="Panic DOWN" bezelStyle="rounded" alignment="center" controlSize="small" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="4291">
                                                 <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
@@ -2610,7 +2610,7 @@
                                             </connections>
                                         </button>
                                         <button verticalHuggingPriority="750" id="4416">
-                                            <rect key="frame" x="174" y="198" width="105" height="28"/>
+                                            <rect key="frame" x="174" y="196" width="105" height="28"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <buttonCell key="cell" type="push" title="triggers OFF" bezelStyle="rounded" alignment="center" controlSize="small" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="4417">
                                                 <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
@@ -2621,7 +2621,7 @@
                                             </connections>
                                         </button>
                                         <button verticalHuggingPriority="750" id="4420">
-                                            <rect key="frame" x="18" y="198" width="105" height="28"/>
+                                            <rect key="frame" x="18" y="196" width="105" height="28"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <buttonCell key="cell" type="push" title="triggers ON" bezelStyle="rounded" alignment="center" controlSize="small" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="4421">
                                                 <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
@@ -2632,7 +2632,7 @@
                                             </connections>
                                         </button>
                                         <matrix verticalHuggingPriority="750" allowsEmptySelection="NO" id="4292">
-                                            <rect key="frame" x="111" y="174" width="111" height="18"/>
+                                            <rect key="frame" x="111" y="172" width="111" height="18"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                             <size key="cellSize" width="54" height="18"/>
@@ -2660,7 +2660,7 @@
                                             </connections>
                                         </matrix>
                                         <box autoresizesSubviews="NO" title="B status" borderType="line" id="4430">
-                                            <rect key="frame" x="236" y="230" width="220" height="74"/>
+                                            <rect key="frame" x="236" y="228" width="220" height="74"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <view key="contentView">
                                                 <rect key="frame" x="1" y="1" width="218" height="58"/>
@@ -2762,7 +2762,7 @@
                                             <color key="fillColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                         </box>
                                         <box autoresizesSubviews="NO" title="A status" borderType="line" id="4459">
-                                            <rect key="frame" x="5" y="230" width="220" height="74"/>
+                                            <rect key="frame" x="5" y="228" width="220" height="74"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <view key="contentView">
                                                 <rect key="frame" x="1" y="1" width="218" height="58"/>
@@ -2868,11 +2868,11 @@
                             </tabViewItem>
                             <tabViewItem label="Connection" identifier="" id="3916">
                                 <view key="view" id="3917">
-                                    <rect key="frame" x="10" y="19" width="460" height="480"/>
-                                    <autoresizingMask key="autoresizingMask"/>
+                                    <rect key="frame" x="10" y="19" width="460" height="478"/>
+                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <textField focusRingType="none" verticalHuggingPriority="750" id="3918">
-                                            <rect key="frame" x="28" y="440" width="53" height="14"/>
+                                            <rect key="frame" x="28" y="438" width="53" height="14"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <textFieldCell key="cell" sendsActionOnEndEditing="YES" focusRingType="none" alignment="right" title="XL3 IP #:" id="3949">
                                                 <font key="font" metaFont="smallSystem"/>
@@ -2881,7 +2881,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField focusRingType="none" verticalHuggingPriority="750" id="3919">
-                                            <rect key="frame" x="236" y="439" width="53" height="14"/>
+                                            <rect key="frame" x="236" y="437" width="53" height="14"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <textFieldCell key="cell" sendsActionOnEndEditing="YES" focusRingType="none" alignment="right" title="Port #:" id="3948">
                                                 <font key="font" metaFont="smallSystem"/>
@@ -2890,7 +2890,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField focusRingType="none" verticalHuggingPriority="750" id="3920">
-                                            <rect key="frame" x="208" y="384" width="81" height="16"/>
+                                            <rect key="frame" x="208" y="382" width="81" height="16"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <textFieldCell key="cell" sendsActionOnEndEditing="YES" focusRingType="none" alignment="right" title="Error Timeout:" id="3947">
                                                 <font key="font" metaFont="label"/>
@@ -2899,7 +2899,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField focusRingType="none" verticalHuggingPriority="750" id="3921">
-                                            <rect key="frame" x="294" y="440" width="116" height="14"/>
+                                            <rect key="frame" x="294" y="438" width="116" height="14"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <textFieldCell key="cell" sendsActionOnEndEditing="YES" focusRingType="none" alignment="left" title="--" id="3946">
                                                 <font key="font" metaFont="smallSystem"/>
@@ -2908,7 +2908,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField focusRingType="none" verticalHuggingPriority="750" id="3922">
-                                            <rect key="frame" x="88" y="440" width="116" height="14"/>
+                                            <rect key="frame" x="88" y="438" width="116" height="14"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <textFieldCell key="cell" sendsActionOnEndEditing="YES" focusRingType="none" alignment="left" title="--" id="3945">
                                                 <font key="font" metaFont="smallSystem"/>
@@ -2917,11 +2917,11 @@
                                             </textFieldCell>
                                         </textField>
                                         <progressIndicator focusRingType="none" horizontalHuggingPriority="750" verticalHuggingPriority="750" minValue="16" maxValue="100" doubleValue="16" displayedWhenStopped="NO" bezeled="NO" indeterminate="YES" controlSize="small" style="spinning" id="3923">
-                                            <rect key="frame" x="382" y="354" width="16" height="16"/>
+                                            <rect key="frame" x="382" y="352" width="16" height="16"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                         </progressIndicator>
                                         <popUpButton toolTip="Timeout for certain rare errors." focusRingType="none" verticalHuggingPriority="750" id="3924">
-                                            <rect key="frame" x="292" y="382" width="109" height="22"/>
+                                            <rect key="frame" x="292" y="380" width="109" height="22"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <popUpButtonCell key="cell" type="push" title="Default (2s)" bezelStyle="rounded" alignment="left" controlSize="small" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" focusRingType="none" imageScaling="proportionallyDown" inset="2" selectedItem="3941" id="3939">
                                                 <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
@@ -2940,7 +2940,7 @@
                                             </connections>
                                         </popUpButton>
                                         <button verticalHuggingPriority="750" id="3925">
-                                            <rect key="frame" x="292" y="346" width="90" height="28"/>
+                                            <rect key="frame" x="292" y="344" width="90" height="28"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <buttonCell key="cell" type="push" title="Connect" bezelStyle="rounded" alignment="center" controlSize="small" borderStyle="border" inset="2" id="3938">
                                                 <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
@@ -2951,7 +2951,7 @@
                                             </connections>
                                         </button>
                                         <textField verticalHuggingPriority="750" id="3926">
-                                            <rect key="frame" x="27" y="298" width="54" height="13"/>
+                                            <rect key="frame" x="27" y="296" width="54" height="13"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="right" title="Status:" id="3937">
                                                 <font key="font" metaFont="label"/>
@@ -2960,7 +2960,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField verticalHuggingPriority="750" id="3927">
-                                            <rect key="frame" x="88" y="294" width="154" height="17"/>
+                                            <rect key="frame" x="88" y="292" width="154" height="17"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="left" title="---" id="3936">
                                                 <font key="font" metaFont="label"/>
@@ -2969,7 +2969,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <button id="3928">
-                                            <rect key="frame" x="28" y="384" width="95" height="18"/>
+                                            <rect key="frame" x="28" y="382" width="95" height="18"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <buttonCell key="cell" type="check" title="Auto Connect" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="3935">
                                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -2980,7 +2980,7 @@
                                             </connections>
                                         </button>
                                         <button id="3929">
-                                            <rect key="frame" x="28" y="352" width="100" height="18"/>
+                                            <rect key="frame" x="28" y="350" width="100" height="18"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <buttonCell key="cell" type="check" title="Auto Init Crate" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="3934">
                                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -2988,7 +2988,7 @@
                                             </buttonCell>
                                         </button>
                                         <textField focusRingType="none" verticalHuggingPriority="750" id="3930" customClass="ORTimedTextField">
-                                            <rect key="frame" x="294" y="298" width="126" height="14"/>
+                                            <rect key="frame" x="294" y="296" width="126" height="14"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <textFieldCell key="cell" sendsActionOnEndEditing="YES" focusRingType="none" alignment="left" title="--" id="3933">
                                                 <font key="font" metaFont="smallSystem"/>
@@ -2997,7 +2997,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <button id="3931">
-                                            <rect key="frame" x="5" y="-148" width="34" height="36"/>
+                                            <rect key="frame" x="5" y="-150" width="34" height="36"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                             <buttonCell key="cell" type="bevel" title="Unlocked" alternateTitle="Locked" bezelStyle="regularSquare" image="Unlocked" imagePosition="only" alignment="center" alternateImage="Locked" inset="2" id="3932">
                                                 <behavior key="behavior" pushIn="YES" changeContents="YES" lightByContents="YES"/>
@@ -3069,48 +3069,6 @@
                             <action selector="lockAction:" target="-2" id="3660"/>
                         </connections>
                     </button>
-                    <button verticalHuggingPriority="750" id="4523">
-                        <rect key="frame" x="46" y="5" width="105" height="28"/>
-                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                        <buttonCell key="cell" type="push" title="Panic DOWN" bezelStyle="rounded" alignment="center" controlSize="small" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="4528">
-                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                            <font key="font" metaFont="smallSystem"/>
-                        </buttonCell>
-                        <connections>
-                            <action selector="hvMasterPanicAction:" target="-2" id="4532"/>
-                        </connections>
-                    </button>
-                    <button verticalHuggingPriority="750" id="4524">
-                        <rect key="frame" x="249" y="5" width="105" height="28"/>
-                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                        <buttonCell key="cell" type="push" title="triggers OFF" bezelStyle="rounded" alignment="center" controlSize="small" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="4527">
-                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                            <font key="font" metaFont="smallSystem"/>
-                        </buttonCell>
-                        <connections>
-                            <action selector="hvMasterTriggerOffAction:" target="-2" id="4533"/>
-                        </connections>
-                    </button>
-                    <button verticalHuggingPriority="750" id="4525">
-                        <rect key="frame" x="148" y="5" width="105" height="28"/>
-                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                        <buttonCell key="cell" type="push" title="triggers ON" bezelStyle="rounded" alignment="center" controlSize="small" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="4526">
-                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                            <font key="font" metaFont="smallSystem"/>
-                        </buttonCell>
-                        <connections>
-                            <action selector="hvMasterTriggerOnAction:" target="-2" id="4534"/>
-                        </connections>
-                    </button>
-                    <textField verticalHuggingPriority="750" id="4530">
-                        <rect key="frame" x="48" y="33" width="223" height="14"/>
-                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                        <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Detector wide:" id="4531">
-                            <font key="font" metaFont="smallSystem"/>
-                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                        </textFieldCell>
-                    </textField>
                 </subviews>
             </view>
             <connections>

--- a/Source/Objects/Custom Hardware/SNO+/XL3/XL3_LinkController.h
+++ b/Source/Objects/Custom Hardware/SNO+/XL3/XL3_LinkController.h
@@ -273,7 +273,6 @@
 //hv
 @property (assign) IBOutlet NSBox *hvBStatusPanel;
 @property (assign) IBOutlet NSBox *hvAStatusPanel;
-
 	
 
 - (IBAction)hvRelayMaskHighAction:(id)sender;
@@ -297,9 +296,7 @@
 - (IBAction)hvPanicAction:(id)sender;
 - (IBAction)hvTriggerOffAction:(id)sender;
 - (IBAction)hvTriggerOnAction:(id)sender;
-- (IBAction)hvMasterPanicAction:(id)sender;
-- (IBAction)hvMasterTriggerOffAction:(id)sender;
-- (IBAction)hvMasterTriggerOnAction:(id)sender;
+
 //connection
 - (IBAction) toggleConnectAction:(id)sender;
 - (IBAction) errorTimeOutAction:(id)sender;

--- a/Source/Objects/Custom Hardware/SNO+/XL3/XL3_LinkController.m
+++ b/Source/Objects/Custom Hardware/SNO+/XL3/XL3_LinkController.m
@@ -62,8 +62,8 @@ static NSDictionary* xl3Ops;
 	[super awakeFromNib];
     
     NSDictionary *statedict = [NSDictionary dictionaryWithObjectsAndKeys:
-                               [NSColor redColor], @"closed",
-                               [NSColor blueColor], @"open",
+                               [NSColor blueColor], @"closed",
+                               [NSColor redColor], @"open",
                                [NSColor blackColor], @"unk",
                                nil];
     msbox = [[ORMultiStateBox alloc] initWithStates:statedict size:20 pad:4 bevel:2];
@@ -1496,34 +1496,6 @@ static NSDictionary* xl3Ops;
 - (IBAction)hvTriggerOnAction:(id)sender
 {
     [model hvTriggersON];
-}
-
-- (IBAction)hvMasterPanicAction:(id)sender
-{
-    /*
-    NSArray* xl3s = [[[NSApp delegate] document] collectObjectsOfClass:NSClassFromString(@"ORXL3Model")];
-    for (id xl3 in xl3s) {
-        [model hvPanicDown];
-    }
-     */
-
-    [[[(ORAppDelegate*)[NSApp delegate] document] collectObjectsOfClass:NSClassFromString(@"ORXL3Model")] makeObjectsPerformSelector:@selector(hvPanicDown)];
-
-    //[model hvMasterPanicDown];
-    NSLog(@"Detector wide panic down started\n");
-}
-
-- (IBAction)hvMasterTriggerOffAction:(id)sender
-{
-    //NSLog(@"Stop all polling of XL3s");
-    [[[(ORAppDelegate*)[NSApp delegate] document] collectObjectsOfClass:NSClassFromString(@"ORXL3Model")] makeObjectsPerformSelector:@selector(setIsPollingXl3:) withObject:NO];
-    
-    [[[(ORAppDelegate*)[NSApp delegate] document] collectObjectsOfClass:NSClassFromString(@"ORXL3Model")] makeObjectsPerformSelector:@selector(hvTriggersOFF)];
-}
-
-- (IBAction)hvMasterTriggerOnAction:(id)sender
-{
-    [[[(ORAppDelegate*)[NSApp delegate] document] collectObjectsOfClass:NSClassFromString(@"ORXL3Model")] makeObjectsPerformSelector:@selector(hvTriggersON)];
 }
 
 //connection


### PR DESCRIPTION
Note: Actions were also removed for detector wide buttons in the XL3_LinkController.
I confirmed that the main SNO+ GUI does not use these actions for detector wide
trigger on/off or HV panic down, so this shouldn't break anything.

Fixes issues #85 and #29 - superficial changes shouldn't need testing.