### PR TITLE
Fix eca type causing errors when given weird values

### DIFF
--- a/Source/Experiments/SNOP/SNOPController.m
+++ b/Source/Experiments/SNOP/SNOPController.m
@@ -1204,9 +1204,14 @@ snopGreenColor;
 {
     
     //Refresh values in GUI to match the model
-    NSInteger* index = [model ECA_pattern] -1;
+    int index = [model ECA_pattern] -1;
+    if(index < 0)
+    {
+        NSLogColor([NSColor redColor], @"ECA bad index returned\n");
+        return;
+    }
     [ECApatternPopUpButton selectItemAtIndex:index];
-    [ECAtypePopUpButton selectItemWithTitle:[[model ECA_type] retain]];
+    [ECAtypePopUpButton selectItemWithTitle:[model ECA_type]];
     int integ = [model ECA_tslope_pattern];
     [TSlopePatternTextField setIntValue:integ];
     integ = [model ECA_nevents];

--- a/Source/Experiments/SNOP/SNOPModel.m
+++ b/Source/Experiments/SNOP/SNOPModel.m
@@ -1768,13 +1768,18 @@ err:
 
 - (NSString*)ECA_type
 {
-    return ECA_type;
+    return [NSString stringWithFormat:@"%@",ECA_type];
 }
 
 - (void) setECA_type:(NSString*)aValue
 {
-    ECA_type = aValue;
-    [[NSNotificationCenter defaultCenter] postNotificationName:ORSNOPModelRunsECAChangedNotification object:self];
+    if(aValue != ECA_type)
+    {
+        NSString* temp = ECA_type;
+        ECA_type = [aValue retain];
+        [temp release];
+        [[NSNotificationCenter defaultCenter] postNotificationName:ORSNOPModelRunsECAChangedNotification object:self];
+    }
 }
 
 - (int)ECA_tslope_pattern


### PR DESCRIPTION
This kind of fixes #128. That error was caused by the fact that ECA_type in the snopmodel was for some reason getting set to really weird values. ECA_Type is an NSString* but the SNOTMain.orca file used UG had that ECA_Type encoded as an NSNumber* with a value of 75. And since no one recently had opened the SNOPModel and changed it to a regular value that weird value has persisted for a long time. If you look at the stack trace referenced in #128 you can see that it tries to cast the NSNumber to an NSString. 

So the actual fix was to change the code so it doesn't attempt to decode that value and then just hardcode in a normal value ( "ECA_type" = @"PDST") then save that into the .orca file. 
Then get rid of the hardcoding and make everything normal again.

Since I have no clue ho ECA_type = NSNumber* with value of 75 it's not unthinkable that it will happen again.  These changes should make it so if somehow ECA_type does get a really weird value orca doesn't crash all the time. I'm unsure how orca should handle that really but I think crashing is probably not the correct way.

 