### PR TITLE
update readHVStatus method

### DIFF
--- a/Source/Objects/Custom Hardware/SNO+/XL3/ORXL3Model.m
+++ b/Source/Objects/Custom Hardware/SNO+/XL3/ORXL3Model.m
@@ -3425,7 +3425,10 @@ err:
         HVReadbackResults status;
         @try {
             [self readHVStatus:&status];
-        } @catch (NSException *exception) {
+        } @catch (NSException *e) {
+            NSLogColor([NSColor redColor],
+                       @"xl3 %i: Failed to read HV status: %@\n",
+                       [self crateNumber], [e reason]);
             return;
         }
 

--- a/Source/Objects/Custom Hardware/SNO+/XL3/ORXL3Model.m
+++ b/Source/Objects/Custom Hardware/SNO+/XL3/ORXL3Model.m
@@ -3413,23 +3413,19 @@ err:
     [self setHvEverUpdated:YES];
 }
 
-//used from polling loop and/or ORCA script
 - (void) readHVStatus
 {
+    /* Read back the HV value and current for supplies A and B and update the
+     * model. */
     @synchronized(self) {
-        if (![[self xl3Link] isConnected]) {//ORSNOPExperiment sends a notification to all crates
+        if (![[self xl3Link] isConnected]) {
             return;
         }
 
         HVReadbackResults status;
         @try {
             [self readHVStatus:&status];
-        }
-        @catch (NSException *exception) {
-            if (isPollingXl3) {
-                NSLog(@"%@ Polling loop stopped because reading XL3 local voltages failed\n", [[self xl3Link] crateName]);
-                [self setIsPollingXl3:NO];
-            }
+        } @catch (NSException *exception) {
             return;
         }
 
@@ -3438,32 +3434,12 @@ err:
         [self setHvACurrentReadValue:status.currentA * 10.];
         [self setHvBCurrentReadValue:status.currentB * 10.];
 
-        //data packet
-        const unsigned char packet_length = 6+6;
-        if (isPollingXl3 && [[ORGlobal sharedGlobal] runInProgress]) {
-            unsigned long data[packet_length];
-            data[0] = [self xl3HvDataId] | packet_length;
-            data[1] = [self crateNumber];
-            float* vlt = (float*)&data[2];
-            vlt[0] = [self hvAVoltageReadValue];
-            vlt[1] = [self hvBVoltageReadValue];
-            vlt[2] = [self hvACurrentReadValue];
-            vlt[3] = [self hvBCurrentReadValue];
-            const char* timestamp = [[self stringDate] cStringUsingEncoding:NSASCIIStringEncoding];
-            memcpy(data+6, timestamp, 6*4);
-            NSData* pdata = [[NSData alloc] initWithBytes:data length:sizeof(long)*(packet_length)];
-            dispatch_async(dispatch_get_main_queue(), ^{
-                [[NSNotificationCenter defaultCenter] postNotificationName:ORQueueRecordForShippingNotification object:pdata];
-                [pdata release];
-            });
-            pdata = nil;
-        }
         dispatch_async(dispatch_get_main_queue(), ^{
-            [[NSNotificationCenter defaultCenter] postNotificationName:ORXL3ModelHvStatusChanged object:self];
+            [[NSNotificationCenter defaultCenter]
+             postNotificationName:ORXL3ModelHvStatusChanged object:self];
         });
     }
 }
-
 
 - (void) hvUserIntervention:(BOOL)forA
 {

--- a/Source/Objects/Custom Hardware/SNO+/XL3/ORXL3Model.m
+++ b/Source/Objects/Custom Hardware/SNO+/XL3/ORXL3Model.m
@@ -3419,6 +3419,8 @@ err:
      * model. */
     @synchronized(self) {
         if (![[self xl3Link] isConnected]) {
+            NSLogColor([NSColor redColor], @"xl3 %i: readHVStatus called, "
+                       "but XL3 is not connected!\n", [self crateNumber]);
             return;
         }
 
@@ -3426,9 +3428,8 @@ err:
         @try {
             [self readHVStatus:&status];
         } @catch (NSException *e) {
-            NSLogColor([NSColor redColor],
-                       @"xl3 %i: Failed to read HV status: %@\n",
-                       [self crateNumber], [e reason]);
+            NSLogColor([NSColor redColor], @"xl3 %i: Failed to read HV status: "
+                       "%@\n", [self crateNumber], [e reason]);
             return;
         }
 


### PR DESCRIPTION
- HV readback is no longer called as part of the polling routines
- HV readback is called often and so we don't want to save it to the ORCA run file
- add some comments

This fixes issue #131.

@BenLand100 Can you confirm that these changes look OK and that the HV readback is no longer a part of the polling routines.