### PR TITLE
SNO+: Accept PMTIC IDs returned from XL3 on init

### DIFF
--- a/Source/Objects/Custom Hardware/SNO+/XL3/DB.h
+++ b/Source/Objects/Custom Hardware/SNO+/XL3/DB.h
@@ -9,6 +9,7 @@ typedef struct
 {
   uint16_t mbID;
   uint16_t dbID[4];
+  uint16_t pmticID;
 } FECConfiguration;
 
 typedef struct {
@@ -46,7 +47,7 @@ typedef struct {
 typedef struct {
   uint16_t mbID; //!< 
   uint16_t dbID[4]; //!<
-  uint8_t vBal[2][32]; //!< 
+  uint8_t vBal[2][32]; //!<
   uint8_t vThr[32]; //!<
   TDisc tDisc; //!< 
   TCmos tCmos; //!<
@@ -61,6 +62,7 @@ typedef struct {
 typedef struct
 {
 	MB mb[16]; //!< all 16 fec database values
+    uint16_t pmticID[16]; //!< All 16 PMTIC IDs. Not in MB for compatibility
 	uint32_t ctcDelay; //!< ctc based trigger delay
 } Crate; //!< all database values for the crate
 


### PR DESCRIPTION
This is in anticipation of a complementary change being made to the ML403 firmware.