### PR TITLE
SNO+: Add HV alarm subsystem to XL3 code.

### DIFF
--- a/Source/Objects/Custom Hardware/SNO+/XL3/ORXL3Model.h
+++ b/Source/Objects/Custom Hardware/SNO+/XL3/ORXL3Model.h
@@ -108,6 +108,8 @@ enum {
     BOOL hvBSwitch;
     BOOL hvARamping;
     BOOL hvBRamping;
+    BOOL hvAFromDB;
+    BOOL hvBFromDB;
     BOOL hvEverUpdated;
     BOOL hvSwitchEverUpdated;
     BOOL hvANeedsUserIntervention;
@@ -115,6 +117,25 @@ enum {
     
     NSString* triggerStatus;
     BOOL _isTriggerON;
+    
+    unsigned long _hvNominalVoltageA;
+    float _hvramp_a_up;
+    float _hvramp_a_down;
+    float _vsetalarm_a_vtol;
+    float _ilowalarm_a_vmin;
+    float _ilowalarm_a_imin;
+    float _vhighalarm_a_vmax;
+    float _ihighalarm_a_imax;
+    
+    unsigned long _hvNominalVoltageB;
+    float _hvramp_b_up;
+    float _hvramp_b_down;
+    float _vsetalarm_b_vtol;
+    float _ilowalarm_b_vmin;
+    float _ilowalarm_b_imin;
+    float _vhighalarm_b_vmax;
+    float _ihighalarm_b_imax;
+    
 
     unsigned long hvAVoltageDACSetValue;
     unsigned long hvBVoltageDACSetValue;
@@ -132,8 +153,6 @@ enum {
     unsigned long _hvBCMOSRateIgnore;
     unsigned long _hvANextStepValue;
     unsigned long _hvBNextStepValue;
-    unsigned long _hvNominalVoltageA;
-    unsigned long _hvNominalVoltageB;
     NSLock* hvInitLock;
     NSThread* hvInitThread;
     NSThread* hvThread;
@@ -215,6 +234,25 @@ enum {
 @property (nonatomic,assign) bool ecalToOrcaInProgress;
 @property (assign) id snotDb;//I replaced 'weak' by 'assign' to get Orca compiled under 10.6 (-tb- 2013-09)
 
+
+@property float hvramp_a_up;
+@property float hvramp_a_down;
+@property float vsetalarm_a_vtol;
+@property float ilowalarm_a_vmin;
+@property float ilowalarm_a_imin;
+@property float vhighalarm_a_vmax;
+@property float ihighalarm_a_imax;
+
+@property float hvramp_b_up;
+@property float hvramp_b_down;
+@property float vsetalarm_b_vtol;
+@property float ilowalarm_b_vmin;
+@property float ilowalarm_b_imin;
+@property float vhighalarm_b_vmax;
+@property float ihighalarm_b_imax;
+
+@property BOOL hvAFromDB;
+@property BOOL hvBFromDB;
 @property BOOL hvEverUpdated;
 @property BOOL hvSwitchEverUpdated;
 @property BOOL hvARamping;

--- a/Source/Objects/Custom Hardware/SNO+/XL3/ORXL3Model.m
+++ b/Source/Objects/Custom Hardware/SNO+/XL3/ORXL3Model.m
@@ -103,8 +103,6 @@ extern NSString* ORSNOPRequestHVStatus;
 - (void) _hvInit;
 - (void) _hvXl3;
 - (void) _setPedestalInParallelWorker;
-- (void) _hv_a_dbparams:(ORPQResult*)result;
-- (void) _hv_b_dbparams:(ORPQResult*)result;
 - (void) _post_heartbeat:(int)crate;
 - (void) _trigger_edge_alarm:(int)alarmid;
 - (void) _update_level_alarm:(int)alarmid level:(bool)state;
@@ -4470,43 +4468,6 @@ err:
     [pollPool release];
 }
 
-//Callback for database access to hv params for supply a
-- (void)_hv_a_dbparams:(ORPQResult*)result
-{
-    if (!hvAFromDB) { // Only do this once
-        @try {
-            NSDictionary* dict = [result fetchRowAsDictionary];
-            [self setHvNominalVoltageA:[(NSNumber*)[dict valueForKey:@"nominal"] intValue]];
-            [self setHvramp_a_up:[(NSNumber*)[dict valueForKey:@"hvramp_up"] floatValue]];
-            [self setHvramp_a_down:[(NSNumber*)[dict valueForKey:@"hvramp_down"] floatValue]];
-            [self setVsetalarm_a_vtol:[(NSNumber*)[dict valueForKey:@"vsetalarm_vtol"] floatValue]];
-            [self setIlowalarm_a_vmin:[(NSNumber*)[dict valueForKey:@"ilowalarm_vmin"] floatValue]];
-            [self setIlowalarm_a_imin:[(NSNumber*)[dict valueForKey:@"ilowalarm_imin"] floatValue]];
-            [self setVhighalarm_a_vmax:[(NSNumber*)[dict valueForKey:@"vhighalarm_vmax"] floatValue]];
-            [self setIhighalarm_a_imax:[(NSNumber*)[dict valueForKey:@"ihighalarm_imax"] floatValue]];
-        } @catch (NSException *exception) { }
-        [self setHvAFromDB:true];
-    }
-}
-
-//Callback for database access to hv params for supply b
-- (void)_hv_b_dbparams:(ORPQResult*)result
-{
-    if (!hvBFromDB) { // Only do this once
-        @try {
-            NSDictionary* dict = [result fetchRowAsDictionary];
-            [self setHvNominalVoltageB:[(NSNumber*)[dict valueForKey:@"nominal"] intValue]];
-            [self setHvramp_b_up:[(NSNumber*)[dict valueForKey:@"hvramp_up"] floatValue]];
-            [self setHvramp_b_down:[(NSNumber*)[dict valueForKey:@"hvramp_down"] floatValue]];
-            [self setVsetalarm_b_vtol:[(NSNumber*)[dict valueForKey:@"vsetalarm_vtol"] floatValue]];
-            [self setIlowalarm_b_vmin:[(NSNumber*)[dict valueForKey:@"ilowalarm_vmin"] floatValue]];
-            [self setIlowalarm_b_imin:[(NSNumber*)[dict valueForKey:@"ilowalarm_imin"] floatValue]];
-            [self setVhighalarm_b_vmax:[(NSNumber*)[dict valueForKey:@"vhighalarm_vmax"] floatValue]];
-            [self setIhighalarm_b_imax:[(NSNumber*)[dict valueForKey:@"ihighalarm_imax"] floatValue]];
-        } @catch (NSException *exception) { }
-        [self setHvBFromDB:true];
-    }
-}
 
 float nominals[] = {2110.0, 2240.0, 2075.0, 2160.0, 2043.0, 2170.0, 2170.0, 2170.0,
                     2060.0, 2435.0, 2240.0, 2370.0, 2220.0, 2270.0, 1970.0, 2025.0,
@@ -4525,10 +4486,6 @@ float nominals[] = {2110.0, 2240.0, 2075.0, 2160.0, 2043.0, 2170.0, 2170.0, 2170
         if ([self xl3Link] && [[self xl3Link] isConnected]) {
             
             //B.J.L. 11/22/16 - this block is a temporary to hardcode parameters pending DB access
-            //Remove this TEMPBLOCK once DB access via postgres works and uncomment below
-            //TEMPBLOCK
-            hvAFromDB = true;
-            hvBFromDB = true;
             [self setHvNominalVoltageA:nominals[[self crateNumber]]];
             [self setHvramp_a_up:10.0];
             [self setHvramp_a_down:50.0];
@@ -4545,10 +4502,9 @@ float nominals[] = {2110.0, 2240.0, 2075.0, 2160.0, 2043.0, 2170.0, 2170.0, 2170
             [self setIlowalarm_b_imin:10.0];
             [self setIhighalarm_b_imax:1000.0];
             [self setVhighalarm_b_vmax:(int)([self crateNumber]==16 ? 2445.0 : 0.0)+50.0];
-            //TEMPBLOCK
-            //if (!hvAFromDB) [[ORPQModel getCurrent] dbQuery:[NSString stringWithFormat:@"SELECT * FROM hvparams WHERE crate=%i AND supply='A'", [self crateNumber]] object:self selector:@selector(_hv_a_dbparams:)];
-            //if (!hvBFromDB) [[ORPQModel getCurrent] dbQuery:[NSString stringWithFormat:@"SELECT * FROM hvparams WHERE crate=%i AND supply='B'", [self crateNumber]] object:self selector:@selector(_hv_b_dbparams:)];
-            
+            hvAFromDB = true; //flag to indicate params were loaded
+            hvBFromDB = true; //flag to indicate params were loaded
+
             //now readback the HV settings according to the XL3
             @try {
                 [self readHVSwitchOn];

--- a/Source/Objects/Custom Hardware/SNO+/XL3/ORXL3Model.m
+++ b/Source/Objects/Custom Hardware/SNO+/XL3/ORXL3Model.m
@@ -31,6 +31,8 @@
 #import "ObjectFactory.h"
 #import "ORDataTypeAssigner.h"
 #import "ORCouchDB.h"
+#import "ORPQModel.h"
+#import "ORPQResult.h"
 
 static Xl3RegNamesStruct reg[kXl3NumRegisters] = {
 	{ @"SelectReg",		RESET_REG },
@@ -101,6 +103,11 @@ extern NSString* ORSNOPRequestHVStatus;
 - (void) _hvInit;
 - (void) _hvXl3;
 - (void) _setPedestalInParallelWorker;
+- (void) _hv_a_dbparams:(ORPQResult*)result;
+- (void) _hv_b_dbparams:(ORPQResult*)result;
+- (void) _post_heartbeat:(int)crate;
+- (void) _trigger_edge_alarm:(int)alarmid;
+- (void) _update_level_alarm:(int)alarmid level:(bool)state;
 @end
 
 @implementation ORXL3Model
@@ -117,6 +124,20 @@ isPollingForced,
 calcCMOSRatesFromCounts = _calcCMOSRatesFromCounts,
 hvANextStepValue = _hvANextStepValue,
 hvBNextStepValue = _hvBNextStepValue,
+hvramp_a_up = _hvramp_a_up,
+hvramp_a_down = _hvramp_a_down,
+vsetalarm_a_vtol = _vsetalarm_a_vtol,
+ilowalarm_a_vmin = _ilowalarm_a_vmin,
+ilowalarm_a_imin = _ilowalarm_a_imin,
+vhighalarm_a_vmax = _vhighalarm_a_vmax,
+ihighalarm_a_imax = _ihighalarm_a_imax,
+hvramp_b_up = _hvramp_b_up,
+hvramp_b_down = _hvramp_b_down,
+vsetalarm_b_vtol = _vsetalarm_b_vtol,
+ilowalarm_b_vmin = _ilowalarm_b_vmin,
+ilowalarm_b_imin = _ilowalarm_b_imin,
+vhighalarm_b_vmax = _vhighalarm_b_vmax,
+ihighalarm_b_imax = _ihighalarm_b_imax,
 hvCMOSReadsCounter = _hvCMOSReadsCounter,
 xl3LinkTimeOut = _xl3LinkTimeOut,
 xl3InitInProgress = _xl3InitInProgress,
@@ -757,6 +778,32 @@ snotDb = _snotDb;
     hvSwitchEverUpdated = ever;
 }
 
+- (BOOL) hvAFromDB
+{
+    return hvAFromDB;
+}
+
+- (void) setHvAFromDB:(BOOL)fromdb
+{
+    hvAFromDB = fromdb;
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [[NSNotificationCenter defaultCenter] postNotificationName:ORXL3ModelHvStatusChanged object:self];
+    });
+}
+
+- (BOOL) hvBFromDB
+{
+    return hvBFromDB;
+}
+
+- (void) setHvBFromDB:(BOOL)fromdb
+{
+    hvBFromDB = fromdb;
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [[NSNotificationCenter defaultCenter] postNotificationName:ORXL3ModelHvStatusChanged object:self];
+    });
+}
+
 - (BOOL) hvARamping
 {
     return hvARamping;
@@ -1373,7 +1420,7 @@ void SwapLongBlock(void* p, int32_t n)
 - (id)initWithCoder:(NSCoder*)decoder
 {
     int i;
-
+    
     self = [super initWithCoder:decoder];
     [[self undoManager] disableUndoRegistration];
 
@@ -1392,7 +1439,6 @@ void SwapLongBlock(void* p, int32_t n)
     [self setXl3PedestalMask:       [decoder decodeIntForKey:@"ORXL3ModelXl3PedestalMask"]];
     [self setXl3ChargeInjMask:      [decoder decodeIntForKey:@"ORXL3ModelXl3ChargeInjMask"]];
     [self setXl3ChargeInjCharge:    [decoder decodeIntForKey:@"ORXL3ModelXl3ChargeInjCharge"]];
-
     [self setPollXl3Time:           [decoder decodeIntForKey:@"ORXL3ModelPollXl3Time"]];
     //[self setIsPollingXl3:          [decoder decodeBoolForKey:@"ORXL3ModelIsPollingXl3"]];
     [self setIsPollingXl3:NO];
@@ -1416,8 +1462,6 @@ void SwapLongBlock(void* p, int32_t n)
     [self setHvBCMOSRateLimit:  [decoder decodeIntForKey:@"ORXL3ModelhvBCMOSRateLimit"]];
     [self setHvACMOSRateIgnore: [decoder decodeIntForKey:@"ORXL3ModelhvACMOSRateIgnore"]];
     [self setHvBCMOSRateIgnore: [decoder decodeIntForKey:@"ORXL3ModelhvBCMOSRateIgnore"]];
-    [self setHvNominalVoltageA: [decoder decodeIntForKey:@"ORXL3ModelHvNominalVoltageA"]];
-    [self setHvNominalVoltageB: [decoder decodeIntForKey:@"ORXL3ModelHvNominalVoltageB"]];
     [self setXl3Mode:           [decoder decodeIntForKey:@"Xl3Mode"]];
     [self setIsTriggerON:       [decoder decodeBoolForKey:@"isTriggerON"]];
 
@@ -1427,15 +1471,7 @@ void SwapLongBlock(void* p, int32_t n)
         [self setTriggerStatus:@"OFF"];
     }
     
-    //FIXME from ORCADB
-    if ([self hvNominalVoltageA] == 0) {
-        [self setHvNominalVoltageA:2500];
-    }
-    if ([self hvNominalVoltageB] == 0) {
-        [self setHvNominalVoltageB:2500];
-    }
-
-    for (i = 0; i < 12; i++) {
+    for (i=0; i<12; i++) {
         [self setXl3VltThreshold:i withValue:[decoder decodeFloatForKey:[NSString stringWithFormat:@"ORXL3ModelVltThreshold%i", i]]];
     }
     [self setIsXl3VltThresholdInInit:[decoder decodeBoolForKey:@"ORXL3ModelXl3VltThresholdInInit"]];
@@ -4434,6 +4470,48 @@ err:
     [pollPool release];
 }
 
+//Callback for database access to hv params for supply a
+- (void)_hv_a_dbparams:(ORPQResult*)result
+{
+    if (!hvAFromDB) { // Only do this once
+        @try {
+            NSDictionary* dict = [result fetchRowAsDictionary];
+            [self setHvNominalVoltageA:[(NSNumber*)[dict valueForKey:@"nominal"] intValue]];
+            [self setHvramp_a_up:[(NSNumber*)[dict valueForKey:@"hvramp_up"] floatValue]];
+            [self setHvramp_a_down:[(NSNumber*)[dict valueForKey:@"hvramp_down"] floatValue]];
+            [self setVsetalarm_a_vtol:[(NSNumber*)[dict valueForKey:@"vsetalarm_vtol"] floatValue]];
+            [self setIlowalarm_a_vmin:[(NSNumber*)[dict valueForKey:@"ilowalarm_vmin"] floatValue]];
+            [self setIlowalarm_a_imin:[(NSNumber*)[dict valueForKey:@"ilowalarm_imin"] floatValue]];
+            [self setVhighalarm_a_vmax:[(NSNumber*)[dict valueForKey:@"vhighalarm_vmax"] floatValue]];
+            [self setIhighalarm_a_imax:[(NSNumber*)[dict valueForKey:@"ihighalarm_imax"] floatValue]];
+        } @catch (NSException *exception) { }
+        [self setHvAFromDB:true];
+    }
+}
+
+//Callback for database access to hv params for supply b
+- (void)_hv_b_dbparams:(ORPQResult*)result
+{
+    if (!hvBFromDB) { // Only do this once
+        @try {
+            NSDictionary* dict = [result fetchRowAsDictionary];
+            [self setHvNominalVoltageB:[(NSNumber*)[dict valueForKey:@"nominal"] intValue]];
+            [self setHvramp_b_up:[(NSNumber*)[dict valueForKey:@"hvramp_up"] floatValue]];
+            [self setHvramp_b_down:[(NSNumber*)[dict valueForKey:@"hvramp_down"] floatValue]];
+            [self setVsetalarm_b_vtol:[(NSNumber*)[dict valueForKey:@"vsetalarm_vtol"] floatValue]];
+            [self setIlowalarm_b_vmin:[(NSNumber*)[dict valueForKey:@"ilowalarm_vmin"] floatValue]];
+            [self setIlowalarm_b_imin:[(NSNumber*)[dict valueForKey:@"ilowalarm_imin"] floatValue]];
+            [self setVhighalarm_b_vmax:[(NSNumber*)[dict valueForKey:@"vhighalarm_vmax"] floatValue]];
+            [self setIhighalarm_b_imax:[(NSNumber*)[dict valueForKey:@"ihighalarm_imax"] floatValue]];
+        } @catch (NSException *exception) { }
+        [self setHvBFromDB:true];
+    }
+}
+
+float nominals[] = {2110.0, 2240.0, 2075.0, 2160.0, 2043.0, 2170.0, 2170.0, 2170.0,
+                    2060.0, 2435.0, 2240.0, 2370.0, 2220.0, 2270.0, 1970.0, 2025.0,
+                    1995.0, 1945.0, 2010.0, 2000.0}; //crates 0-19 supply a
+
 // This method is started as a thread when a new ORXL3Model is created. It waits
 // for the XL3 to connect AND for the XL3 to report that it the xilinx chip
 // is properly initialized (necessary for HV readback) before launching the high
@@ -4445,6 +4523,31 @@ err:
         sleep(1);
         //do nothing without an xl3 connected
         if ([self xl3Link] && [[self xl3Link] isConnected]) {
+            
+            //B.J.L. 11/22/16 - this block is a temporary to hardcode parameters pending DB access
+            //Remove this TEMPBLOCK once DB access via postgres works and uncomment below
+            //TEMPBLOCK
+            hvAFromDB = true;
+            hvBFromDB = true;
+            [self setHvNominalVoltageA:nominals[[self crateNumber]]];
+            [self setHvramp_a_up:10.0];
+            [self setHvramp_a_down:50.0];
+            [self setVsetalarm_a_vtol:50.0];
+            [self setIlowalarm_a_vmin:500.0];
+            [self setIlowalarm_a_imin:10.0];
+            [self setIhighalarm_a_imax:1000.0];
+            [self setVhighalarm_a_vmax:nominals[[self crateNumber]]+50.0];
+            [self setHvNominalVoltageB:(int)([self crateNumber]==16 ? 2445.0 : 0.0)];
+            [self setHvramp_b_up:10.0];
+            [self setHvramp_b_down:50.0];
+            [self setVsetalarm_b_vtol:50.0];
+            [self setIlowalarm_b_vmin:500.0];
+            [self setIlowalarm_b_imin:10.0];
+            [self setIhighalarm_b_imax:1000.0];
+            [self setVhighalarm_b_vmax:(int)([self crateNumber]==16 ? 2445.0 : 0.0)+50.0];
+            //TEMPBLOCK
+            //if (!hvAFromDB) [[ORPQModel getCurrent] dbQuery:[NSString stringWithFormat:@"SELECT * FROM hvparams WHERE crate=%i AND supply='A'", [self crateNumber]] object:self selector:@selector(_hv_a_dbparams:)];
+            //if (!hvBFromDB) [[ORPQModel getCurrent] dbQuery:[NSString stringWithFormat:@"SELECT * FROM hvparams WHERE crate=%i AND supply='B'", [self crateNumber]] object:self selector:@selector(_hv_b_dbparams:)];
             
             //now readback the HV settings according to the XL3
             @try {
@@ -4463,8 +4566,8 @@ err:
             if (!self.hvANeedsUserIntervention) {
                 if ([self hvASwitch]) {
                     double next = [self hvAVoltageReadValue]*4096/3000.;
-                    if (next > [self hvAVoltageTargetValue])
-                        next = [self hvAVoltageTargetValue];
+                    if (next > [self hvNominalVoltageA]*4096/3000)
+                        next = [self hvNominalVoltageA]*4096/3000;
                     [self setHvAVoltageDACSetValue:next];
                     [self setHvANextStepValue:next];
                 } else {
@@ -4475,8 +4578,8 @@ err:
             if (!self.hvBNeedsUserIntervention) {
                 if ([self hvBSwitch]) {
                     double next = [self hvBVoltageReadValue]*4096/3000.;
-                    if (next > [self hvBVoltageTargetValue])
-                        next = [self hvBVoltageTargetValue];
+                    if (next > [self hvNominalVoltageB]*4096/3000)
+                        next = [self hvNominalVoltageB]*4096/3000;
                     [self setHvBVoltageDACSetValue:next];
                     [self setHvBNextStepValue:next];
                 } else {
@@ -4493,8 +4596,12 @@ err:
                 [hvThread release];
                 hvThread = nil;
             }
-            hvThread = [[NSThread alloc] initWithTarget:self selector:@selector(_hvXl3) object:nil];
-            [hvThread start];
+            if (hvAFromDB && hvBFromDB) {
+                hvThread = [[NSThread alloc] initWithTarget:self selector:@selector(_hvXl3) object:nil];
+                [hvThread start];
+            } else {
+                continue;
+            }
             
             //let everyone know that we now have HV control
             dispatch_async(dispatch_get_main_queue(), ^{
@@ -4504,6 +4611,35 @@ err:
         }
     }
     [hvPool release];
+}
+
+- (void) _trigger_edge_alarm:(int)alarmid
+{
+    @try {
+        NSString* msg = [NSString stringWithFormat:@"SELECT * FROM post_alarm(%i)", alarmid];
+        [[ORPQModel getCurrent] dbQuery:msg object:nil selector:nil];
+    } @catch (NSException *exception) { }
+}
+
+- (void) _update_level_alarm:(int)alarmid level:(bool)level
+{
+    @try {
+        NSString* msg;
+        if (level) {
+            msg = [NSString stringWithFormat:@"SELECT * FROM post_alarm(%i)", alarmid];
+        } else {
+            msg = [NSString stringWithFormat:@"SELECT * FROM clear_alarm(%i)", alarmid];
+        }
+        [[ORPQModel getCurrent] dbQuery:msg object:nil selector:nil];
+    } @catch (NSException *exception) { }
+}
+
+- (void) _post_heartbeat:(int)crate
+{
+    @try {
+        NSString* msg = [NSString stringWithFormat:@"SELECT * FROM post_heartbeat('orca_crate_%i_hv')", crate];
+        [[ORPQModel getCurrent] dbQuery:msg object:nil selector:nil];
+    } @catch (NSException *exception) { }
 }
 
 // This is the historical HV control and monitoring thread. It effectively ramps
@@ -4522,6 +4658,11 @@ err:
 // condition.
 - (void) _hvXl3
 {
+    if (![self hvAFromDB] && ![self hvBFromDB]) {
+        NSLog(@"%@ trying to start HV control thread without parameters!\n",[[self xl3Link] crateName]);
+        return;
+    }
+    
     NSAutoreleasePool* hvPool = [[NSAutoreleasePool alloc] init];
     
     NSLog(@"%@ starting HV control thread\n",[[self xl3Link] crateName]);
@@ -4537,7 +4678,6 @@ err:
         NSLog(msg);
     }
     
-    
     //Runs until the thread is cancelled
     while (![[NSThread currentThread] isCancelled] ) {
         
@@ -4548,11 +4688,11 @@ err:
             unsigned long aValueToSet = [self hvANextStepValue];
             changing = true;
             
-            if ([self hvANextStepValue] > [self hvAVoltageDACSetValue] + 10 / 3000. * 4096) {
-                aValueToSet = [self hvAVoltageDACSetValue] + 10 / 3000. * 4096;
+            if ([self hvANextStepValue] > [self hvAVoltageDACSetValue] + [self hvramp_a_up] / 3000. * 4096) {
+                aValueToSet = [self hvAVoltageDACSetValue] + [self hvramp_a_up] / 3000. * 4096;
             }
-            if ([self hvANextStepValue] < [self hvAVoltageDACSetValue] - 50 / 3000. * 4096) {
-                aValueToSet = [self hvAVoltageDACSetValue] - 50 / 3000. * 4096;
+            if ([self hvANextStepValue] < [self hvAVoltageDACSetValue] - [self hvramp_b_down] / 3000. * 4096) {
+                aValueToSet = [self hvAVoltageDACSetValue] - [self hvramp_b_down] / 3000. * 4096;
             }
             if (aValueToSet > [self hvAVoltageTargetValue]) { //never go above target (?)
                 aValueToSet = [self hvAVoltageTargetValue];
@@ -4569,15 +4709,15 @@ err:
             }
         }
         
-        if (!self.hvBNeedsUserIntervention && [self hvBNextStepValue] != [self hvBVoltageDACSetValue]) {
+        if ([self crateNumber] == 16 && !self.hvBNeedsUserIntervention && [self hvBNextStepValue] != [self hvBVoltageDACSetValue]) {
             unsigned long aValueToSet = [self hvBNextStepValue];
             changing = true;
             
-            if ([self hvBNextStepValue] > [self hvBVoltageDACSetValue] + 10 / 3000. * 4096) {
-                aValueToSet = [self hvBVoltageDACSetValue] + 10 / 3000. * 4096;
+            if ([self hvBNextStepValue] > [self hvBVoltageDACSetValue] + [self hvramp_a_up] / 3000. * 4096) {
+                aValueToSet = [self hvBVoltageDACSetValue] + [self hvramp_a_up] / 3000. * 4096;
             }
-            if ([self hvBNextStepValue] < [self hvBVoltageDACSetValue] - 50 / 3000. * 4096) {
-                aValueToSet = [self hvBVoltageDACSetValue] - 50 / 3000. * 4096;
+            if ([self hvBNextStepValue] < [self hvBVoltageDACSetValue] - [self hvramp_b_down] / 3000. * 4096) {
+                aValueToSet = [self hvBVoltageDACSetValue] - [self hvramp_b_down] / 3000. * 4096;
             }
             if (aValueToSet > [self hvBVoltageTargetValue]) { // never go above target (?)
                 aValueToSet = [self hvBVoltageTargetValue];
@@ -4617,10 +4757,12 @@ err:
 
             //check for ramps that aren't tracking the setpoints
             if ([self hvASwitch] && aUp && fabs([self hvAVoltageReadValue] - [self hvAVoltageDACSetValue]/4096.*3000.) > 100) {
+                [self _trigger_edge_alarm:80100+[self crateNumber]*2+0];
                 NSLogColor([NSColor redColor],@"%@ HV A read value differs from the setpoint. stopping!\nPress Ramp UP to continue.\n", [[self xl3Link] crateName]);
                 [self setHvANextStepValue:[self hvAVoltageDACSetValue]];
             }
-            if ([self hvBSwitch] && bUp && fabs([self hvBVoltageReadValue] - [self hvBVoltageDACSetValue]/4096.*3000.) > 100) {
+            if ([self crateNumber] == 16 && [self hvBSwitch] && bUp && fabs([self hvBVoltageReadValue] - [self hvBVoltageDACSetValue]/4096.*3000.) > 100) {
+                [self _trigger_edge_alarm:80100+[self crateNumber]*2+0];
                 NSLogColor([NSColor redColor],@"%@ HV B read value differs from the setpoint. stopping!\nPress Ramp UP to continue.\n", [[self xl3Link] crateName]);
                 [self setHvBNextStepValue:[self hvBVoltageDACSetValue]];
             }
@@ -4630,38 +4772,63 @@ err:
             [self setHvARamping:false];
             [self setHvBRamping:false];
 
-            //check for voltage dropout (FIXME: add current checking)
+            //check hv setpoint alarm
+            bool supplyASetpointDiscrepancy = false;
             if (self.hvANeedsUserIntervention) {
-                if (fabs([self hvAVoltageReadValue] - [self hvAVoltageDACSetValue]/4096.*3000.) <= 100) {
+                if (fabs([self hvAVoltageReadValue] - [self hvAVoltageDACSetValue]/4096.*3000.) <= [self vsetalarm_a_vtol]) {
                     NSLogColor([NSColor redColor],@"%@ HV A read value recovered.", [[self xl3Link] crateName]);
                     self.hvANeedsUserIntervention = false;
+                } else {
+                    supplyASetpointDiscrepancy = true;
                 }
             } else {
-                if ([self hvASwitch] && (fabs([self hvAVoltageReadValue] - [self hvAVoltageDACSetValue]/4096.*3000.) > 100)) {
+                if ([self hvASwitch] && (fabs([self hvAVoltageReadValue] - [self hvAVoltageDACSetValue]/4096.*3000.) > [self vsetalarm_a_vtol])) {
                     self.hvANeedsUserIntervention = true;
-                    NSString* alarmString = [NSString stringWithFormat:@"%@ HV A Setpoint Discrepancy",[[self xl3Link] crateName]];
-                    ORAlarm *hvHighCurrentAlarm = [[ORAlarm alloc] initWithName:alarmString severity:kEmergencyAlarm];
-                    [hvHighCurrentAlarm setAcknowledged:NO];
-                    [hvHighCurrentAlarm postAlarm];
+                    supplyASetpointDiscrepancy = true;
                     NSLogColor([NSColor redColor],@"%@ HV A read value differs from the setpoint! Suspending HV monitoring and control. Press 'Accept Readback' to resume.\n", [[self xl3Link] crateName]);
                 }
             }
-            if (self.hvBNeedsUserIntervention) {
-                if (fabs([self hvBVoltageReadValue] - [self hvBVoltageDACSetValue]/4096.*3000.) <= 100) {
-                    NSLog(@"%@ HV B read value recovered", [[self xl3Link] crateName]);
-                    self.hvBNeedsUserIntervention = false;
+            [self _update_level_alarm:80200+2*[self crateNumber]+0 level:supplyASetpointDiscrepancy];
+            
+            if ([self crateNumber] == 16) {
+                bool supplyBSetpointDiscrepancy = false;
+                if (self.hvBNeedsUserIntervention) {
+                    if (fabs([self hvBVoltageReadValue] - [self hvBVoltageDACSetValue]/4096.*3000.) <= [self vsetalarm_b_vtol]) {
+                        NSLog(@"%@ HV B read value recovered", [[self xl3Link] crateName]);
+                        self.hvBNeedsUserIntervention = false;
+                    } else {
+                        supplyBSetpointDiscrepancy = true;
+                    }
+                } else {
+                    if ([self hvBSwitch] && (fabs([self hvBVoltageReadValue] - [self hvBVoltageDACSetValue]/4096.*3000.) > 100)) {
+                        self.hvBNeedsUserIntervention = true;
+                        supplyBSetpointDiscrepancy = true;
+                        NSLogColor([NSColor redColor],@"%@ HV B read value differs from the setpoint! Suspending HV monitoring and control. Press 'Accept Readback' to resume.\n", [[self xl3Link] crateName]);
+                    }
                 }
-            } else {
-                if ([self hvBSwitch] && (fabs([self hvBVoltageReadValue] - [self hvBVoltageDACSetValue]/4096.*3000.) > 100)) {
-                    self.hvBNeedsUserIntervention = true;
-                    NSString* alarmString = [NSString stringWithFormat:@"%@ HV B Setpoint Discrepancy",[[self xl3Link] crateName]];
-                    ORAlarm *hvHighCurrentAlarm = [[ORAlarm alloc] initWithName:alarmString severity:kEmergencyAlarm];
-                    [hvHighCurrentAlarm setAcknowledged:NO];
-                    [hvHighCurrentAlarm postAlarm];
-                    NSLogColor([NSColor redColor],@"%@ HV B read value differs from the setpoint! Suspending HV monitoring and control. Press 'Accept Readback' to resume.\n", [[self xl3Link] crateName]);
-                }
+                [self _update_level_alarm:80200+2*[self crateNumber]+1 level:supplyBSetpointDiscrepancy];
             }
         }
+        
+        bool supplyACurrentDropout = [self hvAVoltageReadValue] > [self ilowalarm_a_vmin] && [self hvACurrentReadValue] < [self ilowalarm_a_imin];
+        bool supplyAOverVoltage = [self hvAVoltageReadValue] > [self vhighalarm_a_vmax];
+        bool supplyAOverCurrent = [self hvACurrentReadValue] > [self ihighalarm_a_imax];
+        int aoffset = 2*[self crateNumber] + 0;
+        [self _update_level_alarm:80000+aoffset level:supplyACurrentDropout];
+        [self _update_level_alarm:80300+aoffset level:supplyAOverCurrent];
+        [self _update_level_alarm:80400+aoffset level:supplyAOverVoltage];
+        
+        if ([self crateNumber] == 16) {
+            bool supplyBCurrentDropout = [self hvBVoltageReadValue] > [self ilowalarm_b_vmin] && [self hvBCurrentReadValue] < [self ilowalarm_a_imin];
+            bool supplyBOverVoltage = [self hvBVoltageReadValue] > [self vhighalarm_b_vmax];
+            bool supplyBOverCurrent = [self hvBCurrentReadValue] > [self ihighalarm_b_imax];
+            int boffset = 2*[self crateNumber] + 1;
+            [self _update_level_alarm:80000+boffset level:supplyBCurrentDropout];
+            [self _update_level_alarm:80300+boffset level:supplyBOverCurrent];
+            [self _update_level_alarm:80400+boffset level:supplyBOverVoltage];
+        }
+        
+        [self _post_heartbeat:[self crateNumber]];
         
         //We can't do anything if the XL3 disconnects anyway
         if (![[self xl3Link] isConnected]) break;

--- a/Source/Objects/Custom Hardware/SNO+/XL3/XL3_LinkController.m
+++ b/Source/Objects/Custom Hardware/SNO+/XL3/XL3_LinkController.m
@@ -614,23 +614,23 @@ static NSDictionary* xl3Ops;
 - (void) updateHVButtons
 {
     if ([hvPowerSupplyMatrix selectedColumn] == 0) { //A
-        [hvOnButton setEnabled:![model hvANeedsUserIntervention] && [model hvEverUpdated] && [model hvSwitchEverUpdated] && ![model hvASwitch]];
-        [hvOffButton setEnabled:![model hvANeedsUserIntervention] && [model hvEverUpdated] && [model hvSwitchEverUpdated] && [model hvASwitch]];
-        [hvStepUpButton setEnabled:![model hvANeedsUserIntervention] && [model hvEverUpdated] && [model hvSwitchEverUpdated] && [model hvASwitch] && ![model hvARamping]];
-        [hvStepDownButton setEnabled:![model hvANeedsUserIntervention] && [model hvEverUpdated] && [model hvSwitchEverUpdated] && [model hvASwitch] && ![model hvARamping]];
-        [hvRampUpButton setEnabled:![model hvANeedsUserIntervention] && [model hvEverUpdated] && [model hvSwitchEverUpdated] && [model hvASwitch] && ![model hvARamping]];
-        [hvRampDownButton setEnabled:![model hvANeedsUserIntervention] && [model hvEverUpdated] && [model hvSwitchEverUpdated] && [model hvASwitch] && ![model hvARamping]];
-        [hvStopRampButton setEnabled:![model hvANeedsUserIntervention] && [model hvEverUpdated] && [model hvSwitchEverUpdated] && [model hvASwitch] && [model hvARamping]];
-        [hvAcceptReadbackButton setEnabled:[model hvANeedsUserIntervention]];
+        [hvOnButton setEnabled:![model hvANeedsUserIntervention] && [model hvEverUpdated] && [model hvSwitchEverUpdated] && ![model hvASwitch] && [model hvAFromDB]];
+        [hvOffButton setEnabled:![model hvANeedsUserIntervention] && [model hvEverUpdated] && [model hvSwitchEverUpdated] && [model hvASwitch] && [model hvAFromDB]];
+        [hvStepUpButton setEnabled:![model hvANeedsUserIntervention] && [model hvEverUpdated] && [model hvSwitchEverUpdated] && [model hvASwitch] && ![model hvARamping] && [model hvAFromDB]];
+        [hvStepDownButton setEnabled:![model hvANeedsUserIntervention] && [model hvEverUpdated] && [model hvSwitchEverUpdated] && [model hvASwitch] && ![model hvARamping] && [model hvAFromDB]];
+        [hvRampUpButton setEnabled:![model hvANeedsUserIntervention] && [model hvEverUpdated] && [model hvSwitchEverUpdated] && [model hvASwitch] && ![model hvARamping] && [model hvAFromDB]];
+        [hvRampDownButton setEnabled:![model hvANeedsUserIntervention] && [model hvEverUpdated] && [model hvSwitchEverUpdated] && [model hvASwitch] && ![model hvARamping] && [model hvAFromDB]];
+        [hvStopRampButton setEnabled:![model hvANeedsUserIntervention] && [model hvEverUpdated] && [model hvSwitchEverUpdated] && [model hvASwitch] && [model hvARamping] && [model hvAFromDB]];
+        [hvAcceptReadbackButton setEnabled:[model hvANeedsUserIntervention] && [model hvAFromDB]];
     } else {
-        [hvOnButton setEnabled:![model hvBNeedsUserIntervention] && [model hvEverUpdated] && [model hvSwitchEverUpdated] && ![model hvBSwitch]];
-        [hvOffButton setEnabled:![model hvBNeedsUserIntervention] && [model hvEverUpdated] && [model hvSwitchEverUpdated] && [model hvBSwitch]];
-        [hvStepUpButton setEnabled:![model hvBNeedsUserIntervention] && [model hvEverUpdated] && [model hvSwitchEverUpdated] && [model hvBSwitch] && ![model hvBRamping]];
-        [hvStepDownButton setEnabled:![model hvBNeedsUserIntervention] && [model hvEverUpdated] && [model hvSwitchEverUpdated] && [model hvBSwitch] && ![model hvBRamping]];
-        [hvRampUpButton setEnabled:![model hvBNeedsUserIntervention] && [model hvEverUpdated] && [model hvSwitchEverUpdated] && [model hvBSwitch] && ![model hvBRamping]];
-        [hvRampDownButton setEnabled:![model hvBNeedsUserIntervention] && [model hvEverUpdated] && [model hvSwitchEverUpdated] && [model hvBSwitch] && ![model hvBRamping]];
-        [hvStopRampButton setEnabled:![model hvBNeedsUserIntervention] && [model hvEverUpdated] && [model hvSwitchEverUpdated] && [model hvBSwitch] && [model hvBRamping]];
-        [hvAcceptReadbackButton setEnabled:[model hvBNeedsUserIntervention]];
+        [hvOnButton setEnabled:![model hvBNeedsUserIntervention] && [model hvEverUpdated] && [model hvSwitchEverUpdated] && ![model hvBSwitch] && [model hvBFromDB]];
+        [hvOffButton setEnabled:![model hvBNeedsUserIntervention] && [model hvEverUpdated] && [model hvSwitchEverUpdated] && [model hvBSwitch] && [model hvBFromDB]];
+        [hvStepUpButton setEnabled:![model hvBNeedsUserIntervention] && [model hvEverUpdated] && [model hvSwitchEverUpdated] && [model hvBSwitch] && ![model hvBRamping] && [model hvBFromDB]];
+        [hvStepDownButton setEnabled:![model hvBNeedsUserIntervention] && [model hvEverUpdated] && [model hvSwitchEverUpdated] && [model hvBSwitch] && ![model hvBRamping] && [model hvBFromDB]];
+        [hvRampUpButton setEnabled:![model hvBNeedsUserIntervention] && [model hvEverUpdated] && [model hvSwitchEverUpdated] && [model hvBSwitch] && ![model hvBRamping] && [model hvBFromDB]];
+        [hvRampDownButton setEnabled:![model hvBNeedsUserIntervention] && [model hvEverUpdated] && [model hvSwitchEverUpdated] && [model hvBSwitch] && ![model hvBRamping] && [model hvBFromDB]];
+        [hvStopRampButton setEnabled:![model hvBNeedsUserIntervention] && [model hvEverUpdated] && [model hvSwitchEverUpdated] && [model hvBSwitch] && [model hvBRamping] && [model hvBFromDB]];
+        [hvAcceptReadbackButton setEnabled:[model hvBNeedsUserIntervention] && [model hvBFromDB]];
     }
     
 }


### PR DESCRIPTION
Uses the current postgres object to send alarm queries for HV monitoring. Currently implements current and voltage limits, current dropout detection, and setpoint discrepancies. Parameters are hardcoded per crate pending full DB integration.

The hardcoded values (ctrl+f TEMPBLOCK) represent previous behavior for the ramps with:
* Explicit hardcoding of nominal values (from twiki) - no longer read from .Orca file
* Setpoint tolerance at 50V
* Over-voltage alarm at NOMINAL+50V
* Over-current alarm at 1000mA - totally arbitrary will need setting later
* Under-current alarm requiring at least 10mA when >500V

The idea is to switch to reading these parameters from the database (code is in place and included in this PR) once the postgres object supports returning query results.

* Compiled on ancient xcode
* Checked for memory leaks
* Didn't modify gui files
* Tested on teststand 11/23
* Tested on detector 11/28