### PR TITLE
Postgres run number

### DIFF
--- a/Source/Objects/Control/RunControl/ORRunModel.m
+++ b/Source/Objects/Control/RunControl/ORRunModel.m
@@ -420,7 +420,7 @@ static NSString *ORRunModelRunControlConnection = @"Run Control Connector";
     if(!remoteControl || remoteInterface){
         NSString* fullFileName = [[[self dirName]stringByExpandingTildeInPath] stringByAppendingPathComponent:@"RunNumber"];
         NSString* s = [NSString stringWithContentsOfFile:fullFileName encoding:NSASCIIStringEncoding error:nil];
-        runNumber = [s intValue];
+        runNumber = [s longLongValue];
     }
     
     return runNumber;
@@ -1607,7 +1607,7 @@ static NSString *ORRunModelRunControlConnection = @"Run Control Connector";
     [[self undoManager] enableUndoRegistration];
 
     
-    if(![self offlineRun])  NSLog(@"Run %d stopped.\n",[self runNumber]);
+    if(![self offlineRun])  NSLog(@"Run %lu stopped.\n",[self runNumber]);
     else                    NSLog(@"Offline Run stopped.\n");
 
     [[NSNotificationCenter defaultCenter] postNotificationName:ORFlushLogsNotification
@@ -1777,8 +1777,8 @@ static NSString *ORRunModelRunControlConnection = @"Run Control Connector";
 	NSLog(@"---------------------------------------\n");
     
     if([[ORGlobal sharedGlobal] runMode] == kNormalRun){
-        if(!forceFullInit)NSLog(@"Run %d started(%@).\n",[self runNumber],doInit?@"cold start":@"quick start");
-		else NSLog(@"Run %d started(%@).\n",[self runNumber],@"Full Init because of Pwr Failure");
+        if(!forceFullInit)NSLog(@"Run %lu started(%@).\n",[self runNumber],doInit?@"cold start":@"quick start");
+		else NSLog(@"Run %lu started(%@).\n",[self runNumber],@"Full Init because of Pwr Failure");
     }
     else {
         NSLog(@"Offline Run started(%@).\n",doInit?@"cold start":@"quick start");

--- a/Source/Objects/Misc Objects/PostgreSQL/ORPQModel.h
+++ b/Source/Objects/Misc Objects/PostgreSQL/ORPQModel.h
@@ -59,6 +59,18 @@
 - (void) dbQuery:(NSString*)aCommand object:(id)anObject selector:(SEL)aSelector timeout:(float)aTimeoutSecs;
 
 /**
+ @brief Arbitrary detector db query with no timeout
+ @param anObject Callback object
+ @param aSelector Callback object selector (called with an ORPQResult object, or nil on error)
+ */
+- (void) dbQuery:(NSString*)aCommand object:(id)anObject selector:(SEL)aSelector;
+
+/**
+ @brief Arbitrary detector db query with no callback or timeout
+ */
+- (void) dbQuery:(NSString*)aCommand;
+
+/**
  @brief Get specified field from detector db
  @param anObject Callback object
  @param aSelector Callback object selector (called with an NSMutableData object

--- a/Source/Objects/Misc Objects/PostgreSQL/ORPQModel.m
+++ b/Source/Objects/Misc Objects/PostgreSQL/ORPQModel.m
@@ -185,6 +185,16 @@ static NSString* ORPQModelInConnector 	= @"ORPQModelInConnector";
     }
 }
 
+- (void)dbQuery:(NSString*)aCommand object:(id)anObject selector:(SEL)aSelector
+{
+    [self dbQuery:aCommand object:anObject selector:aSelector timeout:0];
+}
+
+- (void)dbQuery:(NSString*)aCommand
+{
+    [self dbQuery:aCommand object:nil selector:nil timeout:0];
+}
+
 - (void)pmtdbQuery:(NSString*)aPmtdbField object:(id)anObject selector:(SEL)aSelector
 {
     if(stealthMode){

--- a/Source/Objects/Misc Objects/PostgreSQL/ORPQModel.m
+++ b/Source/Objects/Misc Objects/PostgreSQL/ORPQModel.m
@@ -172,7 +172,9 @@ static NSString* ORPQModelInConnector 	= @"ORPQModelInConnector";
 
 - (void)dbQuery:(NSString*)aCommand object:(id)anObject selector:(SEL)aSelector timeout:(float)aTimeoutSecs
 {
-    if(!stealthMode){
+    if(stealthMode){
+        [anObject performSelector:aSelector withObject:nil afterDelay:0.1];
+    } else {
         ORPQQueryOp* anOp = [[ORPQQueryOp alloc] initWithDelegate:self object:anObject selector:aSelector];
         if (aTimeoutSecs) {
             [anOp performSelector:@selector(cancel) withObject:nil afterDelay:aTimeoutSecs];
@@ -185,7 +187,9 @@ static NSString* ORPQModelInConnector 	= @"ORPQModelInConnector";
 
 - (void)pmtdbQuery:(NSString*)aPmtdbField object:(id)anObject selector:(SEL)aSelector
 {
-    if(!stealthMode){
+    if(stealthMode){
+        [anObject performSelector:aSelector withObject:nil afterDelay:0.1];
+    } else {
         ORPQQueryOp* anOp = [[ORPQQueryOp alloc] initWithDelegate:self object:anObject selector:aSelector];
         [anOp setPmtdbFieldName:aPmtdbField];
         [ORPQDBQueue addOperation:anOp];
@@ -451,14 +455,18 @@ static NSString* ORPQModelInConnector 	= @"ORPQModelInConnector";
 - (void) cancel
 {
     [super cancel];
-    // do callback with nil object
-    [object performSelectorOnMainThread:selector withObject:nil waitUntilDone:YES];
+    if (selector) {
+        // do callback with nil object
+        [object performSelectorOnMainThread:selector withObject:nil waitUntilDone:YES];
+        selector = nil;
+    }
 }
 
 - (void) main
 {
-    if([self isCancelled])return;
-   NSAutoreleasePool* thePool = [[NSAutoreleasePool alloc] init];
+    if([self isCancelled]) return;
+
+    NSAutoreleasePool* thePool = [[NSAutoreleasePool alloc] init];
     NSObject *theResultObject = nil;
     @try {
         ORPQConnection* pqConnection = [[delegate pqConnection] retain];
@@ -466,9 +474,10 @@ static NSString* ORPQModelInConnector 	= @"ORPQModelInConnector";
             ORPQResult *theResult = [pqConnection queryString:command];
 
             if (theResult && ![self isCancelled]) {
-
                 switch (commandType) {
-
+                    case kPQCommandType_General:
+                        theResultObject = theResult;
+                        break;
                     case kPQCommandType_GetPMT: {
                         int numRows = [theResult numOfRows];
                         int numCols = [theResult numOfFields];
@@ -502,6 +511,7 @@ static NSString* ORPQModelInConnector 	= @"ORPQModelInConnector";
         // do callback on main thread if a selector was specified
         if (selector && ![self isCancelled]) {
             [object performSelectorOnMainThread:selector withObject:theResultObject waitUntilDone:YES];
+            selector = nil;
         }
         [thePool release];
     }


### PR DESCRIPTION
This pull request updates ORCA so that it fetches the run number from the database. It also fixes a few bugs in the ORPQModel.

Tested on the teststand on Monday, November 28 2016.

At the start of a run, the SNO+ model contacts the database to get the next run number. If the database is not connected it aborts the run. If the database is available but the query fails for some reason, the run number is set to 0xffffffff. This run number will then be interpreted by the builder as a "default" run in which it writes events to default_[something].zdab. This means that if the database is unavailable we can still switch runs and get events in XSNOED, but these runs will never make it through data flow which is what we want since if the database is unavailable, the runs will not be considered golden anyways.