### PR TITLE
SNO+: Add float retrieval to postgres object and HV parameter retrieval from DB.

### DIFF
--- a/Source/Objects/Misc Objects/DatabaseSupport/PostgreSQL/ORPQResult.m
+++ b/Source/Objects/Misc Objects/DatabaseSupport/PostgreSQL/ORPQResult.m
@@ -20,6 +20,8 @@ enum {
     kPQTypeInt16    = 21,   // 2-byte integer
     kPQTypeVector16 = 22,   // vector of 2-byte integers
     kPQTypeInt32    = 23,   // 4-byte integer
+    kPQTypeFloat4   = 700,  // 4-byte single precision float
+    kPQTypeFloat8   = 701,  // 8-byte double precision float
     kPQTypeArrayChar= 1002, // array of 8-bit characters
     kPQTypeArray16  = 1005, // array of 2-byte integers
     kPQTypeArray32  = 1007, // array of 4-byte integers
@@ -117,6 +119,12 @@ NSDate* MCPYear0000;
                 case kPQTypeInt16:
                 case kPQTypeInt32:
                     theCurrentObj = [NSNumber numberWithLong:strtoll(pt, NULL, 0)];
+                    break;
+                case kPQTypeFloat4:
+                    theCurrentObj = [NSNumber numberWithFloat:strtof(pt,NULL)];
+                    break;
+                case kPQTypeFloat8:
+                    theCurrentObj = [NSNumber numberWithDouble:strtod(pt,NULL)];
                     break;
                 case kPQTypeArrayChar:
                 case kPQTypeArray16:


### PR DESCRIPTION
The HV monitoring and control thread now uses the current postgres object to retrieve control and alarm parameters on program start. Without DB access neither control nor monitoring of HV will be enabled as the thread responsible for those actions will not start.

I've tested this locally but not yet on the teststand. If anyone is feeling courageous feel free to give it a try, but I'll get to it when I get to it. The hvparams table is setup on both the detector (dbug) and test (minard) databases with appropriate values including current limits from Noel.