### PR TITLE
Load high thresholds no matter what

### DIFF
--- a/Source/Experiments/SNOP/SNOPController.m
+++ b/Source/Experiments/SNOP/SNOPController.m
@@ -360,21 +360,18 @@ snopGreenColor;
 {
     
     NSString* standardRun = [model standardRunType];
-    if(standardRun != nil && ![standardRun isEqualToString:@""] && [standardRunPopupMenu indexOfItemWithObjectValue:standardRun] == NSNotFound){
+    if([[model standardRunType] isEqualToString:@"HIGH THRESHOLDS"]) {
+        [model setStandardRunVersion:@"DEFAULT"];
+    }
+    else if(standardRun != nil && ![standardRun isEqualToString:@""] && [standardRunPopupMenu indexOfItemWithObjectValue:standardRun] == NSNotFound){
         NSLogColor([NSColor redColor],@"Standard Run \"%@\" does not exist in DB. \n",standardRun);
         return;
     }
     else{
         [standardRunPopupMenu selectItemWithObjectValue:standardRun];
-    }
-    
-    if([[model standardRunType] isEqualToString:@"HIGH THRESHOLDS"]) {
-        [model setStandardRunVersion:@"DEFAULT"];
-    }
-    else if(![standardRun isEqualToString:@""] && standardRun != nil){
         [self refreshStandardRunVersions];
     }
-
+    
 }
 
 -(void) SRVersionChanged:(NSNotification*)aNote

--- a/Source/Experiments/SNOP/SNOPController.m
+++ b/Source/Experiments/SNOP/SNOPController.m
@@ -360,10 +360,7 @@ snopGreenColor;
 {
     
     NSString* standardRun = [model standardRunType];
-    if([[model standardRunType] isEqualToString:@"HIGH THRESHOLDS"]) {
-        [model setStandardRunVersion:@"DEFAULT"];
-    }
-    else if(standardRun != nil && ![standardRun isEqualToString:@""] && [standardRunPopupMenu indexOfItemWithObjectValue:standardRun] == NSNotFound){
+    if(standardRun != nil && ![standardRun isEqualToString:@""] && [standardRunPopupMenu indexOfItemWithObjectValue:standardRun] == NSNotFound){
         NSLogColor([NSColor redColor],@"Standard Run \"%@\" does not exist in DB. \n",standardRun);
         return;
     }
@@ -714,7 +711,7 @@ snopGreenColor;
     if(cancel) return;
 
     NSLogColor([NSColor redColor],@"Setting MTC high thresholds...\n");
-    [model loadHighThresholdRun];
+    [model loadHighThresholds];
 }
 
 - (IBAction)hvMasterPanicAction:(id)sender
@@ -1610,11 +1607,6 @@ snopGreenColor;
     
     NSString *standardRun = [[standardRunPopupMenu stringValue] uppercaseString];
     [standardRunPopupMenu setStringValue:standardRun];
-    //Do not allow to overwrite the detector safe offline run
-    if ([standardRun isEqualTo:@"HIGH THRESHOLDS"]){
-        ORRunAlertPanel([NSString stringWithFormat:@"Cannot create a version called HIGH THRESHOLDS"], @"It is a protected word",@"Cancel",@"OK",nil);
-        return;
-    }
     //Create new SR if does not exist
     if ([standardRunPopupMenu indexOfItemWithObjectValue:standardRun] == NSNotFound && [standardRun isNotEqualTo:@""]){
         BOOL cancel = ORRunAlertPanel([NSString stringWithFormat:@"Creating new Standard Run: \"%@\"", standardRun],@"Is this really what you want?",@"Cancel",@"Yes, Make New Standard Run",nil);

--- a/Source/Experiments/SNOP/SNOPModel.h
+++ b/Source/Experiments/SNOP/SNOPModel.h
@@ -293,7 +293,7 @@
 -(BOOL) loadStandardRun:(NSString*)runTypeName withVersion:(NSString*)runVersion;
 -(BOOL) saveStandardRun:(NSString*)runTypeName withVersion:(NSString*)runVersion;
 -(void) loadSettingsInHW;
--(void) loadHighThresholdRun;
+-(void) loadHighThresholds;
 
 @end
 

--- a/Source/Experiments/SNOP/SNOPModel.m
+++ b/Source/Experiments/SNOP/SNOPModel.m
@@ -2003,7 +2003,7 @@ err:
 
 }
 
--(void) loadHighThresholdRun
+-(void) loadHighThresholds
 {
 
     //Get RC model

--- a/Source/Experiments/SNOP/SNOPModel.m
+++ b/Source/Experiments/SNOP/SNOPModel.m
@@ -1988,10 +1988,18 @@ err:
         return;
     }
 
-    //Load MTC settings
-    [mtc loadTheMTCADacs];
-    [mtc setGlobalTriggerWordMask];
-    [mtc setThePulserRate:[mtc dbFloatByIndex:kPulserPeriod]];
+    @try{
+        //Load MTC settings
+        [mtc loadTheMTCADacs];
+        [mtc setGlobalTriggerWordMask];
+        [mtc setThePulserRate:[mtc dbFloatByIndex:kPulserPeriod]];
+    }
+    @catch(NSException *e){
+        NSLogColor([NSColor redColor], @"Problem loading settings into Hardware: %@\n",[e reason]);
+        return;
+    }
+    
+    NSLogColor([NSColor redColor], @"Settings loaded in Hardware \n");
 
 }
 
@@ -2032,12 +2040,8 @@ err:
     [mtc setDbObject:[NSNumber numberWithDouble:0.0] forIndex:kPulserPeriod];
     [runControlModel setRunType:0x0]; //Zero run type word since this run is not valid
 
-    //Restart the run if the run is ongoing and do nothing if there is no run happening
-    if([runControlModel isRunning]){
-        [self setStandardRunType:@"HIGH THRESHOLDS"];
-        [runControlModel restartRun];
-    }
-    
+    [self loadSettingsInHW];
+
 }
 
 @end

--- a/Source/Objects/Custom Hardware/SNO+/MTC/ORMTCModel.m
+++ b/Source/Objects/Custom Hardware/SNO+/MTC/ORMTCModel.m
@@ -1783,7 +1783,7 @@ resetFifoOnStart = _resetFifoOnStart;
     @try {
         [mtc okCommand:"load_mtca_dacs %d %d %d %d %d %d %d %d %d %d %d %d %d %d", dacs[0], dacs[1], dacs[2], dacs[3], dacs[4], dacs[5], dacs[6], dacs[7], dacs[8], dacs[9], dacs[10], dacs[11], dacs[12], dacs[13]];
     } @catch(NSException* e) {
-        NSLog(@"failed to load the MTCA dacs: %@", [e reason]);     
+        NSLogColor([NSColor redColor],@"failed to load the MTCA dacs: %@\n", [e reason]);
         [e raise];
     }
 }


### PR DESCRIPTION
Bug fix: high thresholds were only loaded if run ongoing. Simplify the load high threshold logic: instead of stopping and restarting the run, the action will set high threshold regardless the run status. This will change trigger settings of the ongoing run, which then will be thrown away by data quality. Nevertheless, this is an emergency action and if someone click this button is most likely because the ongoing run is misbehaving and won't be used in any case.