### PR TITLE
SNO+: Fix user-lockout of HV control

### DIFF
--- a/Source/Objects/Custom Hardware/SNO+/XL3/ORXL3Model.m
+++ b/Source/Objects/Custom Hardware/SNO+/XL3/ORXL3Model.m
@@ -4582,7 +4582,10 @@ float nominals[] = {2110.0, 2240.0, 2075.0, 2160.0, 2043.0, 2170.0, 2170.0, 2170
                 NSLogColor([NSColor redColor],@"%@ error reading XL3 hv status; error: %@ reason: %@\n", [[self xl3Link] crateName], [e name], [e reason]);
                 continue; // try again later if there was an error
             }
-            
+           
+            //the above methods can fail without an exception, but the flags never lie
+            if (![self hvEverUpdated] || ![self hvSwitchEverUpdated]) continue;
+
             //set model values to hv readback or 0 if switch is off
             //N.B. readback can be arbitrarily offset from the previous setpoint
             //so we can't trust it enough to update the real setpoint. Never


### PR DESCRIPTION
The methods to read back voltage/current and switch status can fail and return without throwing an exception in certain cases. If reading switch status failed in this way but then reading back voltage was successful, the hv control logic would end up in a state where the monitoring thread was running but the user was unable to control the high voltage. This ensures that the switch and voltage are both successfully read back before starting the high voltage thread, preventing the above from occurring.

In #188 this was realized by the xl3 disconnecting and reconnecting quickly. Between checking that the XL3 was connected and reading the switch / voltage status the XL3 disconnected. When the HV monitoring thread was launched the XL3 had connected again and did read back the voltage eventually, but the hv monitoring thread does not query the switch status again so the GUI correctly assumed it did not know the XL3 state and refused user control.