### PR TITLE
HV Improvements

### DIFF
--- a/Source/Objects/Custom Hardware/SNO+/XL3/ORXL3Model.h
+++ b/Source/Objects/Custom Hardware/SNO+/XL3/ORXL3Model.h
@@ -108,12 +108,15 @@ enum {
     BOOL hvBSwitch;
     BOOL hvARamping;
     BOOL hvBRamping;
+    BOOL hvAQueryWaiting;
+    BOOL hvBQueryWaiting;
     BOOL hvAFromDB;
     BOOL hvBFromDB;
     BOOL hvEverUpdated;
     BOOL hvSwitchEverUpdated;
     BOOL hvANeedsUserIntervention;
     BOOL hvBNeedsUserIntervention;
+    
     
     NSString* triggerStatus;
     BOOL _isTriggerON;
@@ -253,6 +256,8 @@ enum {
 @property float vhighalarm_b_vmax;
 @property float ihighalarm_b_imax;
 
+@property BOOL hvAQueryWaiting;
+@property BOOL hvBQueryWaiting;
 @property BOOL hvAFromDB;
 @property BOOL hvBFromDB;
 @property BOOL hvEverUpdated;
@@ -416,6 +421,8 @@ enum {
 - (void) readHVSwitchOnForA:(BOOL*)aIsOn forB:(BOOL*)bIsOn;
 - (void) readHVSwitchOn;
 
+
++ (bool) requestHVParams:(ORXL3Model *)model;
 - (void) safeHvInit;
 - (void) setHVSwitch:(BOOL)aOn forPowerSupply:(unsigned char)sup;
 - (void) hvPanicDown;

--- a/Source/Objects/Custom Hardware/SNO+/XL3/XL3_LinkController.m
+++ b/Source/Objects/Custom Hardware/SNO+/XL3/XL3_LinkController.m
@@ -1411,13 +1411,13 @@ static NSDictionary* xl3Ops;
 
     if (sup == 0 && [model hvASwitch]) {
         if ([model hvAVoltageDACSetValue] > 30) {
-            ORRunAlertPanel (@"Not turning OFF",@"OK",nil,nil,@"Voltage too high. Ramp down first.");
+            ORRunAlertPanel (@"Not turning OFF",@"Voltage too high. Ramp down first.",@"OK",nil,nil);
             return;
         }
     }
     else if (sup == 1 && [model hvBSwitch]) {
         if ([model hvBVoltageDACSetValue] > 30) {
-            ORRunAlertPanel (@"Not turning OFF",@"OK",nil,nil,@"Voltage too high. Ramp down first.");
+            ORRunAlertPanel (@"Not turning OFF",@"Voltage too high. Ramp down first.",@"OK",nil,nil);
             return;
         }
     }
@@ -1460,8 +1460,7 @@ static NSDictionary* xl3Ops;
     }
     if ((sup == 0 && nextTargetValue + 20 < [model hvAVoltageDACSetValue]) || (sup == 1 && nextTargetValue + 20 < [model hvBVoltageDACSetValue])) {
         [self hvTargetValueChanged:nil];
-        ORRunAlertPanel (@"HV target NOT changed.",@"OK",nil,nil,
-                           @"Can not set target value lower than the current HV. Ramp down first.");
+        ORRunAlertPanel (@"HV target NOT changed.",@"Can not set target value lower than the current HV. Ramp down first.",@"OK",nil,nil);
         return;
     }
     if (sup == 0) {

--- a/Source/Objects/Misc Objects/DatabaseSupport/PostgreSQL/ORPQResult.m
+++ b/Source/Objects/Misc Objects/DatabaseSupport/PostgreSQL/ORPQResult.m
@@ -20,6 +20,8 @@ enum {
     kPQTypeInt16    = 21,   // 2-byte integer
     kPQTypeVector16 = 22,   // vector of 2-byte integers
     kPQTypeInt32    = 23,   // 4-byte integer
+    kPQTypeFloat4   = 700,  // 4-byte single precision float
+    kPQTypeFloat8   = 701,  // 8-byte double precision float
     kPQTypeArrayChar= 1002, // array of 8-bit characters
     kPQTypeArray16  = 1005, // array of 2-byte integers
     kPQTypeArray32  = 1007, // array of 4-byte integers
@@ -117,6 +119,12 @@ NSDate* MCPYear0000;
                 case kPQTypeInt16:
                 case kPQTypeInt32:
                     theCurrentObj = [NSNumber numberWithLong:strtoll(pt, NULL, 0)];
+                    break;
+                case kPQTypeFloat4:
+                    theCurrentObj = [NSNumber numberWithFloat:strtof(pt,NULL)];
+                    break;
+                case kPQTypeFloat8:
+                    theCurrentObj = [NSNumber numberWithDouble:strtod(pt,NULL)];
                     break;
                 case kPQTypeArrayChar:
                 case kPQTypeArray16:
@@ -343,6 +351,12 @@ NSDate* MCPYear0000;
                 break;
             case kPQTypeInt64:
                 theType = @"int8";
+                break;
+            case kPQTypeFloat4:
+                theType = @"float4";
+                break;
+            case kPQTypeFloat8:
+                theType = @"float8";
                 break;
             default:
                 theType = @"unknown";


### PR DESCRIPTION
Introduces a loopCounter in the hv thread (where loops are ~1s each) such that the heartbeat is sent only on loopCounter multiples of 10. Also modifies HV alarms to be updated on the initial loop (and 2^32 loops) or whenever the state of the alarm changes which should significantly reduce db load.