### PR TITLE
SNO+: update XL3 model to wait until crate has been initialized before checking the HV

### DIFF
--- a/Source/Objects/Custom Hardware/SNO+/SNOCrate/ORSNOCrateController.m
+++ b/Source/Objects/Custom Hardware/SNO+/SNOCrate/ORSNOCrateController.m
@@ -69,26 +69,28 @@
 
     ORXL3Model *xl3 = [model adapter];
 
-    if ([[xl3 xl3Link] isConnected]) {
+    if ([[xl3 xl3Link] isConnected] && [xl3 stateUpdated]) {
         if ([xl3 initialized]) {
             /* The Xilinx has been loaded, so we need to enable the load
              * hardware button. */
             [loadHardwareButton setEnabled:TRUE];
-        } else {
-            /* The Xilinx hasn't been loaded, so we disable the load hardware
-             * button. */
-            [loadHardwareButton setEnabled:FALSE];
-        }
 
-        if ([xl3 hvSwitchEverUpdated]) {
-            if (![xl3 hvASwitch] && ![xl3 hvBSwitch]) {
-                /* HV is off, so enable crate reset button. */
-                [resetCrateButton setEnabled:TRUE];
+            if ([xl3 hvSwitchEverUpdated]) {
+                if (![xl3 hvASwitch] && ![xl3 hvBSwitch]) {
+                    /* HV is off, so enable crate reset button. */
+                    [resetCrateButton setEnabled:TRUE];
+                } else {
+                    [resetCrateButton setEnabled:FALSE];
+                }
             } else {
+                /* HV switch isn't known, so disable the reset crate button. */
                 [resetCrateButton setEnabled:FALSE];
             }
         } else {
-            [resetCrateButton setEnabled:FALSE];
+            /* The Xilinx hasn't been loaded, so we disable the load hardware
+             * button, and enable the reset crate button. */
+            [loadHardwareButton setEnabled:FALSE];
+            [resetCrateButton setEnabled:TRUE];
         }
     } else {
         /* XL3 isn't connected, so don't enable any buttons. */

--- a/Source/Objects/Custom Hardware/SNO+/XL3/ORXL3Model.h
+++ b/Source/Objects/Custom Hardware/SNO+/XL3/ORXL3Model.h
@@ -174,6 +174,7 @@ enum {
     bool _ecalToOrcaInProgress;
 
     bool initialized;
+    bool stateUpdated;
 }
 
 @property (nonatomic,assign) unsigned long xl3MegaBundleDataId;
@@ -283,6 +284,7 @@ enum {
 
 #pragma mark •••Accessors
 - (bool) initialized;
+- (bool) stateUpdated;
 - (NSString*) shortName;
 - (id) controllerCard;
 - (void) setSlot:(int)aSlot;

--- a/Source/Objects/Custom Hardware/SNO+/XL3/ORXL3Model.m
+++ b/Source/Objects/Custom Hardware/SNO+/XL3/ORXL3Model.m
@@ -216,7 +216,13 @@ hvBQueryWaiting = hvBQueryWaiting;
 - (void) connectionStateChanged
 {
     /* If we just connected, find out if Xilinx has been loaded or not. */
-    if ([xl3Link isConnected]) [self updateXl3Mode];
+    if ([xl3Link isConnected]) {
+        [self updateXl3Mode];
+    } else {
+        /* If we disconnected, assume we don't know the state any more. */
+        initialized = FALSE;
+        stateUpdated = FALSE;
+    }
 }
 
 - (int) initAtRunStart
@@ -317,6 +323,11 @@ hvBQueryWaiting = hvBQueryWaiting;
 - (bool) initialized
 {
     return initialized;
+}
+
+- (bool) stateUpdated
+{
+    return stateUpdated;
 }
 
 - (id) controllerCard
@@ -1485,6 +1496,7 @@ void SwapLongBlock(void* p, int32_t n)
     [self setIsTriggerON:       [decoder decodeBoolForKey:@"isTriggerON"]];
 
     initialized = FALSE;
+    stateUpdated = FALSE;
 
     if ([self isTriggerON]) {
         [self setTriggerStatus:@"ON"];
@@ -1734,6 +1746,8 @@ void SwapLongBlock(void* p, int32_t n)
     } else {
         initialized = FALSE;
     }
+
+    stateUpdated = TRUE;
 
     [[NSNotificationCenter defaultCenter]
         postNotificationName:ORXL3ModelStateChanged object:self userInfo:nil];
@@ -4724,6 +4738,13 @@ float nominals[] = {2110.0, 2240.0, 2075.0, 2160.0, 2043.0, 2170.0, 2170.0, 2170
         sleep(1);
         //do nothing without an xl3 connected
         if ([self xl3Link] && [[self xl3Link] isConnected]) {
+            if (![self stateUpdated] || ![self initialized]) {
+                /* If the XL3 hasn't been initialized, then the registers are
+                 * just random bytes, so we need to wait for a crate reset
+                 * before checking the switches. */
+                [hvLoopPool release];
+                continue;
+            }
             
             //Request the hv parameters (N.B. true does not mean they were loaded, check hvAFromDB and hvBFromDB)
             if (![ORXL3Model requestHVParams:self]) {


### PR DESCRIPTION
The HV registers are undefined just after the crate has been turned on but
before the crate has been reset. So, the HV thread now waits until the crate
has been reset before continuing. This commit also updates the crate reset
button so that it is enabled only when either the crate has not been reset or
if the HV is off.

@BenLand100 can you just take a quick look at my change to the _hvInit method and make sure that it makes sense?