### PR TITLE
SNO+: add a ping crates button to the SNO+ Control Panel

### DIFF
--- a/Source/Experiments/SNOP/SNOP.xib
+++ b/Source/Experiments/SNOP/SNOP.xib
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="6254" systemVersion="13F1077" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="6751" systemVersion="13F1603" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
     <dependencies>
         <deployment identifier="macosx"/>
         <development version="5100" identifier="xcode"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="6254"/>
-        <plugIn identifier="com.apple.WebKitIBPlugin" version="6254"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="6751"/>
+        <plugIn identifier="com.apple.WebKitIBPlugin" version="6751"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="SNOPController">
@@ -50,6 +50,7 @@
                 <outlet property="orcaDBUser" destination="2685" id="E4e-CV-d2D"/>
                 <outlet property="panicDownButton" destination="zmA-F4-wTd" id="37F-oN-VJj"/>
                 <outlet property="panicDownCrateButton" destination="vcZ-IJ-Cct" id="5Ap-rK-1u4"/>
+                <outlet property="pingCratesButton" destination="drG-95-YYb" id="Aug-97-auQ"/>
                 <outlet property="refreshRunWordNames" destination="Xjy-eU-kJv" id="hSn-Qi-M78"/>
                 <outlet property="repeatRunCB" destination="1339" id="1354"/>
                 <outlet property="runBar" destination="MBu-zu-x36" id="iTV-aT-8hr"/>
@@ -3591,7 +3592,7 @@
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <button id="266-Dd-MIl">
-                                            <rect key="frame" x="15" y="161" width="333" height="55"/>
+                                            <rect key="frame" x="15" y="111" width="333" height="55"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <animations/>
                                             <buttonCell key="cell" type="bevel" title="TRIGGERS OFF" bezelStyle="regularSquare" imagePosition="overlaps" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="y3E-wc-fQv">
@@ -3613,7 +3614,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <button id="zmA-F4-wTd">
-                                            <rect key="frame" x="15" y="53" width="333" height="105"/>
+                                            <rect key="frame" x="15" y="53" width="333" height="55"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <animations/>
                                             <buttonCell key="cell" type="bevel" title="PANIC DOWN" bezelStyle="regularSquare" imagePosition="overlaps" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="A2d-ym-1VI">
@@ -3622,6 +3623,17 @@
                                             </buttonCell>
                                             <connections>
                                                 <action selector="hvMasterPanicAction:" target="-2" id="Dmd-aj-sUv"/>
+                                            </connections>
+                                        </button>
+                                        <button id="drG-95-YYb">
+                                            <rect key="frame" x="15" y="169" width="158" height="47"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                            <buttonCell key="cell" type="bevel" title="Ping Crates" bezelStyle="regularSquare" imagePosition="overlaps" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="Nbm-1z-7bg">
+                                                <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                                <font key="font" metaFont="system"/>
+                                            </buttonCell>
+                                            <connections>
+                                                <action selector="pingCratesAction:" target="-2" id="gaE-se-Lfq"/>
                                             </connections>
                                         </button>
                                     </subviews>

--- a/Source/Experiments/SNOP/SNOPController.h
+++ b/Source/Experiments/SNOP/SNOPController.h
@@ -49,6 +49,8 @@
     IBOutlet NSButton *panicDownButton;
     IBOutlet NSTextField *detectorHVStatus;
     
+    IBOutlet NSButton *pingCratesButton;
+
     //Standard Runs
     IBOutlet NSComboBox *standardRunPopupMenu;
     IBOutlet NSComboBox *standardRunVersionPopupMenu;
@@ -182,6 +184,8 @@
 - (IBAction) hvMasterPanicAction:(id)sender;
 - (IBAction) hvMasterTriggersOFF:(id)sender;
 - (IBAction) hvMasterStatus:(id)sender;
+
+- (IBAction) pingCratesAction:(id)sender;
 
 //smellie functions -------------------
 - (IBAction) loadSmellieRunAction:(id)sender;

--- a/Source/Experiments/SNOP/SNOPController.m
+++ b/Source/Experiments/SNOP/SNOPController.m
@@ -458,7 +458,6 @@ snopGreenColor;
 
 - (void) runStatusChanged:(NSNotification*)aNotification
 {
-    
     [startRunButton setEnabled:true];
 
     if([runControl runningState] == eRunInProgress){
@@ -485,7 +484,13 @@ snopGreenColor;
 		}
         [lightBoardView setState:kCautionLight];
 	}
-    
+
+    if ([runControl isRunning] && ([runControl runType] & ECA_RUN)) {
+        /* Disable the ping crates button if we are in an ECA run. */
+        [pingCratesButton setEnabled:FALSE];
+    } else {
+        [pingCratesButton setEnabled:TRUE];
+    }
 }
 
 - (IBAction) pingCratesAction: (id) sender

--- a/Source/Experiments/SNOP/SNOPController.m
+++ b/Source/Experiments/SNOP/SNOPController.m
@@ -488,6 +488,11 @@ snopGreenColor;
     
 }
 
+- (IBAction) pingCratesAction: (id) sender
+{
+    [model pingCrates];
+}
+
 - (void) dbOrcaDBIPChanged:(NSNotification*)aNote
 {
     [orcaDBIPAddressPU setStringValue:[model orcaDBIPAddress]];

--- a/Source/Experiments/SNOP/SNOPGlobals.h
+++ b/Source/Experiments/SNOP/SNOPGlobals.h
@@ -21,6 +21,32 @@
 #ifndef Orca_SNOPGlobals_h
 #define Orca_SNOPGlobals_h
 
+/* mutually exclusive run types */
+#define MAINTENANCE_RUN         0x1
+#define TRANSITION_RUN          0x2
+#define PHYSICS_RUN             0x4
+#define DEPLOYED_SOURCE_RUN     0x8
+#define EXTERNAL_SOURCE_RUN     0x10
+#define ECA_RUN                 0x20
+#define DIAGNOSTIC_RUN          0x40
+#define EXPERIMENTAL_RUN        0x80
+#define SUPERNOVA_RUN           0x100
+/* calibration */
+#define TELLIE_RUN              0x800
+#define SMELLIE_RUN             0x1000
+#define AMELLIE_RUN             0x2000
+#define PCA_RUN                 0x4000
+#define ECA_PDST_RUN            0x8000
+#define ECA_TSLP_RUN            0x10000
+/* detector state */
+#define DCR_ACTIVITY_RUN        0x200000
+#define COMP_COILS_OFF_RUN      0x400000
+#define PMT_OFF_RUN             0x800000
+#define BUBBLERS_RUN            0x1000000
+#define RECIRCULATION_RUN       0x2000000
+#define SLASSAY_RUN             0x4000000
+#define UNUSUAL_ACTIVITY_RUN    0x8000000
+
 //Run types
 typedef enum kSNOPRunType {
     kDiagnosticRunType = 0x40,

--- a/Source/Experiments/SNOP/SNOPModel.h
+++ b/Source/Experiments/SNOP/SNOPModel.h
@@ -204,6 +204,8 @@
 - (void) taskFinished:(NSTask*)aTask;
 - (void) couchDBResult:(id)aResult tag:(NSString*)aTag op:(id)anOp;
 
+- (void) pingCrates;
+
 #pragma mark ¥¥orcascript helpers
 - (void) zeroPedestalMasks;
 - (void) updatePedestalMasks:(unsigned int)pattern;

--- a/Source/Experiments/SNOP/SNOPModel.m
+++ b/Source/Experiments/SNOP/SNOPModel.m
@@ -1102,7 +1102,8 @@ static NSComparisonResult compareXL3s(ORXL3Model *xl3_1, ORXL3Model *xl3_2, void
 
         if ([[xl3 xl3Link] isConnected]) {
             if ([xl3 setPedestalMask:[xl3 getSlotsPresent] pattern:0]) {
-                NSLog(@"failed to set pedestal mask for crate %02d\n", i);
+                NSLogColor([NSColor redColor],
+                           @"failed to set pedestal mask for crate %02d\n", i);
                 continue;
             }
         }
@@ -1116,15 +1117,17 @@ static NSComparisonResult compareXL3s(ORXL3Model *xl3_1, ORXL3Model *xl3_2, void
         if ([[xl3 xl3Link] isConnected]) {
             if ([xl3 setPedestalMask:[xl3 getSlotsPresent]
                  pattern:0xffffffff]) {
-                NSLog(@"failed to set pedestal mask for crate %02d\n", i);
+                NSLogColor([NSColor redColor],
+                           @"failed to set pedestal mask for crate %02d\n", i);
                 continue;
             }
 
             @try {
                 [mtc firePedestals:1 withRate:1];
             } @catch (NSException *e) {
-                NSLog(@"failed to fire pedestal. error: %@ reason: %@\n",
-                      [e name], [e reason]);
+                NSLogColor([NSColor redColor],
+                           @"failed to fire pedestal. error: %@ reason: %@\n",
+                           [e name], [e reason]);
             }
 
             /* Set pedestal mask back to what it was before. */

--- a/Source/Experiments/SNOP/SNOPModel.m
+++ b/Source/Experiments/SNOP/SNOPModel.m
@@ -1044,6 +1044,17 @@ err:
     }
 }
 
+static NSComparisonResult compareXL3s(ORXL3Model *xl3_1, ORXL3Model *xl3_2, void *context)
+{
+    if ([xl3_1 crateNumber] < [xl3_2 crateNumber]) {
+        return NSOrderedAscending;
+    } else if ([xl3_1 crateNumber] > [xl3_2 crateNumber]) {
+        return NSOrderedDescending;
+    } else {
+        return NSOrderedSame;
+    }
+}
+
 - (void) pingCrates
 {
     /* Enables pedestals for all channels in each crate one at a time and sends
@@ -1055,6 +1066,8 @@ err:
          collectObjectsOfClass:NSClassFromString(@"ORXL3Model")];
     NSArray* mtcs = [[(ORAppDelegate*)[NSApp delegate] document]
          collectObjectsOfClass:NSClassFromString(@"ORMTCModel")];
+
+    xl3s = [xl3s sortedArrayUsingFunction:compareXL3s context:nil];
 
     ORMTCModel* mtc;
     ORXL3Model* xl3;

--- a/Source/Experiments/SNOP/SNOPModel.m
+++ b/Source/Experiments/SNOP/SNOPModel.m
@@ -1062,6 +1062,7 @@ static NSComparisonResult compareXL3s(ORXL3Model *xl3_1, ORXL3Model *xl3_2, void
      * crates that are at high voltage. */
     int i;
     uint32_t crate_pedestal_mask;
+    float pulser_rate;
 
     NSArray* xl3s = [[(ORAppDelegate*)[NSApp delegate] document]
          collectObjectsOfClass:NSClassFromString(@"ORXL3Model")];
@@ -1081,6 +1082,8 @@ static NSComparisonResult compareXL3s(ORXL3Model *xl3_1, ORXL3Model *xl3_2, void
     mtc = [mtcs objectAtIndex:0];
 
     crate_pedestal_mask = [mtc getPedestalCrateMask];
+
+    pulser_rate = [mtc getThePulserRate];
 
     /* Enable all crates in the MTCD pedestal mask. */
     [mtc setDbLong:0xffffff forIndex:kPEDCrateMask];
@@ -1139,9 +1142,17 @@ static NSComparisonResult compareXL3s(ORXL3Model *xl3_1, ORXL3Model *xl3_2, void
         NSLogColor([NSColor redColor],
                    @"error setting the MTCD crate pedestal mask. error: "
                     "%@ reason: %@\n", [e name], [e reason]);
-        return;
     }
 
+    /* Reset the pulser rate since the firePedestals function sets the pulser
+     * rate to 0. */
+    @try {
+        [mtc setThePulserRate:pulser_rate];
+    } @catch (NSException *e) {
+        NSLogColor([NSColor redColor],
+                   @"error setting the pulser rate. error: "
+                    "%@ reason: %@\n", [e name], [e reason]);
+    }
 }
 
 - (void) updateRHDRSruct

--- a/Source/Experiments/SNOP/SNOPModel.m
+++ b/Source/Experiments/SNOP/SNOPModel.m
@@ -1124,11 +1124,8 @@ static NSComparisonResult compareXL3s(ORXL3Model *xl3_1, ORXL3Model *xl3_2, void
                       [e name], [e reason]);
             }
 
-            /* Set pedestal mask to 0. */
-            if ([xl3 setPedestalMask:[xl3 getSlotsPresent] pattern:0]) {
-                NSLog(@"failed to set pedestal mask for crate %02d\n", i);
-                continue;
-            }
+            /* Set pedestal mask back to what it was before. */
+            [xl3 setPedestalInParallel];
 
             NSLog(@"PING crate %02d\n", i);
         }

--- a/Source/Objects/Custom Hardware/SNO+/MTC/ORMTCModel.h
+++ b/Source/Objects/Custom Hardware/SNO+/MTC/ORMTCModel.h
@@ -207,6 +207,7 @@
 - (void) setSingleGTWordMask:(unsigned long) gtWordMask;
 - (void) clearSingleGTWordMask:(unsigned long) gtWordMask;
 - (void) clearPedestalCrateMask;
+- (long) getPedestalCrateMask;
 - (void) setPedestalCrateMask;
 - (void) clearGTCrateMask;
 - (void) setGTCrateMask;

--- a/Source/Objects/Custom Hardware/SNO+/MTC/ORMTCModel.h
+++ b/Source/Objects/Custom Hardware/SNO+/MTC/ORMTCModel.h
@@ -229,6 +229,7 @@
 - (void) setupGTCorseDelay;
 - (void) setupGTFineDelay:(unsigned short) theAddelValue;
 - (void) setupGTFineDelay;
+- (float) getThePulserRate;
 - (void) setThePulserRate:(float) pulserRate;
 - (void) enablePulser;
 - (void) disablePulser;

--- a/Source/Objects/Custom Hardware/SNO+/MTC/ORMTCModel.m
+++ b/Source/Objects/Custom Hardware/SNO+/MTC/ORMTCModel.m
@@ -1572,6 +1572,11 @@ resetFifoOnStart = _resetFifoOnStart;
 	}
 }
 
+- (float) getThePulserRate
+{
+    return floatDBValue(kPulserPeriod);
+}
+
 - (void) setThePulserRate:(float) pulserRate
 {
 	@try {

--- a/Source/Objects/Custom Hardware/SNO+/MTC/ORMTCModel.m
+++ b/Source/Objects/Custom Hardware/SNO+/MTC/ORMTCModel.m
@@ -1731,11 +1731,15 @@ resetFifoOnStart = _resetFifoOnStart;
     long timeout = [mtc timeout];
 
     /* Temporarily increase the timeout since it might take a while */
-    [mtc setTimeout:(long) 1.5*count/rate];
+    [mtc setTimeout:(long) 1500*count/rate];
 
-    [mtc okCommand:"fire_pedestals %d %f", count, rate];
-
-    [mtc setTimeout:timeout];
+    @try {
+        [mtc okCommand:"fire_pedestals %d %f", count, rate];
+    } @catch (NSException *e) {
+        @throw e;
+    } @finally {
+        [mtc setTimeout:timeout];
+    }
 }
 
 - (void) basicMTCReset

--- a/Source/Objects/Custom Hardware/SNO+/MTC/ORMTCModel.m
+++ b/Source/Objects/Custom Hardware/SNO+/MTC/ORMTCModel.m
@@ -1142,6 +1142,11 @@ resetFifoOnStart = _resetFifoOnStart;
 	}	
 }
 
+- (long) getPedestalCrateMask
+{
+    return uLongDBValue(kPEDCrateMask);
+}
+
 - (void) setPedestalCrateMask
 {
 	@try {

--- a/Source/Objects/Custom Hardware/SNO+/XL3/ORXL3Model.h
+++ b/Source/Objects/Custom Hardware/SNO+/XL3/ORXL3Model.h
@@ -381,6 +381,7 @@ enum {
 - (void) writeXl3Mode;
 - (void) compositeXl3RW;
 - (void) compositeQuit;
+- (int) setPedestalMask: (uint32_t) slotMask pattern: (uint32_t) pattern;
 - (void) compositeSetPedestal;
 - (void) setPedestalInParallel;
 - (void) zeroPedestalMasks;

--- a/Source/Objects/Custom Hardware/SNO+/XL3/ORXL3Model.m
+++ b/Source/Objects/Custom Hardware/SNO+/XL3/ORXL3Model.m
@@ -2535,6 +2535,37 @@ err:
 	[self setXl3OpsRunning:NO forKey:@"compositeQuit"];
 }
 
+- (int) setPedestalMask: (uint32_t) slotMask pattern: (uint32_t) pattern
+{
+    /* Set the pedestal mask for a given slot mask. Any slots not in the mask
+     * will have pedestals disabled. Returns 0 on success, -1 on error. */
+    char payload[XL3_PAYLOAD_SIZE];
+    SetCratePedestalsArgs *args;
+    SetCratePedestalsResults *results;
+
+    memset(&payload, 0, XL3_PAYLOAD_SIZE);
+
+    args = (SetCratePedestalsArgs *) payload;
+
+    args->slotMask = htonl(slotMask);
+    args->pattern = htonl(pattern);
+
+    @try {
+        [[self xl3Link] sendCommand:SET_CRATE_PEDESTALS_ID withPayload:payload
+                        expectResponse:YES];
+    } @catch (NSException *e) {
+        return -1;
+    }
+
+    results = (SetCratePedestalsResults *) payload;
+
+    if (ntohl(results->errorMask)) {
+        return -1;
+    }
+
+    return 0;
+}
+
 - (void) compositeSetPedestal
 {
 	char payload[XL3_PAYLOAD_SIZE];


### PR DESCRIPTION
This button enables pedestals for one crate at a time and sends a single
pedestal pulse. This is useful to make sure that you are getting NHIT triggers
from all the crates.

This has been tested on the teststand on Friday, December 16, 2016. I verified that I could successfully ping crate 19, although since this function is supposed to go crate by crate it definitely needs testing on the full detector to make sure that it is doing what we expect it to do.