### PR TITLE
SNO+: fix bug which caused multiple dogs to appear in status bar

### DIFF
--- a/Source/Experiments/SNOP/RunStatusIcon.m
+++ b/Source/Experiments/SNOP/RunStatusIcon.m
@@ -23,6 +23,8 @@
     [statusIcon setEnabled:NO];
     [statusIcon setTarget:self];
 
+    animate_timer = nil;
+
     return self;
 }
 
@@ -37,7 +39,9 @@
     if([statusIcon image])
     {
         //Timer doggy
-        animate_timer = [NSTimer scheduledTimerWithTimeInterval:1.0/20.0 target:self selector:@selector(animate_icon) userInfo:nil repeats:YES];
+        if (!animate_timer) {
+            animate_timer = [NSTimer scheduledTimerWithTimeInterval:1.0/20.0 target:self selector:@selector(animate_icon) userInfo:nil repeats:YES];
+        }
         isRunning =true;
         [statusIcon setEnabled:YES];
 
@@ -49,6 +53,7 @@
     if(isRunning)
     {
         [animate_timer invalidate];
+        animate_timer = nil;
         isRunning = NO;
         [statusIcon setImage:[NSImage imageNamed:@"waiting_dog.tiff"]];
         [statusIcon setEnabled:NO];

--- a/Source/Experiments/SNOP/SNOPController.m
+++ b/Source/Experiments/SNOP/SNOPController.m
@@ -67,6 +67,7 @@ snopGreenColor;
     [snopGreenColor release];
     [snopOrangeColor release];
     [snopRedColor release];
+    [doggy_icon stop_animation];
     [doggy_icon release];
     
     [super dealloc];


### PR DESCRIPTION
The timer which is used to animate the dog icon holds a reference to the RunStatusIcon class so it is not actually freed when the SNO+ controller is deallocated.

This commit fixes the issue by making sure to only create one timer (this was causing the dogs to run at different speeds I think) and then making sure to stop the animation before releasing the object.