### PR TITLE
SNO+: fix the MTC model so that it disables pedestals when pressing the "Load & Fire" button if the pulser feed is set to PGT

### DIFF
--- a/Source/Objects/Custom Hardware/SNO+/MTC/ORMTCModel.m
+++ b/Source/Objects/Custom Hardware/SNO+/MTC/ORMTCModel.m
@@ -1689,6 +1689,8 @@ resetFifoOnStart = _resetFifoOnStart;
 		//[self clearGlobalTriggerWordMask];							//STEP 0a:	//added 01/24/98 QRA
         if ([self isPedestalEnabledInCSR]) {
             [self enablePedestal];											// STEP 1 : Enable Pedestal
+        } else {
+            [self disablePedestal];
         }
 		[self setPedestalCrateMask];									// STEP 2: Mask in crates for pedestals (PMSK)
 		[self setGTCrateMask];											// STEP 3: Mask  Mask in crates fo GTRIGs (GMSK)


### PR DESCRIPTION
Fixes issue #106.