### PR TITLE
SNO+: update MTC model to store whether the pulser is enabled and disable the pulser when the run stops

### DIFF
--- a/Source/Experiments/SNOP/SNOPModel.m
+++ b/Source/Experiments/SNOP/SNOPModel.m
@@ -833,6 +833,14 @@ err:
             goto err;
         }
 
+        @try {
+            [mtc_server okCommand:"disable_pulser"];
+        } @catch (NSException *e) {
+            NSLogColor([NSColor redColor], @"error sending disable_pulser "
+                       "command to mtc_server: %@\n", [e reason]);
+            goto err;
+        }
+
         NSDictionary *userInfo = [NSDictionary dictionaryWithObjectsAndKeys:
                                   @"waiting for MTC/XL3/CAEN data", @"Reason",
                                   nil];

--- a/Source/Objects/Custom Hardware/SNO+/MTC/ORMTCModel.h
+++ b/Source/Objects/Custom Hardware/SNO+/MTC/ORMTCModel.h
@@ -53,6 +53,8 @@
 		unsigned long			fixedPulserRateCount;
 		float				fixedPulserRateDelay;
     BOOL _isPedestalEnabledInCSR;
+
+    BOOL _pulserEnabled;
 		
 		//settings
 		NSString*				lastFileLoaded;
@@ -106,6 +108,7 @@
 @property (nonatomic,assign) unsigned long mtcStatusNumEventsInMem;
 @property (nonatomic,assign) BOOL isPedestalEnabledInCSR;
 @property (nonatomic,assign) BOOL resetFifoOnStart;
+@property (nonatomic,assign) BOOL pulserEnabled;
 
 #pragma mark •••Initialization
 - (id) init;


### PR DESCRIPTION
Fixes issue #90.