### PR TITLE
SNO+: update HV check in reset crate function

### DIFF
--- a/Source/Objects/Custom Hardware/SNO+/XL3/ORXL3Model.m
+++ b/Source/Objects/Custom Hardware/SNO+/XL3/ORXL3Model.m
@@ -1844,7 +1844,7 @@ void SwapLongBlock(void* p, int32_t n)
     int i, j;
 
     /* Check that HV Relays for XL3 are open if performing a full crate init. */
-    if ([self hvASwitch] || [self hvBSwitch]) {
+    if ([self hvEverUpdated] && ([self hvASwitch] || [self hvBSwitch])) {
         NSLogColor([NSColor redColor], @"XL3 %02d has high voltage on.  HV must be turned off before a crate reset.\n", [self crateNumber]);
         return;
     }


### PR DESCRIPTION
This pull request updates the check in the reset crate function to make sure that the HV thread has updated the switch values before checking if the switches are on.

I noticed this on the teststand when I power cycled the crate with the HV switch still on. When the XL3 came back the HV thread didn't start (because the crate hadn't been reset), but the switch variables in ORCA were still set to show that the HV was on so I had no way to reset the crate.

Tested on the teststand on Saturday, December 17, 2016.