### PR TITLE
SNO+: Fix supply A overcurrent alarm not clearing.

### DIFF
--- a/Source/Objects/Custom Hardware/SNO+/XL3/ORXL3Model.m
+++ b/Source/Objects/Custom Hardware/SNO+/XL3/ORXL3Model.m
@@ -5103,7 +5103,7 @@ float nominals[] = {2110.0, 2240.0, 2075.0, 2160.0, 2043.0, 2170.0, 2170.0, 2170
             [self _update_level_alarm:80000+aoffset level:supplyACurrentDropout];
         }
         if (!loopCounter || supplyAOverCurrent != lastSupplyAOverCurrent) {
-            lastSupplyBOverCurrent = supplyAOverCurrent;
+            lastSupplyAOverCurrent = supplyAOverCurrent;
             [self _update_level_alarm:80300+aoffset level:supplyAOverCurrent];
         }
         if (!loopCounter || supplyAOverVoltage != lastSupplyAOverVoltage) {


### PR DESCRIPTION
Found by @fbdescamps and crew, a typo set the last state of supply B instead of supply A so the alarm was triggered but when the state cleared internally he DB was never updated. This fixes the typo.

Simple change, so should be safe to merge, but hasn't actually been tested.