### PR TITLE
SNO+: Lighten blue color used in multistate buttons.

### DIFF
--- a/Source/Objects/Custom Hardware/SNO+/Fec32/Fec32.xib
+++ b/Source/Objects/Custom Hardware/SNO+/Fec32/Fec32.xib
@@ -5303,7 +5303,7 @@
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Enabled" id="cjT-x5-bNd">
                                                 <font key="font" metaFont="smallSystem"/>
-                                                <color key="textColor" red="0.0" green="0.0" blue="1" alpha="0.84999999999999998" colorSpace="calibratedRGB"/>
+                                                <color key="textColor" red="0.11764705882352941" green="0.56470588235294117" blue="1" alpha="0.84999999999999998" colorSpace="calibratedRGB"/>
                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                             </textFieldCell>
                                         </textField>

--- a/Source/Objects/Custom Hardware/SNO+/Fec32/ORFec32Controller.m
+++ b/Source/Objects/Custom Hardware/SNO+/Fec32/ORFec32Controller.m
@@ -50,7 +50,7 @@
 {
     NSDictionary *statedict = [NSDictionary dictionaryWithObjectsAndKeys:
                                [NSColor redColor], @"disabled",
-                               [NSColor blueColor], @"enabled",
+                               [NSColor colorWithCalibratedRed:(30.0/255.0) green:(144.0/255.0) blue:1.0 alpha:1.0], @"enabled",
                                [NSColor blackColor], @"unknwon",
                                nil];
     msbox = [[ORMultiStateBox alloc] initWithStates:statedict size:20 pad:0 bevel:2];

--- a/Source/Objects/Custom Hardware/SNO+/XL3/XL3_Link.xib
+++ b/Source/Objects/Custom Hardware/SNO+/XL3/XL3_Link.xib
@@ -2583,7 +2583,7 @@
                                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Closed" id="hdb-zX-1QV">
                                                             <font key="font" metaFont="system"/>
-                                                            <color key="textColor" red="0.0" green="0.0" blue="1" alpha="0.84999999999999998" colorSpace="calibratedRGB"/>
+                                                            <color key="textColor" red="0.11764705882352941" green="0.56470588235294117" blue="1" alpha="0.84999999999999998" colorSpace="calibratedRGB"/>
                                                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                         </textFieldCell>
                                                     </textField>

--- a/Source/Objects/Custom Hardware/SNO+/XL3/XL3_LinkController.m
+++ b/Source/Objects/Custom Hardware/SNO+/XL3/XL3_LinkController.m
@@ -63,7 +63,7 @@ static NSDictionary* xl3Ops;
 	[super awakeFromNib];
     
     NSDictionary *statedict = [NSDictionary dictionaryWithObjectsAndKeys:
-                               [NSColor blueColor], @"closed",
+                               [NSColor colorWithCalibratedRed:(30.0/255.0) green:(144.0/255.0) blue:1.0 alpha:1.0], @"closed",
                                [NSColor redColor], @"open",
                                [NSColor blackColor], @"unk",
                                nil];


### PR DESCRIPTION
Minor changes, awaiting confirmation from color blind folk and others to merge. One line changes in .xib should merge fine.