### PR TITLE
SNO+: update load hardware button to put XL3 in NORMAL mode

### DIFF
--- a/Source/Objects/Custom Hardware/SNO+/SNOCrate/ORSNOCrateController.m
+++ b/Source/Objects/Custom Hardware/SNO+/SNOCrate/ORSNOCrateController.m
@@ -148,6 +148,10 @@
 - (IBAction) loadHardwareAction:(id)sender
 {
     [model loadHardware];
+    [[self undoManager] disableUndoRegistration];
+    [model setXl3Mode:NORMAL_MODE];
+    [[self undoManager] enableUndoRegistration];
+    [model writeXl3Mode:NORMAL_MODE];
 }
 
 @end

--- a/Source/Objects/Custom Hardware/SNO+/SNOCrate/ORSNOCrateController.m
+++ b/Source/Objects/Custom Hardware/SNO+/SNOCrate/ORSNOCrateController.m
@@ -148,10 +148,6 @@
 - (IBAction) loadHardwareAction:(id)sender
 {
     [model loadHardware];
-    [[self undoManager] disableUndoRegistration];
-    [model setXl3Mode:NORMAL_MODE];
-    [[self undoManager] enableUndoRegistration];
-    [model writeXl3Mode:NORMAL_MODE];
 }
 
 @end

--- a/Source/Objects/Custom Hardware/SNO+/SNOCrate/ORSNOCrateModel.m
+++ b/Source/Objects/Custom Hardware/SNO+/SNOCrate/ORSNOCrateModel.m
@@ -352,13 +352,20 @@ NSString* ORSNOCrateSlotChanged = @"ORSNOCrateSlotChanged";
 - (void) fetchECALSettings
 {
     /* Fetch the latest ECAL settings and load them to the GUI. */
-	[[self adapter] fetchECALSettings];
+    [[self adapter] fetchECALSettings];
 }
 
 - (void) loadHardware
 {
     /* Loads hardware settings from the GUI -> XL3. */
-	[[self adapter] loadHardware];
+    [[self adapter] loadHardware];
+
+    /* Put the XL3 in NORMAL mode and set the readout mask to all cards which
+     * are present. */
+    [[self undoManager] disableUndoRegistration];
+    [[self adapter] setXl3Mode:NORMAL_MODE];
+    [[self undoManager] enableUndoRegistration];
+    [[self adapter] writeXl3Mode:NORMAL_MODE];
 }
 
 @end

--- a/Source/Objects/Custom Hardware/SNO+/XL3/ORXL3Model.h
+++ b/Source/Objects/Custom Hardware/SNO+/XL3/ORXL3Model.h
@@ -380,7 +380,8 @@ enum {
 
 #pragma mark •••Composite
 - (void) deselectComposite;
-- (void) writeXl3Mode;
+- (void) writeXl3Mode: (uint32_t) mode;
+- (void) writeXl3Mode: (uint32_t) mode withSlotMask: (uint32_t) slotMask;
 - (void) compositeXl3RW;
 - (void) compositeQuit;
 - (int) setPedestalMask: (uint32_t) slotMask pattern: (uint32_t) pattern;

--- a/Source/Objects/Custom Hardware/SNO+/XL3/XL3_LinkController.m
+++ b/Source/Objects/Custom Hardware/SNO+/XL3/XL3_LinkController.m
@@ -1186,7 +1186,7 @@ static NSDictionary* xl3Ops;
 
 - (IBAction) compositeXl3ModeSetAction:(id) sender
 {
-	[model writeXl3Mode];
+	[model writeXl3Mode:[model xl3Mode] withSlotMask:[model slotMask]];
 }
 
 - (IBAction) compositeXl3RWAddressValueAction:(id)sender


### PR DESCRIPTION
Also, allow the user to change the readout mask when setting the mode from the
Ops tab in the XL3 window.

Fixes issue #228.