### PR TITLE
update HW Wizard to disable channel triggers if a channel is connected to an open HV relay

### DIFF
--- a/Source/Objects/Custom Hardware/SNO+/Fec32/ORFec32Model.m
+++ b/Source/Objects/Custom Hardware/SNO+/Fec32/ORFec32Model.m
@@ -1929,10 +1929,10 @@ static int              sChannelsNotChangedCount = 0;
         // triggers must be disabled on channels with HV disabled or if the
         // relay is open
         wanted = trigger20nsDisabledMask;
-        trigger20nsDisabledMask |= (trigger20nsDisabledMask ^ startTrigger20nsDisabledMask) & card->hvDisabled & ~[self relayChannelMask];
+        trigger20nsDisabledMask |= (trigger20nsDisabledMask ^ startTrigger20nsDisabledMask) & (card->hvDisabled | ~[self relayChannelMask]);
         notChanged |= (wanted ^ trigger20nsDisabledMask);
         wanted = trigger100nsDisabledMask;
-        trigger100nsDisabledMask |= (trigger100nsDisabledMask ^ startTrigger100nsDisabledMask) & card->hvDisabled & ~[self relayChannelMask];
+        trigger100nsDisabledMask |= (trigger100nsDisabledMask ^ startTrigger100nsDisabledMask) & (card->hvDisabled | ~[self relayChannelMask]);
         notChanged |= (wanted ^ trigger100nsDisabledMask);
         // can't be online if HV is disabled
         wanted = onlineMask;
@@ -2904,7 +2904,7 @@ const short kVoltageADCMaximumAttempts = 10;
     uint32_t hv = 0;
 
     for (i = 0; i < 4; i++) {
-        if (([guardian relayMask] >> ([self stationNumber]*4 + (3-i))) & 0x1) {
+        if (([[[self guardian] adapter] relayMask] >> ([self stationNumber]*4 + (3-i))) & 0x1) {
             hv |= 0xff << i*8;
         }
     }

--- a/Source/Objects/Custom Hardware/SNO+/Fec32/ORFec32Model.m
+++ b/Source/Objects/Custom Hardware/SNO+/Fec32/ORFec32Model.m
@@ -98,6 +98,7 @@ static int              sChannelsNotChangedCount = 0;
 @end
 
 @interface ORFec32Model (XL3)
+- (uint32_t) relayChannelMask;
 -(BOOL) parseVoltagesUsingXL3:(VMonResults*)result;
 -(BOOL) readVoltagesUsingXL3;
 -(void) readCMOSCountsUsingXL3:(unsigned long)aChannelMask;
@@ -1925,12 +1926,13 @@ static int              sChannelsNotChangedCount = 0;
         wanted = pedEnabledMask;
         pedEnabledMask &= ~((pedEnabledMask ^ startPedEnabledMask) & card->hvDisabled);
         notChanged |= (wanted ^ pedEnabledMask);
-        // triggers must be disabled on channels with HV disabled
+        // triggers must be disabled on channels with HV disabled or if the
+        // relay is open
         wanted = trigger20nsDisabledMask;
-        trigger20nsDisabledMask |= (trigger20nsDisabledMask ^ startTrigger20nsDisabledMask) & card->hvDisabled;
+        trigger20nsDisabledMask |= (trigger20nsDisabledMask ^ startTrigger20nsDisabledMask) & card->hvDisabled & ~[self relayChannelMask];
         notChanged |= (wanted ^ trigger20nsDisabledMask);
         wanted = trigger100nsDisabledMask;
-        trigger100nsDisabledMask |= (trigger100nsDisabledMask ^ startTrigger100nsDisabledMask) & card->hvDisabled;
+        trigger100nsDisabledMask |= (trigger100nsDisabledMask ^ startTrigger100nsDisabledMask) & card->hvDisabled & ~[self relayChannelMask];
         notChanged |= (wanted ^ trigger100nsDisabledMask);
         // can't be online if HV is disabled
         wanted = onlineMask;
@@ -2893,6 +2895,23 @@ const short kVoltageADCMaximumAttempts = 10;
 
 
 @implementation ORFec32Model (XL3)
+
+- (uint32_t) relayChannelMask
+{
+    /* Returns a 32 bit mask indicating which channels are connected to a
+     * closed relay. */
+    int i;
+    uint32_t hv = 0;
+
+    for (i = 0; i < 4; i++) {
+        if (([guardian relayMask] >> ([self stationNumber]*4 + (3-i))) & 0x1) {
+            hv |= 0xff << i*8;
+        }
+    }
+
+    return hv;
+}
+
 
 -(BOOL) parseVoltagesUsingXL3:(VMonResults*) result
 {


### PR DESCRIPTION
The HW wizard now checks the HV relays when deciding whether to enable or disable triggers for a particular channel.

With this change it should be possible to use the HW wizard to enable triggers for an entire crate and be sure that triggers are only enabled for channels actually at HV.