### PR TITLE
SNO+: Make HV/relay controls OWL aware

### DIFF
--- a/Source/Objects/Custom Hardware/SNO+/XL3/ORXL3Model.h
+++ b/Source/Objects/Custom Hardware/SNO+/XL3/ORXL3Model.h
@@ -328,6 +328,10 @@ enum {
 - (NSString*) xl3LockName;
 - (NSComparisonResult) XL3NumberCompare:(id)aCard;
 
++ (void) setOwlSupplyOn:(BOOL)isOn;
++ (BOOL) owlSupplyOn;
+- (BOOL) isOwlCrate;
+
 #pragma mark •••DB Helpers
 - (void) synthesizeDefaultsIntoBundle:(MB*)aBundle forSlot:(unsigned short)aSlot;
 - (void) byteSwapBundle:(MB*)aBundle;

--- a/Source/Objects/Custom Hardware/SNO+/XL3/ORXL3Model.m
+++ b/Source/Objects/Custom Hardware/SNO+/XL3/ORXL3Model.m
@@ -796,9 +796,12 @@ BOOL owlSupplyState = true; //better safe than sorry
         owlSupplyState = isOn;
         NSArray* objs = [[(ORAppDelegate*)[NSApp delegate] document] collectObjectsOfClass:NSClassFromString(@"ORXL3Model")];
         for (uint32_t i = 0; i < [objs count]; i++) {
-            dispatch_async(dispatch_get_main_queue(), ^{
-                [[NSNotificationCenter defaultCenter] postNotificationName:ORXL3ModelHvStatusChanged object:[objs objectAtIndex:i]];
-            });
+            ORXL3Model *xl3 = [objs objectAtIndex:i];
+            if ([xl3 isOwlCrate]) {
+                dispatch_async(dispatch_get_main_queue(), ^{
+                    [[NSNotificationCenter defaultCenter] postNotificationName:ORXL3ModelHvStatusChanged object:xl3];
+                });
+            }
         }
     }
 }

--- a/Source/Objects/Custom Hardware/SNO+/XL3/ORXL3Model.m
+++ b/Source/Objects/Custom Hardware/SNO+/XL3/ORXL3Model.m
@@ -3876,7 +3876,7 @@ err:
             NSLogColor([NSColor redColor],@"%@ error in readHVInterlock\n",[[self xl3Link] crateName]);
         }
     }
-    if (interlockIsGood) {
+    if (!interlockIsGood) {
         if (aOn) {
             NSLog(@"%@ NOT turning ON the HV power supply.\n",[[self xl3Link] crateName]);
             return;

--- a/Source/Objects/Custom Hardware/SNO+/XL3/ORXL3Model.m
+++ b/Source/Objects/Custom Hardware/SNO+/XL3/ORXL3Model.m
@@ -782,11 +782,50 @@ hvBQueryWaiting = hvBQueryWaiting;
     
 }
 
+/**
+ * Global variable to store the state of the OWL supply
+ */
+BOOL owlSupplyState = true; //better safe than sorry
+
+/**
+ * Called by the owl supply to set the state. Also posts a ORXL3HVStatusChanged 
+ * notification to make sure all GUIs are properly updated in the event of a change.
+ */
++ (void) setOwlSupplyOn:(BOOL)isOn {
+    if (owlSupplyState != isOn) {
+        owlSupplyState = isOn;
+        NSArray* objs = [[(ORAppDelegate*)[NSApp delegate] document] collectObjectsOfClass:NSClassFromString(@"ORXL3Model")];
+        for (uint32_t i = 0; i < [objs count]; i++) {
+            dispatch_async(dispatch_get_main_queue(), ^{
+                [[NSNotificationCenter defaultCenter] postNotificationName:ORXL3ModelHvStatusChanged object:[objs objectAtIndex:i]];
+            });
+        }
+    }
+}
+
+/**
+ * Returns true if the OWL supply is on
+ */
++ (BOOL) owlSupplyOn {
+    return owlSupplyState;
+}
+
+/**
+ * Returns true if the crate has OWL PTMs connected
+ */
+- (BOOL) isOwlCrate {
+    uint32_t n = [self crateNumber];
+    if (n == 3 || n == 13 || n == 18) {
+        return true;
+    }
+    return false;
+}
+
 - (void) setHvEverUpdated:(BOOL)ever
 {
     hvEverUpdated = ever;
     dispatch_async(dispatch_get_main_queue(), ^{
-     [[NSNotificationCenter defaultCenter] postNotificationName:ORXL3ModelHvStatusChanged object:self];
+        [[NSNotificationCenter defaultCenter] postNotificationName:ORXL3ModelHvStatusChanged object:self];
     });
 }
 
@@ -859,10 +898,12 @@ hvBQueryWaiting = hvBQueryWaiting;
 
 - (void) setHvASwitch:(BOOL)aHvASwitch
 {
-    hvASwitch = aHvASwitch;
-	dispatch_async(dispatch_get_main_queue(), ^{
-    [[NSNotificationCenter defaultCenter] postNotificationName:ORXL3ModelHvStatusChanged object:self];
-    });
+    if (hvASwitch != aHvASwitch) {
+        hvASwitch = aHvASwitch;
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [[NSNotificationCenter defaultCenter] postNotificationName:ORXL3ModelHvStatusChanged object:self];
+        });
+    }
 }
 
 - (BOOL) hvBSwitch
@@ -872,10 +913,17 @@ hvBQueryWaiting = hvBQueryWaiting;
 
 - (void) setHvBSwitch:(BOOL)aHvBSwitch
 {
-    hvBSwitch = aHvBSwitch;
-    dispatch_async(dispatch_get_main_queue(), ^{
-	[[NSNotificationCenter defaultCenter] postNotificationName:ORXL3ModelHvStatusChanged object:self];        
-    });
+    if (hvBSwitch != aHvBSwitch) {
+        hvBSwitch = aHvBSwitch;
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [[NSNotificationCenter defaultCenter] postNotificationName:ORXL3ModelHvStatusChanged object:self];        
+        });
+    }
+    if ([self crateNumber] == 16) {
+        //Should be called even if the model value appears not to change to
+        //properly update the GUI and keep everything consistent
+        [ORXL3Model setOwlSupplyOn:aHvBSwitch];
+    }
 }
 
 - (BOOL) hvANeedsUserIntervention
@@ -3788,24 +3836,49 @@ err:
     [self setHvASwitch:xl3SwitchA];
     [self setHvBSwitch:xl3SwitchB];
         
-    BOOL interlockIsGood;
-    
-    @try {
-        [self readHVInterlockGood:&interlockIsGood];
+        
+    BOOL interlockIsGood = false;
+    if ([self crateNumber] == 16 && sup != 0) { //16B
+        //Checks interlocks for any crates with connected OWL tubes
+        //Assumes that all relevant crates are represented in the open experiment
+        uint32_t checkedInterlocks = 0;
+        uint32_t goodInterlocks = 0;
+        NSArray* objs = [[(ORAppDelegate*)[NSApp delegate] document] collectObjectsOfClass:NSClassFromString(@"ORXL3Model")];
+        for (uint32_t i = 0; i < [objs count]; i++) {
+            ORXL3Model *xl3 = [objs objectAtIndex:i];
+            if ([xl3 isOwlCrate]) {
+                checkedInterlocks++;
+                @try {
+                    BOOL good = false;
+                    [xl3 readHVInterlockGood:&good];
+                    if (good) {
+                        goodInterlocks++;
+                    } else {
+                        NSLogColor([NSColor redColor],@"%@ HV interlock BAD\n",[[xl3 xl3Link] crateName]);
+                    }
+                }
+                @catch (NSException *exception) {
+                    NSLogColor([NSColor redColor],@"%@ error in readHVInterlock\n",[[xl3 xl3Link] crateName]);
+                }
+            }
+        }
+        interlockIsGood = checkedInterlocks == goodInterlocks;
+    } else {
+        //Checks the interlock for this crate only
+        @try {
+            [self readHVInterlockGood:&interlockIsGood];
+            if (!interlockIsGood) NSLogColor([NSColor redColor],@"%@ HV interlock BAD\n",[[self xl3Link] crateName]);
+        }
+        @catch (NSException *exception) {
+            NSLogColor([NSColor redColor],@"%@ error in readHVInterlock\n",[[self xl3Link] crateName]);
+        }
     }
-    @catch (NSException *exception) {
-        NSLogColor([NSColor redColor],@"%@ error in readHVInterlock\n",[[self xl3Link] crateName]);
-        return;
-    }
-
-    if (!interlockIsGood) {
-        NSLogColor([NSColor redColor],@"%@ HV interlock BAD\n",[[self xl3Link] crateName]);
+    if (interlockIsGood) {
         if (aOn) {
             NSLog(@"%@ NOT turning ON the HV power supply.\n",[[self xl3Link] crateName]);
             return;
-        }
-        else {
-            NSLog(@"%@ continuing to turn OFF the HV power supply.\n",[[self xl3Link] crateName]);            
+        } else {
+            NSLog(@"%@ continuing to turn OFF the HV power supply.\n",[[self xl3Link] crateName]);
         }
     }
         

--- a/Source/Objects/Custom Hardware/SNO+/XL3/XL3_LinkController.h
+++ b/Source/Objects/Custom Hardware/SNO+/XL3/XL3_LinkController.h
@@ -151,7 +151,6 @@
     IBOutlet NSButton*              connectionAutoConnectButton;
     IBOutlet NSButton*              connectionAutoInitCrateButton;
     
-    id owl_crate_master;
     NSBox *hvBStatusPanel;
     NSBox *hvAStatusPanel;
 }	

--- a/Source/Objects/Custom Hardware/SNO+/XL3/XL3_LinkController.m
+++ b/Source/Objects/Custom Hardware/SNO+/XL3/XL3_LinkController.m
@@ -760,12 +760,6 @@ static NSDictionary* xl3Ops;
 
 - (void) hvStatusChanged:(NSNotification*)aNote
 { dispatch_async(dispatch_get_main_queue(), ^{
-    if (!owl_crate_master) { //cache owl master
-        NSArray* xl3s = [[(ORAppDelegate*)[NSApp delegate] document] collectObjectsOfClass:NSClassFromString(@"ORXL3Model")];
-        for (id xl3 in xl3s) {
-            if ([xl3 crateNumber] == 16) owl_crate_master = xl3;
-        }
-    }
     
     [hvAOnStatusField setStringValue:[model hvASwitch]?@"ON":@"OFF"];
     [hvAVoltageSetField setStringValue:[NSString stringWithFormat:@"%lu V",[model hvAVoltageDACSetValue]*3000/4096]];
@@ -791,11 +785,7 @@ static NSDictionary* xl3Ops;
 
     BOOL lockedOrNotRunningMaintenance = [gSecurity runInProgressButNotType:eMaintenanceRunType orIsLocked:ORXL3Lock];
 
-    //todo: add exception for OWLs
-    //if ([hvPowerSupplyMatrix selectedColumn] == 0 && [model hvASwitch]) {
-    if ([model hvASwitch] || //A ON or
-        (([model crateNumber] == 3 || [model crateNumber] == 13 || [model crateNumber] == 18) && //OWL crate
-         ([owl_crate_master hvBSwitch]))) { //and crate 16 HV B ON
+    if ([model hvASwitch] || ([model isOwlCrate] && [ORXL3Model owlSupplyOn])) {
         [hvRelayMaskHighField setEnabled:NO];
         [hvRelayMaskLowField setEnabled:NO];
         [hvRelayMaskMatrix setEnabled:NO];


### PR DESCRIPTION
Adds some class methods to ORXL3Model for storing the state of the
OWL supply (16B) and an instance method which identifies crates with
OWL tubes connected (3,13,18). The relay controls are disabled for
the whole crate for crates with OWL tubes whenever 16B is ON. This
is the safest option but may not be strictly necessary.

Also corrects a bug where 16B checked the HV interlocks for crate
16. Now 16B checks all crates identified as having OWL tubes
connected for a good HV interlock prior to turning on the supply.