### PR TITLE
SNO+: end editing of target value field prior to HV supply actions.

### DIFF
--- a/Source/Objects/Custom Hardware/SNO+/XL3/XL3_LinkController.m
+++ b/Source/Objects/Custom Hardware/SNO+/XL3/XL3_LinkController.m
@@ -1402,11 +1402,13 @@ static NSDictionary* xl3Ops;
 
 - (IBAction)hvTurnOnAction:(id)sender
 {
+    [[sender window] makeFirstResponder:tabView];
     [model setHVSwitch:YES forPowerSupply:[hvPowerSupplyMatrix selectedColumn]];
 }
 
 - (IBAction)hvTurnOffAction:(id)sender
 {
+    [[sender window] makeFirstResponder:tabView];
     unsigned int sup = [hvPowerSupplyMatrix selectedColumn];
 
     if (sup == 0 && [model hvASwitch]) {
@@ -1515,6 +1517,7 @@ static NSDictionary* xl3Ops;
 
 - (IBAction)hvStepUpAction:(id)sender;
 {
+    [[sender window] makeFirstResponder:tabView];
     unsigned long aVoltageDACValue;
     if ([hvPowerSupplyMatrix selectedColumn] == 0) {
         aVoltageDACValue = [model hvANextStepValue];
@@ -1532,6 +1535,7 @@ static NSDictionary* xl3Ops;
 
 - (IBAction)hvStepDownAction:(id)sender
 {
+    [[sender window] makeFirstResponder:tabView];
     unsigned long aVoltageDACValue;
     if ([hvPowerSupplyMatrix selectedColumn] == 0) {
         aVoltageDACValue = [model hvANextStepValue];
@@ -1549,16 +1553,18 @@ static NSDictionary* xl3Ops;
 
 - (IBAction)hvRampUpAction:(id)sender
 {
-        if ([hvPowerSupplyMatrix selectedColumn] == 0) {
-            [model setHvANextStepValue:[model hvAVoltageTargetValue]];
-        }
-        else {
-            [model setHvBNextStepValue:[model hvBVoltageTargetValue]];
-        }
+    [[sender window] makeFirstResponder:tabView];
+    if ([hvPowerSupplyMatrix selectedColumn] == 0) {
+        [model setHvANextStepValue:[model hvAVoltageTargetValue]];
+    }
+    else {
+        [model setHvBNextStepValue:[model hvBVoltageTargetValue]];
+    }
 }
 
 - (IBAction)hvRampDownAction:(id)sender
 {
+    [[sender window] makeFirstResponder:tabView];
     if ([model isTriggerON]) {
         [model hvTriggersOFF];
     }
@@ -1572,6 +1578,7 @@ static NSDictionary* xl3Ops;
 
 - (IBAction)hvRampPauseAction:(id)sender
 {
+    [[sender window] makeFirstResponder:tabView];
     if ([hvPowerSupplyMatrix selectedColumn] == 0) {
         [model setHvANextStepValue:[model hvAVoltageDACSetValue]];
     }


### PR DESCRIPTION
Ensures that a ramp will go to the value that appears to be typed into the text field (rounded to the nearest 12bit value) whether the user has remembered to press enter or not.

Coco idiosyncratic code stolen from https://stackoverflow.com/questions/2284149/forcing-a-cocoa-text-field-to-end-editing
Tested on teststand 1/23 (minor change). Fixes #226 