### PR TITLE
XL3 multi set triggers and sequencers

### DIFF
--- a/Source/Objects/Custom Hardware/SNO+/XL3/ORXL3Model.h
+++ b/Source/Objects/Custom Hardware/SNO+/XL3/ORXL3Model.h
@@ -357,6 +357,9 @@ enum {
 - (void)encodeWithCoder:(NSCoder*)encoder;
 
 #pragma mark •••Hardware Access
+- (void) loadTriggers;
+- (void) disableTriggers;
+- (void) loadSequencers;
 - (void) selectCards:(unsigned long) selectBits;
 - (void) deselectCards;
 - (void) select:(ORSNOCard*) aCard;

--- a/Source/Objects/Custom Hardware/SNO+/XL3/ORXL3Model.m
+++ b/Source/Objects/Custom Hardware/SNO+/XL3/ORXL3Model.m
@@ -1668,15 +1668,18 @@ void SwapLongBlock(void* p, int32_t n)
      * This function will raise an exception if any error occurs. */
     int slot, dbNum, channel;
     char payload[XL3_PAYLOAD_SIZE];
+    ORFec32Model *fec;
+    ORFecDaughterCardModel *db;
+
     memset(&payload, 0, sizeof(payload));
 
     MultiSetCrateTriggersArgs *args = (MultiSetCrateTriggersArgs *) payload;
 
-    args.slotMask = 0;
+    args->slotMask = 0;
 
     for (slot = 0; slot < 16; slot++) {
-        args.tr100Masks[slot] = 0;
-        args.tr20Masks[slot] = 0;
+        args->tr100Masks[slot] = 0;
+        args->tr20Masks[slot] = 0;
     }
 
     for (slot = 0; slot < 16; slot++) {
@@ -1684,7 +1687,7 @@ void SwapLongBlock(void* p, int32_t n)
 
         if (!fec) continue;
 
-        args.slotMask |= 1 << slot;
+        args->slotMask |= 1 << slot;
 
         if ([self isTriggerON]) {
             for (dbNum = 0; dbNum < 4; dbNum++) {
@@ -1694,11 +1697,11 @@ void SwapLongBlock(void* p, int32_t n)
 
                 for (channel = 0; channel < 8; channel++) {
                     if ([fec trigger100nsEnabled: (dbNum*8 + channel)]) {
-                        args.tr100Masks[slot] |= 1 << (dbNum*8+channel);
+                        args->tr100Masks[slot] |= 1 << (dbNum*8+channel);
                     }
 
                     if ([fec trigger20nsEnabled: (dbNum*8 + channel)]) {
-                        args.tr20Masks[slot] |= 1 << (dbNum*8+channel);
+                        args->tr20Masks[slot] |= 1 << (dbNum*8+channel);
                     }
                 }
             }
@@ -1706,11 +1709,11 @@ void SwapLongBlock(void* p, int32_t n)
     }
 
     /* Convert args to network byte order. */
-    args.slotMask = htonl(args.slotMask);
+    args->slotMask = htonl(args->slotMask);
 
     for (slot = 0; slot < 16; slot++) {
-        args.tr100Masks[slot] = htonl(args.tr100Masks[slot]);
-        args.tr20Masks[slot] = htonl(args.tr20Masks[slot]);
+        args->tr100Masks[slot] = htonl(args->tr100Masks[slot]);
+        args->tr20Masks[slot] = htonl(args->tr20Masks[slot]);
     }
 
     [[self xl3Link] sendCommand:MULTI_SET_CRATE_TRIGGERS_ID withPayload:payload expectResponse:YES];
@@ -1721,7 +1724,7 @@ void SwapLongBlock(void* p, int32_t n)
         NSException *e = [NSException exceptionWithName:@"loadTriggersError"
                           reason:@"failed to load channel triggers"
                           userInfo:nil];
-        [e raise]
+        [e raise];
     }
 }
 
@@ -1733,25 +1736,26 @@ void SwapLongBlock(void* p, int32_t n)
      * runs where you want to disable channel triggers but then load them back
      * at the end of the run. This function will block until the operation
      * completes. This function will raise an exception if any error occurs. */
-    int slot, dbNum, channel;
+    int slot;
     char payload[XL3_PAYLOAD_SIZE];
+
     memset(&payload, 0, sizeof(payload));
 
     MultiSetCrateTriggersArgs *args = (MultiSetCrateTriggersArgs *) payload;
 
-    args.slotMask = [self getSlotsPresent];
+    args->slotMask = [self getSlotsPresent];
 
     for (slot = 0; slot < 16; slot++) {
-        args.tr100Masks[slot] = 0;
-        args.tr20Masks[slot] = 0;
+        args->tr100Masks[slot] = 0;
+        args->tr20Masks[slot] = 0;
     }
 
     /* Convert args to network byte order. */
-    args.slotMask = htonl(args.slotMask);
+    args->slotMask = htonl(args->slotMask);
 
     for (slot = 0; slot < 16; slot++) {
-        args.tr100Masks[slot] = htonl(args.tr100Masks[slot]);
-        args.tr20Masks[slot] = htonl(args.tr20Masks[slot]);
+        args->tr100Masks[slot] = htonl(args->tr100Masks[slot]);
+        args->tr20Masks[slot] = htonl(args->tr20Masks[slot]);
     }
 
     [[self xl3Link] sendCommand:MULTI_SET_CRATE_TRIGGERS_ID withPayload:payload expectResponse:YES];
@@ -1762,7 +1766,7 @@ void SwapLongBlock(void* p, int32_t n)
         NSException *e = [NSException exceptionWithName:@"loadTriggersError"
                           reason:@"failed to load channel triggers"
                           userInfo:nil];
-        [e raise]
+        [e raise];
     }
 }
 
@@ -1771,16 +1775,18 @@ void SwapLongBlock(void* p, int32_t n)
     /* Loads the current GUI channel sequencer settings to the hardware. This
      * function will block and so should only be called on a separate thread.
      * This function will raise an exception if any error occurs. */
-    int slot, dbNum, channel;
+    int slot;
     char payload[XL3_PAYLOAD_SIZE];
+    ORFec32Model *fec;
+
     memset(&payload, 0, sizeof(payload));
 
     MultiSetCrateSequencersArgs *args = (MultiSetCrateSequencersArgs *) payload;
 
-    args.slotMask = 0;
+    args->slotMask = 0;
 
     for (slot = 0; slot < 16; slot++) {
-        args.channelMasks[slot] = 0;
+        args->channelMasks[slot] = 0;
     }
 
     for (slot = 0; slot < 16; slot++) {
@@ -1788,16 +1794,16 @@ void SwapLongBlock(void* p, int32_t n)
 
         if (!fec) continue;
 
-        args.slotMask |= 1 << slot;
+        args->slotMask |= 1 << slot;
 
-        args.channelMasks[slot] = ~[fec seqDisabledMask];
+        args->channelMasks[slot] = ~[fec seqDisabledMask];
     }
 
     /* Convert args to network byte order. */
-    args.slotMask = htonl(args.slotMask);
+    args->slotMask = htonl(args->slotMask);
 
     for (slot = 0; slot < 16; slot++) {
-        args.channelMasks[slot] = htonl(args.channelMasks[slot]);
+        args->channelMasks[slot] = htonl(args->channelMasks[slot]);
     }
 
     [[self xl3Link] sendCommand:MULTI_SET_CRATE_SEQUENCERS_ID withPayload:payload expectResponse:YES];
@@ -1808,7 +1814,7 @@ void SwapLongBlock(void* p, int32_t n)
         NSException *e = [NSException exceptionWithName:@"loadSequencersError"
                           reason:@"failed to load channel sequencers"
                           userInfo:nil];
-        [e raise]
+        [e raise];
     }
 }
 

--- a/Source/Objects/Custom Hardware/SNO+/XL3/ORXL3Model.m
+++ b/Source/Objects/Custom Hardware/SNO+/XL3/ORXL3Model.m
@@ -1458,7 +1458,7 @@ void SwapLongBlock(void* p, int32_t n)
         if (![fec dcPresent:dbNum]) continue;
 
         db = [fec dc:dbNum];
-            
+
         for (channel = 0; channel < 8; channel++) {
             mb->vThr[dbNum*8+channel] = [db vt:channel];
             mb->tCmos.tacShift[dbNum*8+channel] = [db tac0trim:channel];
@@ -1660,6 +1660,158 @@ void SwapLongBlock(void* p, int32_t n)
 }
 
 #pragma mark •••Hardware Access
+
+- (void) loadTriggers
+{
+    /* Loads the current GUI channel trigger settings to the hardware. This
+     * function will block and so should only be called on a separate thread.
+     * This function will raise an exception if any error occurs. */
+    int slot, dbNum, channel;
+    char payload[XL3_PAYLOAD_SIZE];
+    memset(&payload, 0, sizeof(payload));
+
+    MultiSetCrateTriggersArgs *args = (MultiSetCrateTriggersArgs *) payload;
+
+    args.slotMask = 0;
+
+    for (slot = 0; slot < 16; slot++) {
+        args.tr100Masks[slot] = 0;
+        args.tr20Masks[slot] = 0;
+    }
+
+    for (slot = 0; slot < 16; slot++) {
+        fec = [[OROrderedObjManager for:[self guardian]] objectInSlot:16-slot];
+
+        if (!fec) continue;
+
+        args.slotMask |= 1 << slot;
+
+        if ([self isTriggerON]) {
+            for (dbNum = 0; dbNum < 4; dbNum++) {
+                if (![fec dcPresent:dbNum]) continue;
+
+                db = [fec dc:dbNum];
+
+                for (channel = 0; channel < 8; channel++) {
+                    if ([fec trigger100nsEnabled: (dbNum*8 + channel)]) {
+                        args.tr100Masks[slot] |= 1 << (dbNum*8+channel);
+                    }
+
+                    if ([fec trigger20nsEnabled: (dbNum*8 + channel)]) {
+                        args.tr20Masks[slot] |= 1 << (dbNum*8+channel);
+                    }
+                }
+            }
+        }
+    }
+
+    /* Convert args to network byte order. */
+    args.slotMask = htonl(args.slotMask);
+
+    for (slot = 0; slot < 16; slot++) {
+        args.tr100Masks[slot] = htonl(args.tr100Masks[slot]);
+        args.tr20Masks[slot] = htonl(args.tr20Masks[slot]);
+    }
+
+    [[self xl3Link] sendCommand:MULTI_SET_CRATE_TRIGGERS_ID withPayload:payload expectResponse:YES];
+
+    MultiSetCrateTriggersResults *results = (MultiSetCrateTriggersResults *) payload;
+
+    if (ntohl(results->errorMask)) {
+        NSException *e = [NSException exceptionWithName:@"loadTriggersError"
+                          reason:@"failed to load channel triggers"
+                          userInfo:nil];
+        [e raise]
+    }
+}
+
+- (void) disableTriggers
+{
+    /* Turns off all channel level triggers. This function does *not* update
+     * the GUI so once this function is called, the GUI will most likely be in
+     * an inconsistent state. This can be useful in certain situations like ECA
+     * runs where you want to disable channel triggers but then load them back
+     * at the end of the run. This function will block until the operation
+     * completes. This function will raise an exception if any error occurs. */
+    int slot, dbNum, channel;
+    char payload[XL3_PAYLOAD_SIZE];
+    memset(&payload, 0, sizeof(payload));
+
+    MultiSetCrateTriggersArgs *args = (MultiSetCrateTriggersArgs *) payload;
+
+    args.slotMask = [self getSlotsPresent];
+
+    for (slot = 0; slot < 16; slot++) {
+        args.tr100Masks[slot] = 0;
+        args.tr20Masks[slot] = 0;
+    }
+
+    /* Convert args to network byte order. */
+    args.slotMask = htonl(args.slotMask);
+
+    for (slot = 0; slot < 16; slot++) {
+        args.tr100Masks[slot] = htonl(args.tr100Masks[slot]);
+        args.tr20Masks[slot] = htonl(args.tr20Masks[slot]);
+    }
+
+    [[self xl3Link] sendCommand:MULTI_SET_CRATE_TRIGGERS_ID withPayload:payload expectResponse:YES];
+
+    MultiSetCrateTriggersResults *results = (MultiSetCrateTriggersResults *) payload;
+
+    if (ntohl(results->errorMask)) {
+        NSException *e = [NSException exceptionWithName:@"loadTriggersError"
+                          reason:@"failed to load channel triggers"
+                          userInfo:nil];
+        [e raise]
+    }
+}
+
+- (void) loadSequencers
+{
+    /* Loads the current GUI channel sequencer settings to the hardware. This
+     * function will block and so should only be called on a separate thread.
+     * This function will raise an exception if any error occurs. */
+    int slot, dbNum, channel;
+    char payload[XL3_PAYLOAD_SIZE];
+    memset(&payload, 0, sizeof(payload));
+
+    MultiSetCrateSequencersArgs *args = (MultiSetCrateSequencersArgs *) payload;
+
+    args.slotMask = 0;
+
+    for (slot = 0; slot < 16; slot++) {
+        args.channelMasks[slot] = 0;
+    }
+
+    for (slot = 0; slot < 16; slot++) {
+        fec = [[OROrderedObjManager for:[self guardian]] objectInSlot:16-slot];
+
+        if (!fec) continue;
+
+        args.slotMask |= 1 << slot;
+
+        args.channelMasks[slot] = ~[fec seqDisabledMask];
+    }
+
+    /* Convert args to network byte order. */
+    args.slotMask = htonl(args.slotMask);
+
+    for (slot = 0; slot < 16; slot++) {
+        args.channelMasks[slot] = htonl(args.channelMasks[slot]);
+    }
+
+    [[self xl3Link] sendCommand:MULTI_SET_CRATE_SEQUENCERS_ID withPayload:payload expectResponse:YES];
+
+    MultiSetCrateSequencersResults *results = (MultiSetCrateSequencersResults *) payload;
+
+    if (ntohl(results->errorMask)) {
+        NSException *e = [NSException exceptionWithName:@"loadSequencersError"
+                          reason:@"failed to load channel sequencers"
+                          userInfo:nil];
+        [e raise]
+    }
+}
+
 - (void) deselectCards
 {
 	[[self xl3Link] sendCommand:DESELECT_FECS_ID expectResponse:YES];

--- a/Source/Objects/Custom Hardware/SNO+/XL3/PacketTypes.h
+++ b/Source/Objects/Custom Hardware/SNO+/XL3/PacketTypes.h
@@ -56,6 +56,10 @@
  * would first run RESET_CRATE_ID and then you would do a CRATE_INIT without
  * Xilinx to load the non-default values into the FEC. */
 #define RESET_CRATE_ID            (0x34) 
+/* Set the sequencer mask for multiple slots at a time. */
+#define MULTI_SET_CRATE_SEQUENCERS_ID (0x35)
+/* Set the trigger mask for multiple slots at a time. */
+#define MULTI_SET_CRATE_TRIGGERS_ID   (0x36)
 // HV Tasks
 #define SET_HV_RELAYS_ID          (0x40) //!< turns on/off hv relays
 #define HV_READBACK_ID			      (0x42) //!< reads voltage and current	
@@ -438,6 +442,25 @@ typedef struct {
   uint32_t fecPresent; // each bit is 1 if that slot as a FEC, 0 if not
   FECConfiguration hwareVals[16];
 } ResetCrateResults;
+
+typedef struct {
+  uint32_t slotMask;
+  uint32_t channelMasks[16];
+} MultiSetCrateSequencersArgs;
+
+typedef struct {
+  uint32_t errorMask;
+} MultiSetCrateSequencersResults;
+
+typedef struct {
+  uint32_t slotMask;
+  uint32_t tr100Masks[16];
+  uint32_t tr20Masks[16];
+} MultiSetCrateTriggersArgs;
+
+typedef struct {
+  uint32_t errorMask;
+} MultiSetCrateTriggersResults;
 
 typedef struct{
     uint32_t slot;


### PR DESCRIPTION
This pull request adds several functions to the XL3 model which allow one to set just the channel triggers and sequencers independently of loading the rest of the crate settings. It also adds a new function `disableTriggers` to the XL3 model which has the following properties:

- doesn't update the GUI
- raises an exception if there was an error
- blocks until the settings have been loaded

This function will be useful for the ECA run since it will ideally want to disable channel triggers, run the ECA run and then reload all the channel trigger settings afterwards.