### PR TITLE
	Fixed problem where CAEN run mode wasn't set properly on hardware reset

### DIFF
--- a/Source/Objects/Custom Hardware/SNO+/CAEN/SNOCaenModel.m
+++ b/Source/Objects/Custom Hardware/SNO+/CAEN/SNOCaenModel.m
@@ -1031,6 +1031,7 @@ NSString* SNOCaenModelContinuousModeChanged              = @"SNOCaenModelContinu
 	[self writeOverUnderThresholds];
 	[self writeDacs];
 	[self writePostTriggerSetting];
+    [self writeAcquistionControl:NO]; // must do this again since it was cleared by the software reset
 }
 
 - (float) convertDacToVolts:(unsigned short)aDacValue 


### PR DESCRIPTION
Run mode is cleared by software reset, so we must write it again.
Requires testing on hardware.