### PR TITLE
	SNO+: Read MB and DC ID's from detector database

### DIFF
--- a/Source/Objects/Custom Hardware/SNO+/Fec32/ORFec32Model.m
+++ b/Source/Objects/Custom Hardware/SNO+/Fec32/ORFec32Model.m
@@ -1823,6 +1823,15 @@ static int              sChannelsNotChangedCount = 0;
         if (fec->valid[kFEC_hvref]) {
             [self setHVRef:fec->hvref];
         }
+        if (fec->valid[kFEC_mbid]) {
+            [self setBoardID:[NSString stringWithFormat:@"%x", fec->mbid]];
+        }
+        for (int i=0; i<kNumDbPerFec; ++i) {
+            if ((fec->valid[kFEC_dbid] & (1 << i)) && dcPresent[i]) {
+                [dc[i] setBoardID:[NSString stringWithFormat:@"%x", fec->dbid[i]]];
+            }
+        }
+        //TODO: set PMTIC ID's
     }
     @finally {
         [ORSNOCard enableNotifications];

--- a/Source/Objects/Misc Objects/PostgreSQL/ORPQModel.h
+++ b/Source/Objects/Misc Objects/PostgreSQL/ORPQModel.h
@@ -56,11 +56,15 @@ enum {
     kFEC_tcmosIseta,
     kFEC_vres,      // (vint in the database)
     kFEC_hvref,
+    kFEC_mbid,
+    kFEC_dbid,
+    kFEC_pmticid,
     kFEC_numDbColumns
 };
 
 #define kNumFecTdisc    8
 #define kNumFecIset     2
+#define kNumDbPerFec    4
 
 typedef struct {
     uint32_t        hvDisabled;   // resistor pulled or no cable
@@ -86,6 +90,9 @@ typedef struct {
     uint32_t        tcmosIseta[kNumFecIset];
     uint32_t        vres;
     uint32_t        hvref;
+    uint32_t        mbid;                       // motherboard ID
+    uint32_t        dbid[kNumDbPerFec];         // daughterboard ID's
+    uint32_t        pmticid;                    // PMTIC ID
     uint32_t        valid[kFEC_numDbColumns];   // bitmasks for settings loaded from hardware (see enum above)
 } PQ_FEC;
 

--- a/Source/Objects/Misc Objects/PostgreSQL/ORPQModel.m
+++ b/Source/Objects/Misc Objects/PostgreSQL/ORPQModel.m
@@ -561,8 +561,8 @@ static NSString* ORPQModelInConnector 	= @"ORPQModelInConnector";
 //
     [command autorelease];
     // (funny, but tcmos_tacshift=tac0trim and scmos=tac1trim)
-    //      0     1    2          3           4         5          6          7      8      9              10    11   12            13           14          15        16        17        18         19           20          21          22   23
-    cols = "crate,slot,tr100_mask,tr100_delay,tr20_mask,tr20_width,tr20_delay,vbal_0,vbal_1,tcmos_tacshift,scmos,vthr,pedestal_mask,disable_mask,tdisc_rmpup,tdisc_rmp,tdisc_vsi,tdisc_vli,tcmos_vmax,tcmos_tacref,tcmos_isetm,tcmos_iseta,vint,hvref";
+    //      0     1    2          3           4         5          6          7      8      9              10    11   12            13           14          15        16        17        18         19           20          21          22   23    24   25   26
+    cols = "crate,slot,tr100_mask,tr100_delay,tr20_mask,tr20_width,tr20_delay,vbal_0,vbal_1,tcmos_tacshift,scmos,vthr,pedestal_mask,disable_mask,tdisc_rmpup,tdisc_rmp,tdisc_vsi,tdisc_vli,tcmos_vmax,tcmos_tacref,tcmos_isetm,tcmos_iseta,vint,hvref,mbid,dbid,pmticid";
     command = [[NSString stringWithFormat: @"SELECT %s FROM current_detector_state",cols] retain];
     @try {
         theResult = [pqConnection queryString:command];
@@ -681,6 +681,15 @@ static NSString* ORPQModelInConnector 	= @"ORPQModelInConnector";
                             break;
                         case kFEC_hvref:
                             pqFEC->hvref = val;
+                            break;
+                        case kFEC_mbid:
+                            pqFEC->mbid = val;
+                            break;
+                        case kFEC_dbid:
+                            if (ch < kNumDbPerFec) pqFEC->dbid[ch] = val;
+                            break;
+                        case kFEC_pmticid:
+                            pqFEC->pmticid = val;
                             break;
                     }
                 }


### PR DESCRIPTION
Sets ORCA FEC32 and DaughterCard ID's from detector database when loaded.
Tested without hardware and it seems to work.