### PR TITLE
SNO+: update clearGlobalTriggerWordMask in MTC model

### DIFF
--- a/Source/Objects/Custom Hardware/SNO+/MTC/ORMTCModel.m
+++ b/Source/Objects/Custom Hardware/SNO+/MTC/ORMTCModel.m
@@ -1230,16 +1230,15 @@ tubRegister;
 
 - (void) clearGlobalTriggerWordMask
 {
-	@try {
-        [self setGtMask:0];
-        [self setGlobalTriggerWordMask];
-		NSLog(@"Cleared GT Mask\n");
-	}
-	@catch(NSException* localException) {
-		NSLog(@"Could not clear GT word mask!\n");					
-		NSLog(@"Exception: %@\n",localException);
-		[localException raise];
-	}
+    @try {
+        [mtc okCommand:"set_gt_mask %lu", 0];
+        NSLog(@"Cleared GT Mask\n");
+    }
+    @catch(NSException* localException) {
+        NSLog(@"Could not clear GT word mask!\n");
+        NSLog(@"Exception: %@\n",localException);
+        [localException raise];
+    }
 }
 
 - (void) setGlobalTriggerWordMask


### PR DESCRIPTION
The clearGlobalTriggerWordMask in the MTC model will now clear the global
trigger mask without updating the GUI.

This fixes a bug in the recent MTC updates which caused a new run to clear the GT mask on every run start.