### PR TITLE
Remove window duplication for SNOP dialogs

### DIFF
--- a/Source/Experiments/SNOP/SNOPController.h
+++ b/Source/Experiments/SNOP/SNOPController.h
@@ -178,6 +178,7 @@
 
 - (void) updateSettings: (NSNotification *) aNote;
 - (void) initializeUnits;
+- (void) duplicateDialog:(id)dialog;
 #pragma mark ¥¥¥Actions
 
 - (IBAction) orcaDBIPAddressAction:(id)sender;

--- a/Source/Experiments/SNOP/SNOPController.m
+++ b/Source/Experiments/SNOP/SNOPController.m
@@ -288,6 +288,9 @@ snopGreenColor;
     }
 }
 
+- (void) duplicateDialog:(id)dialog {
+    return;
+}
 #pragma mark ¥¥¥Notifications
 - (void) registerNotificationObservers
 {

--- a/Source/Main Document/ORDocument.m
+++ b/Source/Main Document/ORDocument.m
@@ -613,7 +613,10 @@ static NSString* ORDocumentScaleFactor  = @"ORDocumentScaleFactor";
 #pragma mark ¥¥¥Orca Dialog Management
 - (void) duplicateDialog:(id)dialog
 {
-    
+    if ([[dialog class] instancesRespondToSelector:@selector(duplicateDialog:)]) {
+        [dialog duplicateDialog:dialog];
+        return;
+    }
     id controller = [[NSClassFromString([dialog className]) alloc] init];
     
     if([controller isKindOfClass:[OrcaObjectController class]]){

--- a/Source/Objects/Custom Hardware/SNO+/CAEN/SNOCaenController.h
+++ b/Source/Objects/Custom Hardware/SNO+/CAEN/SNOCaenController.h
@@ -148,9 +148,8 @@
 - (void) totalRateChanged:(NSNotification*)aNote;
 - (void) slotChanged:(NSNotification*)aNote;
 - (void) continousRunsChanged:(NSNotification*)aNote;
-
 - (void) setBufferStateLabel;
-
+- (void) duplicateDialog:(id)dialog;
 #pragma mark •••Actions
 - (IBAction) eventSizeAction:(id)sender;
 - (IBAction) integrationAction:(id)sender;

--- a/Source/Objects/Custom Hardware/SNO+/CAEN/SNOCaenController.m
+++ b/Source/Objects/Custom Hardware/SNO+/CAEN/SNOCaenController.m
@@ -354,6 +354,10 @@ static int chanConfigToMaskBit[kNumChanConfigBits] = {1,3,4,6,11};
 	}
 }
 
+- (void) duplicateDialog:(id)dialog {
+    return;
+}
+
 - (void) totalRateChanged:(NSNotification*)aNotification
 {
 	ORRateGroup* theRateObj = [aNotification object];

--- a/Source/Objects/Custom Hardware/SNO+/ELLIE/ELLIEController.h
+++ b/Source/Objects/Custom Hardware/SNO+/ELLIE/ELLIEController.h
@@ -141,6 +141,7 @@
 
 -(void)tellieRunFinished:(NSNotification *)aNote;
 -(void)initialiseTellie;
+- (void) duplicateDialog:(id)dialog;
 
 //Server tab functions -----------------------------
 - (IBAction)telliePing:(id)sender;

--- a/Source/Objects/Custom Hardware/SNO+/ELLIE/ELLIEController.m
+++ b/Source/Objects/Custom Hardware/SNO+/ELLIE/ELLIEController.m
@@ -193,6 +193,10 @@ NSString* ORTELLIERunStart = @"ORTELLIERunStarted";
     [tellieTriggerDelayTf setStringValue:@"700"];
 }
 
+- (void) duplicateDialog:(id)dialog {
+    return;
+}
+
 -(IBAction)tellieGeneralFireAction:(id)sender
 {
     ////////////

--- a/Source/Objects/Custom Hardware/SNO+/Fec32/ORFec32Controller.h
+++ b/Source/Objects/Custom Hardware/SNO+/Fec32/ORFec32Controller.h
@@ -143,6 +143,7 @@
 - (void) update20nTriggerInfo:(NSNotification*)aNote;
 - (void) update100nTriggerInfo:(NSNotification*)aNote;
 - (void) updateCmosReadInfo:(NSNotification*)aNote;
+- (void) duplicateDialog:(id)dialog;
 
 #pragma mark •••Actions
 - (IBAction) readCmosRatesAction:(id)sender;

--- a/Source/Objects/Custom Hardware/SNO+/Fec32/ORFec32Controller.m
+++ b/Source/Objects/Custom Hardware/SNO+/Fec32/ORFec32Controller.m
@@ -410,6 +410,10 @@
     }
 }
 
+- (void) duplicateDialog:(id)dialog {
+    return;
+}
+
 - (void) dcThresholdsChanged:(NSNotification*)aNote
 {
 	int i;

--- a/Source/Objects/Custom Hardware/SNO+/FecDaughterCard/ORFecDaughterCardController.h
+++ b/Source/Objects/Custom Hardware/SNO+/FecDaughterCard/ORFecDaughterCardController.h
@@ -81,7 +81,7 @@
 - (void) tac0trimChanged:(NSNotification*)aNote; 	   
 - (void) tac1trimChanged:(NSNotification*)aNote;
 - (void) boardIdChanged:(NSNotification*)aNote;
-
+- (void) duplicateDialog:(id)dialog;
 #pragma mark •••Actions
 - (IBAction) lockAction:(id)sender;
 - (IBAction) showVoltsAction:(id)sender;

--- a/Source/Objects/Custom Hardware/SNO+/FecDaughterCard/ORFecDaughterCardController.m
+++ b/Source/Objects/Custom Hardware/SNO+/FecDaughterCard/ORFecDaughterCardController.m
@@ -238,6 +238,10 @@
 	[crateNumberField setIntValue:[[[model guardian] guardian] crateNumber]];
 }
 
+- (void) duplicateDialog:(id)dialog {
+    return;
+}
+
 - (void) boardIdChanged:(NSNotification*)aNote
 {
 	[boardIdField setStringValue:[model boardID]];

--- a/Source/Objects/Custom Hardware/SNO+/MTC/ORMTCController.h
+++ b/Source/Objects/Custom Hardware/SNO+/MTC/ORMTCController.h
@@ -157,6 +157,7 @@
 - (int) trigger_scan_name_to_index:(NSString*) name;
 - (int) index_to_trigger_scan_name:(int) index;
 - (void) showHideOptions:(id) sender Box:(id)box resizeSmall:(NSSize) smallSize resizeLarge:(NSSize) largeSize;
+- (void) duplicateDialog:(id)dialog;
 
 
 #pragma mark •••Actions

--- a/Source/Objects/Custom Hardware/SNO+/MTC/ORMTCController.m
+++ b/Source/Objects/Custom Hardware/SNO+/MTC/ORMTCController.m
@@ -1324,4 +1324,8 @@
         }
     }
 }
+- (void) duplicateDialog:(id)dialog {
+    return;
+}
+
 @end

--- a/Source/Objects/Custom Hardware/SNO+/SNOCrate/ORSNOCrateController.h
+++ b/Source/Objects/Custom Hardware/SNO+/SNOCrate/ORSNOCrateController.h
@@ -44,6 +44,7 @@
 #pragma mark •••Interface Management
 - (void) slotChanged:(NSNotification*)aNote;
 - (void) setModel:(id)aModel;
+- (void) duplicateDialog:(id)dialog;
 
 #pragma mark •••Actions
 - (IBAction) incCrateAction:(id)sender;

--- a/Source/Objects/Custom Hardware/SNO+/SNOCrate/ORSNOCrateController.m
+++ b/Source/Objects/Custom Hardware/SNO+/SNOCrate/ORSNOCrateController.m
@@ -119,6 +119,10 @@
 	[crateNumberField setIntValue:[model crateNumber]];
 }
 
+- (void) duplicateDialog:(id)dialog {
+    return;
+}
+
 #pragma mark •••Actions
 - (IBAction) incCrateAction:(id)sender
 {

--- a/Source/Objects/Custom Hardware/SNO+/SNORack/ORSNORackController.h
+++ b/Source/Objects/Custom Hardware/SNO+/SNORack/ORSNORackController.h
@@ -48,6 +48,7 @@
 - (BOOL) validateMenuItem:(NSMenuItem*)aMenuItem;
 - (void) documentLockChanged:(NSNotification*)aNote;
 - (void) setCrateLabels;
+- (void) duplicateDialog:(id)dialog;
 
 - (IBAction) delete:(id)sender; 
 - (IBAction) cut:(id)sender; 

--- a/Source/Objects/Custom Hardware/SNO+/SNORack/ORSNORackController.m
+++ b/Source/Objects/Custom Hardware/SNO+/SNORack/ORSNORackController.m
@@ -135,6 +135,10 @@
 	else [crate1Field setStringValue:@""];
 }
 
+- (void) duplicateDialog:(id)dialog {
+    return;
+}
+
 - (void) setCrateTitle
 {
 	[[self window] setTitle:[NSString stringWithFormat:@"SNO crate %lu",[model uniqueIdNumber]]];

--- a/Source/Objects/Custom Hardware/SNO+/TUBii/TUBiiController.h
+++ b/Source/Objects/Custom Hardware/SNO+/TUBii/TUBiiController.h
@@ -138,7 +138,7 @@
 - (void) SendBitInfo:(NSUInteger) maskVal FromBit:(int)low ToBit:(int) high ToCheckBoxes: (NSMatrix*) aMatrix;
 - (void) tabView:(NSTabView*)aTabView didSelectTabViewItem:(NSTabViewItem*)item;
 - (void) tubiiLockChanged:(NSNotification*)aNote;
-
+- (void) duplicateDialog:(id)dialog;
 - (IBAction)InitializeClicked:(id)sender;
 - (IBAction)SendPing:(id)sender;
 - (IBAction)DataReadoutChanged:(id)sender;

--- a/Source/Objects/Custom Hardware/SNO+/TUBii/TUBiiController.m
+++ b/Source/Objects/Custom Hardware/SNO+/TUBii/TUBiiController.m
@@ -186,6 +186,10 @@
     
 }
 
+- (void) duplicateDialog:(id)dialog {
+    return;
+}
+
 - (void) tabView:(NSTabView*)aTabView didSelectTabViewItem:(NSTabViewItem*)item
 {
     int tabIndex = [aTabView indexOfTabViewItem:item];

--- a/Source/Objects/Custom Hardware/SNO+/XL3/XL3_LinkController.h
+++ b/Source/Objects/Custom Hardware/SNO+/XL3/XL3_LinkController.h
@@ -190,6 +190,7 @@
 - (void) autoIncrementChanged:(NSNotification*)aNote;
 - (void) basicOpsRunningChanged:(NSNotification*)aNote;
 - (void) writeValueChanged:(NSNotification*)aNote;
+- (void) duplicateDialog:(id)dialog;
 //composite
 - (void) compositeXl3ModeRunningChanged:(NSNotification*)aNote;
 - (void) compositeXl3ModeChanged:(NSNotification*)aNote;

--- a/Source/Objects/Custom Hardware/SNO+/XL3/XL3_LinkController.m
+++ b/Source/Objects/Custom Hardware/SNO+/XL3/XL3_LinkController.m
@@ -537,7 +537,9 @@ static NSDictionary* xl3Ops;
 	[selectedRegisterPU selectItemAtIndex: [model selectedRegister]];
 }); }
 
-
+- (void) duplicateDialog:(id)dialog {
+    return;
+}
 #pragma mark •composite
 - (void) compositeXl3ModeChanged:(NSNotification*)aNote
 { dispatch_async(dispatch_get_main_queue(), ^{


### PR DESCRIPTION
Fixes #291, which was already closed. But I think we can agree it's best not to have two dialogs when there really shouldn't ever be for most SNO+ things. 

We'll probably have to get Mark Howe approval for this one, but it's probably worth having others here look at it first.