### PR TITLE
SNO+: New features for standard runs

### DIFF
--- a/Source/Experiments/SNOP/SNOPController.h
+++ b/Source/Experiments/SNOP/SNOPController.h
@@ -207,23 +207,23 @@
 - (IBAction) emergencySmellieStopAction:(id)sender;
 
 //tellie functions ---------------------
--(IBAction)startTellieRunAction:(id)sender;
+- (IBAction)startTellieRunAction:(id)sender;
 - (IBAction) stopTellieRunAction:(id)sender;
--(void)startTellieRunNotification:(NSNotification *)notification;
+- (void)startTellieRunNotification:(NSNotification *)notification;
 
 //xl3 mode status
 - (IBAction)updatexl3Mode:(id)sender;
 
 #pragma mark ¥¥¥Details Interface Management
 - (void) tabView:(NSTabView*)aTabView didSelectTabViewItem:(NSTabViewItem*)tabViewItem;
--(void) windowDidLoad;
+- (void) windowDidLoad;
 
 - (IBAction) runsLockAction:(id)sender;
 - (IBAction) refreshStandardRunsAction: (id) sender;
+- (void) refreshStandardRunVersions;
 
 //Run type
 - (IBAction) runTypeWordAction:(id)sender;
-- (void) refreshStandardRunVersions;
 @end
 
 extern NSString* ORSNOPRequestHVStatus;

--- a/Source/Experiments/SNOP/SNOPController.m
+++ b/Source/Experiments/SNOP/SNOPController.m
@@ -267,11 +267,10 @@ snopGreenColor;
     [self runTypeWordChanged:nil];
     //Lock Standard Runs menus at init
     if([model standardRunType] == nil){
-        [standardRunPopupMenu setEnabled:false];
         [standardRunVersionPopupMenu setEnabled:false];
     }
     else{
-        [self refreshStandardRunsAction:nil];
+        [model refreshStandardRunsFromDB];
     }
 
     if(!doggy_icon)
@@ -337,6 +336,11 @@ snopGreenColor;
                        object: nil];
     
     [notifyCenter addObserver:self
+                     selector:@selector(standardRunsCollectionChanged:)
+                         name:ORSNOPModelSRCollectionChangedNotification
+                         object:nil];
+
+    [notifyCenter addObserver:self
                      selector:@selector(SRTypeChanged:)
                          name:ORSNOPModelSRChangedNotification
                        object:nil];
@@ -353,9 +357,14 @@ snopGreenColor;
     
     [notifyCenter addObserver : self
                      selector : @selector(runsLockChanged:)
+                         name : ORSecurityNumberLockPagesChanged
+                       object : nil];
+
+    [notifyCenter addObserver : self
+                     selector : @selector(runsLockChanged:)
                          name : ORSNOPRunsLockNotification
                        object : nil];
-    
+
     [notifyCenter addObserver : self
                      selector : @selector(runsLockChanged:)
                          name : ORRunStatusChangedNotification
@@ -435,32 +444,32 @@ snopGreenColor;
 
 -(void) SRTypeChanged:(NSNotification*)aNote
 {
+
     NSString* standardRun = [model standardRunType];
     if([standardRunPopupMenu numberOfItems] == 0 || standardRun == nil || [standardRun isEqualToString:@""]){
-        //NSLogColor([NSColor redColor],@"Please refresh the Standard Runs DB. \n");
         return;
     }
     if([standardRunPopupMenu indexOfItemWithObjectValue:standardRun] == NSNotFound){
-        NSLogColor([NSColor redColor],@"Standard Run \"%@\" does not exist in DB. \n",standardRun);
+        NSLogColor([NSColor redColor],@"Standard Run \"%@\" does not exist. \n", standardRun);
         return;
     }
     else{
         [standardRunPopupMenu selectItemWithObjectValue:standardRun];
         [self refreshStandardRunVersions];
     }
-    
+
 }
 
 //Update the SR diplay when SR changes
 -(void) SRVersionChanged:(NSNotification*)aNote
 {
+
     NSString* standardRunVersion = [model standardRunVersion];
     if([standardRunVersionPopupMenu numberOfItems] == 0 || standardRunVersion == nil || [standardRunVersion isEqualToString:@""]){
-        //NSLogColor([NSColor redColor],@"Please refresh the Standard Runs DB. \n",standardRunVersion);
         return;
     }
     if([standardRunVersionPopupMenu indexOfItemWithObjectValue:standardRunVersion] == NSNotFound){
-        NSLogColor([NSColor redColor],@"Standard Run Version \"%@\" does not exist in DB. \n",standardRunVersion);
+        NSLogColor([NSColor redColor],@"Standard Run Version \"%@\" does not exist. \n",standardRunVersion);
         return;
     }
     else{
@@ -493,11 +502,11 @@ snopGreenColor;
 
     //Handle no SR cases
     if([standardRun isEqualToString:@""] || standardRun == nil){
-        NSLogColor([NSColor redColor],@"Standard Run not set. Please, refresh the Standard Runs. \n");
+        NSLogColor([NSColor redColor],@"Standard Run not set. Enter a valid name. \n");
         return;
     }
     if([standardRunVersion isEqualToString:@""] || standardRunVersion == nil){
-        NSLogColor([NSColor redColor],@"Standard Run Version not set. Please, refresh the Standard Runs. \n");
+        NSLogColor([NSColor redColor],@"Standard Run Version not set. Enter a valid name. \n");
         return;
     }
     
@@ -510,9 +519,11 @@ snopGreenColor;
 {
     /* A resync run does a hard stop and start without the user having to hit
      * stop run and then start run. Doing this resets the GTID, which resyncs
-     * crate 9 after it goes out of sync :).
-     *
-     * Does not load the standard run settings. */
+     * crate 9 after it goes out of sync :). */
+
+    //Load the standard run and stop run initialization if failed
+    if(![model loadStandardRun:[model standardRunType] withVersion:[model standardRunVersion]]) return;
+
     [model setResync:YES];
 
     if ([[model document] isDocumentEdited]) {
@@ -1376,7 +1387,7 @@ snopGreenColor;
     [debugDBClearButton setEnabled:!lockedOrNotRunningMaintenance];    
     
     //Display status
-    if(locked){
+    if(![gSecurity numberItemsUnlocked]){
         [lockStatusTextField setStringValue:@"OPERATOR MODE"];
         [lockStatusTextField setBackgroundColor:snopBlueColor];
     }
@@ -1663,7 +1674,7 @@ snopGreenColor;
     
     NSString *standardRun = [standardRunPopupMenu objectValueOfSelectedItem];
     NSString *standardRunVer = [standardRunVersionPopupMenu objectValueOfSelectedItem];
-    
+
     [model loadStandardRun:standardRun withVersion: standardRunVer];
     [model loadSettingsInHW];
     
@@ -1716,6 +1727,12 @@ snopGreenColor;
 
     //Create new SR version if does not exist
     if ([standardRunVersionPopupMenu indexOfItemWithObjectValue:standardRunVer] == NSNotFound && [standardRunVer isNotEqualTo:@""]){
+
+        if([standardRun isEqualToString:@"DIAGNOSTIC"]){
+            NSLog(@"You cannot create a version for a DIAGNOSTIC run.\n");
+            return;
+        }
+
         BOOL cancel = ORRunAlertPanel([NSString stringWithFormat:@"Creating new Version: \"%@\" of Standard Run: \"%@\"", standardRunVer, standardRun], @"Is this really what you want?",@"Cancel",@"Yes, Make New Version",nil);
         if(cancel){
             [standardRunVersionPopupMenu selectItemWithObjectValue:[model standardRunVersion]];
@@ -1777,12 +1794,13 @@ snopGreenColor;
     }
     thresholdsFromDB[row] = raw;
 }
+
 //Query the DB for the selected Standard Run name and version
 //and display the values in the GUI.
 -(void) displayThresholdsFromDB
 {
-    
-    //Get MTC model
+
+    /* Get models */
     NSArray*  objs = [[(ORAppDelegate*)[NSApp delegate] document] collectObjectsOfClass:NSClassFromString(@"ORMTCModel")];
     ORMTCModel* mtcModel;
     if ([objs count]) {
@@ -1791,73 +1809,32 @@ snopGreenColor;
         NSLogColor([NSColor redColor], @"couldn't find MTC model. Please add it to the experiment and restart the run.\n");
         return;
     }
-    
-    //If no SR: display null values
-    if([model standardRunType] == nil || [[model standardRunType] isEqualToString:@""]){
-        for (int i=0; i<[standardRunThresStoredValues numberOfRows];i++) {
-            [[standardRunThresStoredValues cellAtRow:i column:0] setStringValue:@"--"];
-        }
-        for(int ibit=0; ibit<21; ibit++){ //Data quality bits are not stored in the SR
-            [[runTypeWordSRMatrix cellAtRow:ibit column:0] setState:0];
-        }
-        NSLogColor([NSColor redColor],@"Standard Run not set: make sure the DB is accesible and refresh the standard runs. \n");
-        return;
-    }
-    //If no version: display null values and quit
-    if([model standardRunVersion] == nil || [[model standardRunVersion] isEqualToString:@""]){
-        for (int i=0; i<[standardRunThresStoredValues numberOfRows];i++) {
-            [[standardRunThresStoredValues cellAtRow:i column:0] setStringValue:@"--"];
-        }
-        for(int ibit=0; ibit<21; ibit++){ //Data quality bits are not stored in the SR
-            [[runTypeWordSRMatrix cellAtRow:ibit column:0] setState:0];
-        }
-        NSLogColor([NSColor redColor],@"Test Standard Run not set: make sure the DB is accesible and refresh the standard runs. \n");
-        return;
-    }
-    
-    //Fetch DB and display trigger configuration in GUI
-    //Query the OrcaDB and get a dictionary with the parameters
-    NSString* urlString = [NSString stringWithFormat:@"http://%@:%@@%@:%u/%@/_design/standardRuns/_view/getStandardRunsWithVersion?startkey=[%@,\"%@\",\"%@\",{}]&endkey=[%@,\"%@\",\"%@\",0]&descending=True&include_docs=True",
-                           [model orcaDBUserName],
-                           [model orcaDBPassword],
-                           [model orcaDBIPAddress],
-                           [model orcaDBPort],
-                           [model orcaDBName],
-                           [model standardRunTableVersion],
-                           [model standardRunType],
-                           [model standardRunVersion],
-                           [model standardRunTableVersion],
-                           [model standardRunType],
-                           [model standardRunVersion]];
 
-    NSString* link = [urlString stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
-    NSURLRequest* request = [NSURLRequest requestWithURL:[NSURL URLWithString:link] cachePolicy:0 timeoutInterval:2];
-    NSURLResponse* response = nil;
-    NSError* error = nil;
-    NSData* data = [NSURLConnection sendSynchronousRequest:request returningResponse:&response error:&error];
-    NSString *ret = [[[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding]autorelease];
-    NSDictionary *versionSettings = [NSJSONSerialization JSONObjectWithData:[ret dataUsingEncoding:NSUTF8StringEncoding] options:0 error:nil];
-    if(error) {
-        NSLogColor([NSColor redColor],@"Couldn't retrieve SR VERSION values. Error querying couchDB, please check the connection is correct. Error: \n %@ \n", error);
+    NSMutableDictionary* runSettings = [[[model standardRunCollection] objectForKey:[model standardRunType]] objectForKey:[model standardRunVersion]];
+    if(runSettings == nil){
+        NSLogColor([NSColor redColor], @"An error occurred: Refresh manually standard runs. \n");
+        for (int i=0; i<[standardRunThresStoredValues numberOfRows];i++) {
+            [[standardRunThresStoredValues cellAtRow:i column:0] setStringValue:@"--"];
+            [[standardRunThresStoredValues cellAtRow:i column:0] setTextColor:[self snopRedColor]];
+            if(i <10){
+                thresholdsFromDB[i] = -1;
+            }
+        }
+        for(int ibit=0; ibit<21; ibit++){ //Data quality bits are not stored in the SR
+            [[runTypeWordSRMatrix cellAtRow:ibit column:0] setState:0];
+        }
         return;
     }
 
     //Get run type word first
-    unsigned long dbruntypeword = [[[[[versionSettings valueForKey:@"rows"]     objectAtIndex:0] valueForKey:@"doc"] valueForKey:@"run_type_word"]  unsignedLongValue];
+    unsigned long dbruntypeword = [[runSettings valueForKey:@"run_type_word"] unsignedLongValue];
 
     //Setup format
     NSNumberFormatter *thresholdFormatter = [[[NSNumberFormatter alloc] init] autorelease];;
     [thresholdFormatter setFormat:@"##0.0"];
     
-    if([[versionSettings valueForKey:@"rows"] count] == 0){
-        for (int i=0; i<[standardRunThresStoredValues numberOfRows];i++) {
-            [[standardRunThresStoredValues cellAtRow:i column:0] setStringValue:@"--"];
-            thresholdsFromDB[i] = -1;
-        }
-        NSLogColor([NSColor redColor],@"Cannot display TEST RUN values. There was some problem with the Standard Run DataBase. \n");
-    }
     //If in DIAGNOSTIC run: display null threshold values
-    else if(dbruntypeword & kDiagnosticRun){
+    if([[model standardRunType] isEqualToString:@"DIAGNOSTIC"]){
         for (int i=0; i<[standardRunThresStoredValues numberOfRows];i++) {
             [[standardRunThresStoredValues cellAtRow:i column:0] setStringValue:@"--"];
             [[standardRunThresStoredValues cellAtRow:i column:0] setTextColor:[self snopRedColor]];
@@ -1871,16 +1848,16 @@ snopGreenColor;
     //If in non-DIAGNOSTIC run: display DB threshold values
     } else {
         float mVolts;
-        int gtmask = [[[[[versionSettings valueForKey:@"rows"] objectAtIndex:0] valueForKey:@"doc"] valueForKey:GTMaskSerializationString] intValue];
+        int gtmask = [[runSettings valueForKey:GTMaskSerializationString] intValue];
         
         for(int i=0;i<10;i++) {
-            float raw = [[[[[versionSettings valueForKey:@"rows"] objectAtIndex:0] valueForKey:@"doc"] valueForKey:[mtcModel stringForThreshold:view_model_map[i]]] floatValue];
+            float raw = [[runSettings valueForKey:[mtcModel stringForThreshold:view_model_map[i]]] floatValue];
             BOOL inMask = ((1<< view_mask_map[i]) & gtmask) != 0;
             [self updateSingleDBThresholdDisplayForRow:i inMask:inMask withModel:mtcModel withFormatter:thresholdFormatter toValue:raw];
         }
 
         //Prescale
-        mVolts = [[[[[versionSettings valueForKey:@"rows"] objectAtIndex:0] valueForKey:@"doc"] valueForKey:PrescaleValueSerializationString] floatValue];
+        mVolts = [[runSettings valueForKey:PrescaleValueSerializationString] floatValue];
         [[standardRunThresStoredValues cellAtRow:10 column:0] setFloatValue:mVolts];
         [[standardRunThresStoredValues cellAtRow:10 column:0] setFormatter:thresholdFormatter];
         if((gtmask >> 11) & 1){
@@ -1889,7 +1866,7 @@ snopGreenColor;
             [[standardRunThresStoredValues cellAtRow:10 column:0] setTextColor:[self snopRedColor]];
         }
         //Pulser
-        mVolts = [[[[[versionSettings valueForKey:@"rows"] objectAtIndex:0] valueForKey:@"doc"] valueForKey:PulserRateSerializationString] floatValue];
+        mVolts = [[runSettings valueForKey:PulserRateSerializationString] floatValue];
         [[standardRunThresStoredValues cellAtRow:11 column:0] setFloatValue:mVolts];
         [[standardRunThresStoredValues cellAtRow:11 column:0] setFormatter:thresholdFormatter];
         if((gtmask >> 10) & 1){
@@ -1903,14 +1880,6 @@ snopGreenColor;
     for(int ibit=0; ibit<21; ibit++){ //Data quality bits are not stored in the SR
         if((dbruntypeword >> ibit) & 1){
             [[runTypeWordSRMatrix cellAtRow:ibit column:0] setState:1];
-            /*
-             This is not used anymore but I'll leave it here as an example of how to change
-             color of an NSButton (Javi)
-             //Changing the color of a NSButton is not simple. You need all the following junk.
-             NSDictionary *dictAttr = [NSDictionary dictionaryWithObjectsAndKeys: snopBlackColor, NSForegroundColorAttributeName, nil];
-             NSAttributedString *attributedString = [[NSAttributedString alloc] initWithString:[[runTypeWordMatrix cellAtRow:ibit column:0] title] attributes:dictAttr];
-             [[runTypeWordMatrix cellAtRow:ibit column:0] setAttributedTitle:attributedString];
-             */
         } else{
             [[runTypeWordSRMatrix cellAtRow:ibit column:0] setState:0];
         }
@@ -1918,171 +1887,45 @@ snopGreenColor;
 
 }
 
-
-//Reload the standard run from the DB:
-//Queries the DB and populate the 'Run Name' popup menu
-//with the SR names. It selects automatically the old
-//SR if any. SR versions are refreshed as well afterwards.
-- (IBAction) refreshStandardRunsAction: (id) sender
+- (IBAction) refreshStandardRunsAction:(id)sender
 {
-    NSString *urlString, *link, *ret;
-    NSURLRequest *request;
-    NSURLResponse *response;
-    NSError *error = nil;
-    NSData *data;
-    
-    // Clear stored SRs
-    [standardRunPopupMenu deselectItemAtIndex:[standardRunPopupMenu indexOfSelectedItem]];
-    [standardRunPopupMenu removeAllItems];
-    [standardRunVersionPopupMenu deselectItemAtIndex:[standardRunVersionPopupMenu indexOfSelectedItem]];
-    [standardRunVersionPopupMenu removeAllItems];
-    
-    // Now query DB and fetch the SRs
-    urlString = [NSString stringWithFormat:@"http://%@:%@@%@:%u/%@/_design/standardRuns/_view/getStandardRunsWithVersion?startkey=[%@, \"\", \"\", 0]&endkey=[%@,\"\ufff0\",\"\ufff0\",{}]",
-                 [model orcaDBUserName],
-                 [model orcaDBPassword],
-                 [model orcaDBIPAddress],
-                 [model orcaDBPort],
-                 [model orcaDBName],
-                 [model standardRunTableVersion],
-                 [model standardRunTableVersion]];
-
-    link = [urlString stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
-    request = [NSURLRequest requestWithURL:[NSURL URLWithString:link] cachePolicy:0 timeoutInterval:2];
-    data = [NSURLConnection sendSynchronousRequest:request returningResponse:&response error:&error];
-    ret = [[[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding] autorelease];
-    NSDictionary *standardRunTypes = [NSJSONSerialization JSONObjectWithData:[ret dataUsingEncoding:NSUTF8StringEncoding] options:0 error:&error];
-    //JSON formatting error
-    if (error != nil) {
-        NSLogColor([NSColor redColor], @"Error reading standard runs from "
-                   "database: %@\n", [error localizedDescription]);
-        [model setStandardRunType:@""];
-        [model setStandardRunVersion:@""];
-        return;
-    }
-
-    //SR not found
-    if ([[standardRunTypes valueForKey:@"error"] isEqualToString:@"not_found"] || error != nil) {
-        [model setStandardRunType:@""];
-        [model setStandardRunVersion:@""];
-        NSLogColor([NSColor redColor],@"Error querying couchDB, please check the settings are correct and you have connection. \n");
-        [standardRunPopupMenu setEnabled:false];
-        [standardRunVersionPopupMenu setEnabled:false];
-        return;
-    }
-    
-    //Query succeded
-    [standardRunPopupMenu setEnabled:true];
-    for(id entry in [standardRunTypes valueForKey:@"rows"]){
-        NSString *runtype = [entry valueForKey:@"value"];
-        if(runtype != (id)[NSNull null]){
-            if([standardRunPopupMenu indexOfItemWithObjectValue:runtype]==NSNotFound)[standardRunPopupMenu addItemWithObjectValue:runtype];
-        }
-    }
-    
-    //Handle case with empty DB
-    if ([standardRunPopupMenu numberOfItems] == 0){
-        [model setStandardRunType:@""];
-    } else{
-        //Check if previous selected run exists
-        if([standardRunPopupMenu indexOfItemWithObjectValue:[model standardRunType]] == NSNotFound){
-            //Select first item in popup menu
-            [standardRunPopupMenu selectItemAtIndex:0];
-        }
-        else{
-            //Recover old run
-            [standardRunPopupMenu selectItemWithObjectValue:[model standardRunType]];
-        }
-        [model setStandardRunType:[standardRunPopupMenu stringValue]];
-    }
-    
+    [model refreshStandardRunsFromDB];
 }
 
-//Read the standard run versions from the DB:
-//Queries the DB for the specified Standard Run and populate
-//the 'Test run' popup menu with the SR versions
-- (void) refreshStandardRunVersions
+-(void) standardRunsCollectionChanged:(NSNotification*)aNote
 {
-    NSString *urlString, *link, *ret;
-    NSURLRequest *request;
-    NSURLResponse *response;
-    NSError *error = nil;
-    NSData *data;
-    
-    // Clear stored Versions
+    // Clear popup menus
+    [standardRunPopupMenu removeAllItems];
+    [standardRunVersionPopupMenu removeAllItems];
+
+    //Populate run type popup menu
+    for(NSString* aStandardRunType in [model standardRunCollection]){
+        [standardRunPopupMenu addItemWithObjectValue:aStandardRunType];
+    }
+}
+
+-(void) refreshStandardRunVersions
+{
+
     [standardRunVersionPopupMenu deselectItemAtIndex:[standardRunVersionPopupMenu indexOfSelectedItem]];
     [standardRunVersionPopupMenu removeAllItems];
-    
-    urlString = [NSString stringWithFormat:@"http://%@:%@@%@:%u/%@/_design/standardRuns/_view/getStandardRunsWithVersion?startkey=[%@, \"\", \"\", 0]&endkey=[%@,\"\ufff0\",\"\ufff0\",{}]",
-                 [model orcaDBUserName],
-                 [model orcaDBPassword],
-                 [model orcaDBIPAddress],
-                 [model orcaDBPort],
-                 [model orcaDBName],
-                 [model standardRunTableVersion],
-                 [model standardRunTableVersion]];
 
-    link = [urlString stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
-    request = [NSURLRequest requestWithURL:[NSURL URLWithString:link] cachePolicy:0 timeoutInterval:2];
-    data = [NSURLConnection sendSynchronousRequest:request returningResponse:&response error:&error];
-    ret = [[[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding] autorelease];
-    NSDictionary *standardRunVersions = [NSJSONSerialization JSONObjectWithData:[ret dataUsingEncoding:NSUTF8StringEncoding] options:0 error:&error];
+    NSString* standardRunVersion = [model standardRunVersion];
+    //Populate run version popup menu
+    for(NSString* aStandardRunVersion in [[model standardRunCollection] objectForKey:[model standardRunType]]){
+        [standardRunVersionPopupMenu addItemWithObjectValue:aStandardRunVersion];
+    }
 
-    //JSON formatting error
-    if (error != nil) {
-        NSLogColor([NSColor redColor], @"Error reading standard runs from "
-                   "database: %@\n", [error localizedDescription]);
-        [model setStandardRunVersion:@""];
+    if([standardRunVersionPopupMenu numberOfItems] == 0 || standardRunVersion == nil || [standardRunVersion isEqualToString:@""]){
         return;
     }
-
-    //SR not found
-    if ([[standardRunVersions valueForKey:@"error"] isEqualToString:@"not_found"] || error != nil)
-    {
-        [model setStandardRunVersion:@""];
-        NSLogColor([NSColor redColor],@"Error querying couchDB, please check the settings are correct and you have connection. \n");
-        [standardRunVersionPopupMenu setEnabled:false];
+    if([standardRunVersionPopupMenu indexOfItemWithObjectValue:standardRunVersion] == NSNotFound){
+        [standardRunVersionPopupMenu selectItemWithObjectValue:standardRunVersion];
         return;
     }
+    else{
+        [standardRunVersionPopupMenu selectItemWithObjectValue:standardRunVersion];
+    }
 
-    //Query succeded
-    BOOL optMode	= [gSecurity isLocked:ORSNOPRunsLockNotification]; //expert or operator mode
-    [standardRunVersionPopupMenu setEnabled:!optMode];
-    for(id entry in [standardRunVersions valueForKey:@"rows"]){
-        NSString *runtype = [[entry valueForKey:@"key"] objectAtIndex:1];
-        NSString *runversion = [[entry valueForKey:@"key"] objectAtIndex:2];
-        if(runversion != (id)[NSNull null]){
-            if([runtype isEqualToString:[model standardRunType]])
-                if([standardRunVersionPopupMenu indexOfItemWithObjectValue:runversion]==NSNotFound)[standardRunVersionPopupMenu addItemWithObjectValue:runversion];
-        }
-    }
-    
-    //Handle case with empty DB
-    if([standardRunVersionPopupMenu numberOfItems] == 0) {
-        [model setStandardRunVersion:@""];
-    } else{
-        //Check if old selected run exists
-        if([standardRunVersionPopupMenu indexOfItemWithObjectValue:[model standardRunVersion]] == NSNotFound){
-            //Select DEFAULT
-            if([standardRunVersionPopupMenu indexOfItemWithObjectValue:@"DEFAULT"] == NSNotFound){
-                [standardRunVersionPopupMenu selectItemWithObjectValue:@"DEFAULT"];
-            }
-            //If everything fails, select first item
-            else{
-                [standardRunVersionPopupMenu selectItemAtIndex:0];
-            }
-        }else{
-            //Recover old run
-            [standardRunVersionPopupMenu selectItemWithObjectValue:[model standardRunVersion]];
-        }
-        NSString *standardRunVersion = [standardRunVersionPopupMenu stringValue];
-        if(standardRunVersion != (id)[NSNull null]){
-            [model setStandardRunVersion:standardRunVersion];
-        }
-        else{
-            [model setStandardRunVersion:@""];
-        }
-    }
-    
 }
 @end

--- a/Source/Experiments/SNOP/SNOPModel.h
+++ b/Source/Experiments/SNOP/SNOPModel.h
@@ -100,11 +100,12 @@
     
     bool _smellieDBReadInProgress;
     bool _smellieDocUploaded;
-    NSString * standardRunType;
-    NSString * standardRunVersion;
-    NSString * lastStandardRunType;
-    NSString * lastStandardRunVersion;
-    NSNumber * standardRunTableVersion;
+    NSMutableDictionary* standardRunCollection;
+    NSString* standardRunType;
+    NSString* standardRunVersion;
+    NSString* lastStandardRunType;
+    NSString* lastStandardRunVersion;
+    NSNumber* standardRunTableVersion;
 
     bool rolloverRun;
 
@@ -220,6 +221,7 @@
 - (void) subRunStarted:(NSNotification*)aNote;
 - (void) subRunEnded:(NSNotification*)aNote;
 - (void) detectorStateChanged:(NSNotification*)aNote;
+- (void) enableGlobalSecurity;
 
 - (void) updateEPEDStructWithCoarseDelay: (unsigned long) coarseDelay
                                fineDelay: (unsigned long) fineDelay
@@ -241,6 +243,7 @@
 - (void) setLastRunTypeWord:(unsigned long)aMask;
 - (NSString*) lastRunTypeWordHex;
 - (void) setLastRunTypeWordHex:(NSString*)aValue;
+- (NSMutableDictionary*) standardRunCollection;
 - (NSString*) standardRunType;
 - (void) setStandardRunType:(NSString*)aValue;
 - (NSString*) standardRunVersion;
@@ -283,6 +286,7 @@
 -(void) startECARunInParallel;
 
 //Standard runs functions
+-(BOOL) refreshStandardRunsFromDB;
 -(BOOL) startStandardRun:(NSString*)_standardRun withVersion:(NSString*)_standardRunVersion;
 -(BOOL) loadStandardRun:(NSString*)runTypeName withVersion:(NSString*)runVersion;
 -(BOOL) saveStandardRun:(NSString*)runTypeName withVersion:(NSString*)runVersion;
@@ -308,5 +312,6 @@ extern NSString* ORSNOPModelDebugDBIPAddressChanged;
 extern NSString* ORSNOPRunTypeWordChangedNotification;
 extern NSString* SNOPRunTypeChangedNotification;
 extern NSString* ORSNOPRunsLockNotification;
+extern NSString* ORSNOPModelSRCollectionChangedNotification;
 extern NSString* ORSNOPModelSRChangedNotification;
 extern NSString* ORSNOPModelSRVersionChangedNotification;

--- a/Source/Experiments/SNOP/SNOPModel.m
+++ b/Source/Experiments/SNOP/SNOPModel.m
@@ -64,6 +64,7 @@ NSString* ORSNOPModelDebugDBIPAddressChanged = @"ORSNOPModelDebugDBIPAddressChan
 NSString* ORSNOPRunTypeWordChangedNotification = @"ORSNOPRunTypeWordChangedNotification";
 NSString* ORSNOPRunTypeChangedNotification = @"ORSNOPRunTypeChangedNotification";
 NSString* ORSNOPRunsLockNotification = @"ORSNOPRunsLockNotification";
+NSString* ORSNOPModelSRCollectionChangedNotification = @"ORSNOPModelSRCollectionChangedNotification";
 NSString* ORSNOPModelSRChangedNotification = @"ORSNOPModelSRChangedNotification";
 NSString* ORSNOPModelSRVersionChangedNotification = @"ORSNOPModelSRVersionChangedNotification";
 
@@ -273,6 +274,7 @@ resync;
     state = STOPPED;
     start = COLD_START;
     resync = NO;
+    [self enableGlobalSecurity];
 
     /* Initialize ECARun object: this doesn't start the run */
     anECARun = [[ECARun alloc] init];
@@ -297,6 +299,10 @@ resync;
 
     //Standard Runs
     [self setStandardRunTableVersion:[[NSNumber alloc] initWithInt:STANDARD_RUN_VERSION]];
+    standardRunCollection = [[NSMutableDictionary alloc] init];
+    [self setLastStandardRunType:[decoder decodeObjectForKey:@"SNOPlastStandardRunType"]];
+    [self setLastStandardRunVersion:[decoder decodeObjectForKey:@"SNOPlastStandardRunVersion"]];
+    [self setLastRunTypeWordHex:[decoder decodeObjectForKey:@"SNOPlastRunTypeWordHex"]];
 
     //ECA
     [anECARun setECA_pattern:[decoder decodeIntForKey:@"SNOPECApattern"]];
@@ -371,6 +377,8 @@ resync;
     [NSObject cancelPreviousPerformRequestsWithTarget:self];
     [[NSNotificationCenter defaultCenter] removeObserver:self];
     
+    [standardRunCollection removeAllObjects];
+    [standardRunCollection release];
     [standardRunType release];
     [standardRunVersion release];
     [standardRunTableVersion release];
@@ -796,6 +804,11 @@ err:
     }
 
     state = RUNNING;
+    [self setLastStandardRunType:[self standardRunType]];
+    [self setLastStandardRunVersion:[self standardRunVersion]];
+    [self setLastRunTypeWord:[self runTypeWord]];
+    NSString* _lastRunTypeWord = [NSString stringWithFormat:@"0x%X",(int)[self runTypeWord]];
+    [self setLastRunTypeWordHex:_lastRunTypeWord]; //FIXME: revisit if we go over 32 bits
 
     [self updateRHDRSruct];
     [self shipRHDRRecord];
@@ -968,6 +981,14 @@ err:
         }
         state = RUNNING;
     }
+}
+
+- (void) enableGlobalSecurity
+{
+
+    [[NSUserDefaults standardUserDefaults] setObject:[NSNumber numberWithBool:YES] forKey:OROrcaSecurityEnabled];
+    [[NSNotificationCenter defaultCenter] postNotificationName:ORGlobalSecurityStateChanged object:self userInfo:[NSDictionary dictionaryWithObject:[NSNumber numberWithBool:YES] forKey:OROrcaSecurityEnabled]];
+
 }
 
 // orca script helper (will come from DB)
@@ -1405,6 +1426,11 @@ static NSComparisonResult compareXL3s(ORXL3Model *xl3_1, ORXL3Model *xl3_2, void
             else if ([aTag isEqualToString:@"Message"]) {
                 [aResult prettyPrint:@"CouchDB Message:"];
             }
+            //Standard Runs querying
+            else if ([aTag isEqualToString:@"kStandardRunPosted"]) {
+                NSLog(@"Standard Run saved. \n");
+                [self refreshStandardRunsFromDB];
+            }
             else {
                 [aResult prettyPrint:@"CouchDB"];
             }
@@ -1526,6 +1552,11 @@ static NSComparisonResult compareXL3s(ORXL3Model *xl3_1, ORXL3Model *xl3_2, void
     [encoder encodeObject:self.debugDBName forKey:@"ORSNOPModelDebugDBName"];
     [encoder encodeInt32:self.debugDBPort forKey:@"ORSNOPModelDebugDBPort"];
     [encoder encodeObject:self.debugDBIPAddress forKey:@"ORSNOPModelDebugDBIPAddress"];
+
+    //Run status
+    [encoder encodeObject:[self lastStandardRunType] forKey:@"SNOPlastStandardRunType"];
+    [encoder encodeObject:[self lastStandardRunVersion] forKey:@"SNOPlastStandardRunVersion"];
+    [encoder encodeObject:[self lastRunTypeWordHex] forKey:@"SNOPlastRunTypeWordHex"];
 
     //ECA
     [encoder encodeInt:[anECARun ECA_pattern] forKey:@"SNOPECApattern"];
@@ -1776,6 +1807,11 @@ static NSComparisonResult compareXL3s(ORXL3Model *xl3_1, ORXL3Model *xl3_2, void
     lastRunTypeWordHex = [aValue copy];
 }
 
+- (NSMutableDictionary*)standardRunCollection
+{
+    return standardRunCollection;
+}
+
 - (NSString*)standardRunType
 {
     return standardRunType;
@@ -1785,8 +1821,23 @@ static NSComparisonResult compareXL3s(ORXL3Model *xl3_1, ORXL3Model *xl3_2, void
 {
     [standardRunType autorelease];//MAH -- strings should be handled like this
     standardRunType = [aValue copy];
-    
+
+    /* Update standard run version */
+    //Check if DB is empty
+    if([[standardRunCollection objectForKey:standardRunType] count] == 0){
+        [self setStandardRunVersion:@""];
+    }
+    //Check if previous selected run version exists
+    else if([[standardRunCollection objectForKey:standardRunType] objectForKey:standardRunVersion] == nil){
+        //If not, select first on the list
+        [self setStandardRunVersion:[[[standardRunCollection objectForKey:standardRunType] keyEnumerator] nextObject]];
+    }
+    else{
+        [self setStandardRunVersion:[self standardRunVersion]];
+    }
+
     [[NSNotificationCenter defaultCenter] postNotificationName:ORSNOPModelSRChangedNotification object:self];
+
 }
 
 - (NSString*)standardRunVersion
@@ -1866,11 +1917,6 @@ static NSComparisonResult compareXL3s(ORXL3Model *xl3_1, ORXL3Model *xl3_2, void
     [self setStandardRunVersion:_standardRunVersion];
 
     //Load the standard run and stop run initialization if failed
-    [self setLastStandardRunType:[self standardRunType]];
-    [self setLastStandardRunVersion:[self standardRunVersion]];
-    [self setLastRunTypeWord:[self runTypeWord]];
-    NSString* _lastRunTypeWord = [NSString stringWithFormat:@"0x%X",(int)[self runTypeWord]];
-    [self setLastRunTypeWordHex:_lastRunTypeWord]; //FIXME: revisit if we go over 32 bits
     if(![self loadStandardRun:_standardRun withVersion:_standardRunVersion]) return false;
 
     //Start or restart the run
@@ -1915,74 +1961,144 @@ static NSComparisonResult compareXL3s(ORXL3Model *xl3_1, ORXL3Model *xl3_2, void
 
 }
 
+-(BOOL) refreshStandardRunsFromDB
+{
+
+    //Prune the Standard Runs collection
+    [standardRunCollection removeAllObjects];
+
+    //First add Off-line standard runs
+    NSMutableDictionary* runSettings = [[NSMutableDictionary alloc] init];
+    NSMutableDictionary* versionCollection = [[NSMutableDictionary alloc] init];
+    NSNumber* diagRunType = [[NSNumber alloc] initWithInt:kDiagnosticRun];
+    [runSettings setObject:diagRunType forKey:@"run_type_word"];
+    [versionCollection setObject:[runSettings copy] forKey:@"DEFAULT"];
+    [standardRunCollection setObject:[versionCollection copy] forKey:@"DIAGNOSTIC"];
+    [versionCollection release];
+    [runSettings release];
+    [diagRunType release];
+
+    // Now query DB and fetch the SRs
+    NSString *urlString, *link, *ret;
+    NSURLRequest *request;
+    NSURLResponse *response;
+    NSError *error = nil;
+    NSData *data;
+
+    urlString = [NSString stringWithFormat:@"http://%@:%@@%@:%u/%@/_design/standardRuns/_view/getStandardRunsWithVersion?startkey=[%@, \"\", \"\", 0]&endkey=[%@,\"\ufff0\",\"\ufff0\",{}]&include_docs=True",
+                 [self orcaDBUserName],
+                 [self orcaDBPassword],
+                 [self orcaDBIPAddress],
+                 [self orcaDBPort],
+                 [self orcaDBName],
+                 [self standardRunTableVersion],
+                 [self standardRunTableVersion]];
+
+    link = [urlString stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
+    request = [NSURLRequest requestWithURL:[NSURL URLWithString:link] cachePolicy:0 timeoutInterval:2];
+    data = [NSURLConnection sendSynchronousRequest:request returningResponse:&response error:&error];
+    ret = [[[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding] autorelease];
+    NSDictionary *theStandardRuns = [NSJSONSerialization JSONObjectWithData:[ret dataUsingEncoding:NSUTF8StringEncoding] options:0 error:&error];
+    //JSON formatting error
+    if (error != nil) {
+        NSLogColor([NSColor redColor], @"Error reading standard runs from "
+                   "database: %@\n", [error localizedDescription]);
+        [[NSNotificationCenter defaultCenter] postNotificationName:ORSNOPModelSRCollectionChangedNotification object:self];
+        [self setStandardRunType:@"DIAGNOSTIC"];
+        [self setStandardRunVersion:@"DEFAULT"];
+        return false;
+    }
+
+    //If SR not found select diagnostic run
+    if ([[theStandardRuns valueForKey:@"error"] isEqualToString:@"not_found"] || error != nil) {
+        [[NSNotificationCenter defaultCenter] postNotificationName:ORSNOPModelSRCollectionChangedNotification object:self];
+        [self setStandardRunType:@"DIAGNOSTIC"];
+        NSLogColor([NSColor redColor],@"Error querying couchDB, please check the settings are correct and you have connection. \n");
+        return false;
+    }
+
+    //Query succeded
+    for(id aStandardRun in [theStandardRuns valueForKey:@"rows"]){
+        NSString *runtype = [[aStandardRun valueForKey:@"key"] objectAtIndex:1];
+        NSString *runversion = [[aStandardRun valueForKey:@"key"] objectAtIndex:2];
+        NSDictionary *runsettings = [aStandardRun valueForKey:@"doc"];
+        if([runtype isEqualToString:@"DIAGNOSTIC"]) continue; //Diagnostic is a protected name
+        if([standardRunCollection objectForKey:runtype] == nil){
+            [standardRunCollection setObject:[[NSMutableDictionary alloc] init] forKey:runtype];
+        }
+        [[standardRunCollection objectForKey:runtype] setObject:runsettings forKey:runversion];
+    }
+
+    /* Notify the controller to update the popup menu */
+    [[NSNotificationCenter defaultCenter] postNotificationName:ORSNOPModelSRCollectionChangedNotification object:self];
+
+    /* Update standard run type */
+    //Check if DB is empty
+    if([standardRunCollection count] == 0){
+        [self setStandardRunType:@""];
+        return false;
+    }
+    //Check if previous selected run exists
+    else if([standardRunCollection objectForKey:[self standardRunType]] == nil){
+        //If not, select first on the list
+        [self setStandardRunType:[[standardRunCollection keyEnumerator] nextObject]];
+    }
+    else{
+        [self setStandardRunType:[self standardRunType]];
+    }
+
+    /* Update standard run version */
+    //Check if DB is empty
+    if([[standardRunCollection objectForKey:[self standardRunType]] count] == 0){
+        [self setStandardRunVersion:@""];
+    }
+    //Check if previous selected run exists
+    else if([standardRunCollection objectForKey:[self standardRunType]] == nil){
+        //If not, select first on the list
+        [self setStandardRunVersion:[[[standardRunCollection objectForKey:[self standardRunType]] keyEnumerator] nextObject]];
+    }
+    else{
+        [self setStandardRunVersion:[self standardRunVersion]];
+    }
+
+    return true;
+
+}
 
 // Load Detector Settings from the DB into the Models
 -(BOOL) loadStandardRun:(NSString*)runTypeName withVersion:(NSString*)runVersion
 {
 
-    //Alert the operator
-    if(runTypeName == nil || runVersion == nil){
-        NSLog(@"Please, set a valid name and click enter. \n");
+    NSMutableDictionary* runSettings = [[[self standardRunCollection] objectForKey:runTypeName] objectForKey:runVersion];
+    if(runSettings == nil){
+        NSLogColor([NSColor redColor], @"Standard run %@(%@) does NOT exists in DB. \n",runTypeName, runVersion);
         return false;
     }
-    else if([runTypeName isEqualToString:@"DIAGNOSTIC"]){
-        NSLog(@"Going to DIAGNOSTIC run: the trigger settings will not change \n",runTypeName, runVersion);
-    }
-    else{
-        NSLog(@"Loading settings for standard run: %@ - Version: %@ ........ \n",runTypeName, runVersion);
+
+    /* Get models */
+    NSArray*  objs = [[(ORAppDelegate*)[NSApp delegate] document] collectObjectsOfClass:NSClassFromString(@"ORMTCModel")];
+    ORMTCModel* mtcModel;
+    if ([objs count]) {
+        mtcModel = [objs objectAtIndex:0];
+    } else {
+        NSLogColor([NSColor redColor], @"couldn't find MTC model. Please add it to the experiment and restart the run.\n");
+        return false;
     }
 
-    //Get RC model
-    NSArray*  objs = [[(ORAppDelegate*)[NSApp delegate] document] collectObjectsOfClass:NSClassFromString(@"ORRunModel")];
+    objs = [[(ORAppDelegate*)[NSApp delegate] document] collectObjectsOfClass:NSClassFromString(@"ORRunModel")];
     ORRunModel* runControlModel;
     if ([objs count]) {
         runControlModel = [objs objectAtIndex:0];
     } else {
-        NSLogColor([NSColor redColor], @"couldn't find MTC model. Please add it to the experiment and restart the run.\n");
-        return 0;
-    }
-    //Get MTC model
-    objs = [[(ORAppDelegate*)[NSApp delegate] document] collectObjectsOfClass:NSClassFromString(@"ORMTCModel")];
-    ORMTCModel* mtc;
-    if ([objs count]) {
-        mtc = [objs objectAtIndex:0];
-    } else {
-        NSLogColor([NSColor redColor], @"couldn't find MTC model. Please add it to the experiment and restart the run.\n");
-        return 0;
-    }
-
-    //Query the OrcaDB and get a dictionary with the parameters
-    NSString *urlString = [NSString stringWithFormat:@"http://%@:%@@%@:%u/%@/_design/standardRuns/_view/getStandardRunsWithVersion?startkey=[%@,\"%@\",\"%@\",{}]&endkey=[%@,\"%@\",\"%@\",0]&descending=True&include_docs=True",
-                           [self orcaDBUserName],
-                           [self orcaDBPassword],
-                           [self orcaDBIPAddress],
-                           [self orcaDBPort],
-                           [self orcaDBName],
-                           [self standardRunTableVersion],
-                           runTypeName,
-                           runVersion,
-                           [self standardRunTableVersion],
-                           runTypeName,
-                           runVersion];
-
-    NSString* urlStringScaped = [urlString stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
-    NSURL *url = [NSURL URLWithString:urlStringScaped];
-    NSData *data = [NSData dataWithContentsOfURL:url];
-    NSString *ret = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
-    NSError *error =  nil;
-    NSMutableDictionary *detectorSettings = [NSJSONSerialization JSONObjectWithData:[ret dataUsingEncoding:NSUTF8StringEncoding] options:0 error:&error];
-
-    if(error) {
-        NSLog(@"Error querying couchDB, please check the connection is correct: \n %@ \n", ret);
-        [ret release];
+        NSLogColor([NSColor redColor], @"couldn't find RC model. Please add it to the experiment and restart the run.\n");
         return false;
     }
-    
+
+
     //Load values
     @try{
-
         //Load run type word
-        unsigned long nextruntypeword = [[[[[detectorSettings valueForKey:@"rows"] objectAtIndex:0] valueForKey:@"doc"] valueForKey:@"run_type_word"] unsignedLongValue];
+        unsigned long nextruntypeword = [[runSettings valueForKey:@"run_type_word"] unsignedLongValue];
         unsigned long currentruntypeword = [runControlModel runType];
         //Do not touch the data quality bits
         currentruntypeword &= 0xFFE00000;
@@ -1993,7 +2109,7 @@ static NSComparisonResult compareXL3s(ORXL3Model *xl3_1, ORXL3Model *xl3_2, void
         if(nextruntypeword & kDiagnosticRun) return true;
 
         //Load MTC thresholds
-        [mtc loadFromSearialization:detectorSettings];
+        [mtcModel loadFromSearialization:runSettings];
         
         NSLog(@"Standard run %@ (%@) settings loaded. \n",runTypeName,runVersion);
         return true;
@@ -2014,11 +2130,16 @@ static NSComparisonResult compareXL3s(ORXL3Model *xl3_1, ORXL3Model *xl3_2, void
         ORRunAlertPanel(@"Invalid Standard Run Name",@"Please, set a valid name in the popup menus and click enter",@"OK",nil,nil);
         return false;
     }
+    else if([runTypeName isEqualToString:@"DIAGNOSTIC"]){
+        NSLog(@"You cannot save a DIAGNOSTIC run. \n");
+        return false;
+    }
     else{
-        BOOL cancel = ORRunAlertPanel([NSString stringWithFormat:@"Overwriting stored values for run \"%@\" with version \"%@\"", runTypeName,runVersion],@"Is this really what you want?",@"Cancel",@"Yes, Save it",nil);
+        BOOL cancel = ORRunAlertPanel([NSString stringWithFormat:@"Overwriting stored values for run \"%@\" with version \"%@\"",
+                                       runTypeName,runVersion],
+                                      @"Is this really what you want?",@"Cancel",@"Yes, Save it",nil);
         if(cancel) return false;
     }
-    NSLog(@"Saving settings for Standard Run: %@ - Version: %@ ........ \n",runTypeName,runVersion);
 
     //Get RC model
     NSArray*  objs = [[(ORAppDelegate*)[NSApp delegate] document] collectObjectsOfClass:NSClassFromString(@"ORRunModel")];
@@ -2057,11 +2178,10 @@ static NSComparisonResult compareXL3s(ORXL3Model *xl3_1, ORXL3Model *xl3_2, void
     NSMutableDictionary* mtc_serial = [[mtc serializeToDictionary] retain];
     [detectorSettings addEntriesFromDictionary:mtc_serial];
     [mtc_serial release];
-    NSLog(@"savestandardrun %@\n",detectorSettings);
-    
-    [[self orcaDbRefWithEntryDB:self withDB:@"orca"] addDocument:detectorSettings tag:@"kStandardRunDocumentAdded"];
+    NSLog(@"Saving settings for Standard Run %@ - Version %@: \n %@ \n",runTypeName,runVersion,detectorSettings);
 
-    NSLog(@"%@ run saved as standard run. \n",runTypeName);    
+    [[self orcaDbRefWithEntryDB:self withDB:[self orcaDBName]] addDocument:detectorSettings tag:@"kStandardRunPosted"];
+
     return true;
 
 }
@@ -2090,7 +2210,7 @@ static NSComparisonResult compareXL3s(ORXL3Model *xl3_1, ORXL3Model *xl3_2, void
         return;
     }
     
-    NSLogColor([NSColor redColor], @"Settings loaded in Hardware \n");
+    NSLog(@"Settings loaded in Hardware \n");
 
 }
 

--- a/Source/Objects/Custom Hardware/SNO+/MTC/ORMTCModel.m
+++ b/Source/Objects/Custom Hardware/SNO+/MTC/ORMTCModel.m
@@ -1059,11 +1059,12 @@ tubRegister;
     }
     return ret;
 }
-- (id) objectFromSerialization: (NSMutableDictionary*) serial withKey:(NSString*)str {
-    id obj=[[[[serial valueForKey:@"rows"] objectAtIndex:0] valueForKey:@"doc"] valueForKey:str];
-    return obj;
 
+- (id) objectFromSerialization: (NSMutableDictionary*) serial withKey:(NSString*)str {
+    id obj=[serial valueForKey:str];
+    return obj;
 }
+
 - (void) loadFromSearialization:(NSMutableDictionary*) serial {
     //This function will let any exceptions from below bubble up
 


### PR DESCRIPTION
- Store SR settings in model so that we only need one query
- Hardcode DIAGNOSTIC run to be available with no DB access
- Save current run type and version in .Orca file
- Move most of the SR logic from the controller to the model
- Display current run type and version only if run actually started
- Never lock SR tab
- Load SR at RESYNC

Author: Javier Caravaca <jcaravaca@berkeley.edu>