### PR TITLE
SNO+: fix caen event size calculation

### DIFF
--- a/Source/Objects/Custom Hardware/SNO+/CAEN/SNOCaenController.m
+++ b/Source/Objects/Custom Hardware/SNO+/CAEN/SNOCaenController.m
@@ -311,9 +311,11 @@ static int chanConfigToMaskBit[kNumChanConfigBits] = {1,3,4,6,11};
 
 - (void) eventSizeChanged:(NSNotification*)aNote
 {
-	[eventSizePopUp selectItemAtIndex:	[model eventSize]];
-	[eventSizeTextField setIntValue:	1024*1024./powf(2.,(float)[model eventSize]) / 2]; //in Samples
-	
+    [eventSizePopUp selectItemAtIndex: [model eventSize]];
+    /* Set the text field in samples. For the conversion between the buffer
+     * organization register and the number of samples see Section 4.15 in the
+     * user manual. */
+    [eventSizeTextField setIntValue: (1 << (20-[model eventSize])];
 }
 
 - (void) checkGlobalSecurity

--- a/Source/Objects/Custom Hardware/SNO+/CAEN/SNOCaenController.m
+++ b/Source/Objects/Custom Hardware/SNO+/CAEN/SNOCaenController.m
@@ -315,7 +315,7 @@ static int chanConfigToMaskBit[kNumChanConfigBits] = {1,3,4,6,11};
     /* Set the text field in samples. For the conversion between the buffer
      * organization register and the number of samples see Section 4.15 in the
      * user manual. */
-    [eventSizeTextField setIntValue: (1 << (20-[model eventSize])];
+    [eventSizeTextField setIntValue: (1 << (20-[model eventSize]))];
 }
 
 - (void) checkGlobalSecurity

--- a/Source/Objects/Hardware/Vme/CAEN/CV1720/ORCaen1720Controller.m
+++ b/Source/Objects/Hardware/Vme/CAEN/CV1720/ORCaen1720Controller.m
@@ -315,7 +315,7 @@ int chanConfigToMaskBit[kNumChanConfigBits] = {1,3,4,6,11};
     /* Set the text field in samples. For the conversion between the buffer
      * organization register and the number of samples see Section 4.15 in the
      * user manual. */
-    [eventSizeTextField setIntValue: (1 << (20-[model eventSize])];
+    [eventSizeTextField setIntValue: (1 << (20-[model eventSize]))];
 }
 
 - (void) checkGlobalSecurity

--- a/Source/Objects/Hardware/Vme/CAEN/CV1720/ORCaen1720Controller.m
+++ b/Source/Objects/Hardware/Vme/CAEN/CV1720/ORCaen1720Controller.m
@@ -311,9 +311,11 @@ int chanConfigToMaskBit[kNumChanConfigBits] = {1,3,4,6,11};
 
 - (void) eventSizeChanged:(NSNotification*)aNote
 {
-	[eventSizePopUp selectItemAtIndex:	[model eventSize]];
-	[eventSizeTextField setIntValue:	1024*1024./powf(2.,(float)[model eventSize]) / 2]; //in Samples
-	
+    [eventSizePopUp selectItemAtIndex: [model eventSize]];
+    /* Set the text field in samples. For the conversion between the buffer
+     * organization register and the number of samples see Section 4.15 in the
+     * user manual. */
+    [eventSizeTextField setIntValue: (1 << (20-[model eventSize])];
 }
 
 - (void) checkGlobalSecurity


### PR DESCRIPTION
The event size calculation in the caen controller was off by a factor of 2.