### PR TITLE
SNO+: update ping crates

### DIFF
--- a/Source/Experiments/SNOP/SNOPModel.m
+++ b/Source/Experiments/SNOP/SNOPModel.m
@@ -1172,10 +1172,23 @@ static NSComparisonResult compareXL3s(ORXL3Model *xl3_1, ORXL3Model *xl3_2, void
                            [e name], [e reason]);
             }
 
-            /* Set pedestal mask back to what it was before. */
-            [xl3 setPedestalInParallel];
+            /* Set pedestal mask back to 0. */
+            if ([xl3 setPedestalMask:[xl3 getSlotsPresent] pattern:0]) {
+                NSLogColor([NSColor redColor],
+                           @"failed to set pedestal mask for crate %02d\n", i);
+                continue;
+            }
 
             NSLog(@"PING crate %02d\n", i);
+        }
+    }
+
+    /* Set the pedestal mask for each crate back. */
+    for (i = 0; i < [xl3s count]; i++) {
+        xl3 = [xl3s objectAtIndex:i];
+
+        if ([[xl3 xl3Link] isConnected]) {
+            [xl3 setPedestals];
         }
     }
 

--- a/Source/Objects/Custom Hardware/SNO+/XL3/ORXL3Model.h
+++ b/Source/Objects/Custom Hardware/SNO+/XL3/ORXL3Model.h
@@ -402,6 +402,7 @@ enum {
 - (void) writeXl3Mode: (uint32_t) mode withSlotMask: (uint32_t) slotMask;
 - (void) compositeXl3RW;
 - (void) compositeQuit;
+- (int) setPedestals;
 - (int) setPedestalMask: (uint32_t) slotMask pattern: (uint32_t) pattern;
 - (void) compositeSetPedestal;
 - (void) setPedestalInParallel;

--- a/Source/Objects/Custom Hardware/SNO+/XL3/ORXL3Model.m
+++ b/Source/Objects/Custom Hardware/SNO+/XL3/ORXL3Model.m
@@ -2842,13 +2842,14 @@ err:
 - (int) setPedestals
 {
     /* Set the pedestal mask. Returns 0 on success, -1 on error. */
+    int i;
     char payload[XL3_PAYLOAD_SIZE];
-    MultiSetCratePedestalsArgs *args;
-    MultiSetCratePedestalsResults *results;
+    MultiSetCratePedsArgs *args;
+    MultiSetCratePedsResults *results;
 
     memset(&payload, 0, XL3_PAYLOAD_SIZE);
 
-    args = (MultiSetCratePedestalsArgs *) payload;
+    args = (MultiSetCratePedsArgs *) payload;
 
     NSArray* fecs = [[self guardian]
                      collectObjectsOfClass:NSClassFromString(@"ORFec32Model")];
@@ -2873,7 +2874,7 @@ err:
         return -1;
     }
 
-    results = (MultiSetCratePedestalsResults *) payload;
+    results = (MultiSetCratePedsResults *) payload;
 
     if (ntohl(results->errorMask)) {
         return -1;

--- a/Source/Objects/Custom Hardware/SNO+/XL3/ORXL3Model.m
+++ b/Source/Objects/Custom Hardware/SNO+/XL3/ORXL3Model.m
@@ -2839,6 +2839,49 @@ err:
 	[self setXl3OpsRunning:NO forKey:@"compositeQuit"];
 }
 
+- (int) setPedestals
+{
+    /* Set the pedestal mask. Returns 0 on success, -1 on error. */
+    char payload[XL3_PAYLOAD_SIZE];
+    MultiSetCratePedestalsArgs *args;
+    MultiSetCratePedestalsResults *results;
+
+    memset(&payload, 0, XL3_PAYLOAD_SIZE);
+
+    args = (MultiSetCratePedestalsArgs *) payload;
+
+    NSArray* fecs = [[self guardian]
+                     collectObjectsOfClass:NSClassFromString(@"ORFec32Model")];
+
+    args->slotMask = 0;
+
+    for (id aFec in fecs) {
+        args->slotMask |= 1 << [aFec stationNumber];
+        args->channelMasks[[aFec stationNumber]] = [aFec pedEnabledMask];
+    }
+
+    args->slotMask = htonl(args->slotMask);
+
+    for (i = 0; i < 16; i++) {
+        args->channelMasks[i] = htonl(args->channelMasks[i]);
+    }
+
+    @try {
+        [[self xl3Link] sendCommand:MULTI_SET_CRATE_PEDS_ID withPayload:payload
+                        expectResponse:YES];
+    } @catch (NSException *e) {
+        return -1;
+    }
+
+    results = (MultiSetCratePedestalsResults *) payload;
+
+    if (ntohl(results->errorMask)) {
+        return -1;
+    }
+
+    return 0;
+}
+
 - (int) setPedestalMask: (uint32_t) slotMask pattern: (uint32_t) pattern
 {
     /* Set the pedestal mask for a given slot mask. Any slots not in the mask


### PR DESCRIPTION
This commit updates the ping crates method to clear the pedestal mask for each
crate after firing pedestals. After firing pedestals on each crate, the
pedestal mask for each crate is set back to what it was before starting.

Fixes issue #294.