### PR TITLE
open last standard run

### DIFF
--- a/Source/Experiments/SNOP/SNOPController.m
+++ b/Source/Experiments/SNOP/SNOPController.m
@@ -461,29 +461,25 @@ snopGreenColor;
 }
 
 //Update the SR diplay when SR changes
--(void) SRVersionChanged:(NSNotification*)aNote
+- (void) SRVersionChanged:(NSNotification*)aNote
 {
-
     NSString* standardRunVersion = [model standardRunVersion];
-    if([standardRunVersionPopupMenu numberOfItems] == 0 || standardRunVersion == nil || [standardRunVersion isEqualToString:@""]){
+    if ([standardRunVersionPopupMenu numberOfItems] == 0 || standardRunVersion == nil || [standardRunVersion isEqualToString:@""]) {
         return;
     }
-    if([standardRunVersionPopupMenu indexOfItemWithObjectValue:standardRunVersion] == NSNotFound){
+    if ([standardRunVersionPopupMenu indexOfItemWithObjectValue:standardRunVersion] == NSNotFound) {
         NSLogColor([NSColor redColor],@"Standard Run Version \"%@\" does not exist. \n",standardRunVersion);
         return;
-    }
-    else{
+    } else {
         [standardRunVersionPopupMenu selectItemWithObjectValue:standardRunVersion];
     }
     
     [self displayThresholdsFromDB];
     [self runTypeWordChanged:nil];
-
 }
 
 - (IBAction) startRunAction:(id)sender
 {
-
     //Load selected SR in case the user didn't click enter
     //fixed memory leak in the next two lines -- don't 'copy without a matching release MAH 03/8/2017
     NSString *standardRun = [standardRunPopupMenu objectValueOfSelectedItem];
@@ -1689,58 +1685,54 @@ snopGreenColor;
 // Create a new SR item if doesn't exist, set the runType string value and query the DB to display the trigger configuration
 - (IBAction)standardRunPopupAction:(id)sender
 {
-    
     NSString *standardRun = [[standardRunPopupMenu stringValue] uppercaseString];
     [standardRunPopupMenu setStringValue:standardRun];
-    //Create new SR if does not exist
-    if ([standardRunPopupMenu indexOfItemWithObjectValue:standardRun] == NSNotFound && [standardRun isNotEqualTo:@""]){
+
+    // Create new SR if does not exist
+    if ([standardRunPopupMenu indexOfItemWithObjectValue:standardRun] == NSNotFound && [standardRun isNotEqualTo:@""]) {
         BOOL cancel = ORRunAlertPanel([NSString stringWithFormat:@"Creating new Standard Run: \"%@\"", standardRun],@"Is this really what you want?",@"Cancel",@"Yes, Make New Standard Run",nil);
-        if(cancel){
+        if (cancel) {
             [standardRunPopupMenu selectItemWithObjectValue:[model standardRunType]];
             [standardRunVersionPopupMenu selectItemWithObjectValue:[model standardRunVersion]];
             return;
-        }
-        else{
+        } else {
             [standardRunPopupMenu addItemWithObjectValue:standardRun];
             [standardRunVersionPopupMenu addItemWithObjectValue:@"DEFAULT"];
             [model saveStandardRun:standardRun withVersion:@"DEFAULT"];
         }
     }
     
-    //Set run type name
-    if(![[model standardRunType] isEqualToString:standardRun]){
+    // Set run type name
+    if(![[model standardRunType] isEqualToString:standardRun]) {
         [model setStandardRunType:standardRun];
     }
-    
 }
 
-- (IBAction)standardRunVersionPopupAction:(id)sender {
-    
+- (IBAction)standardRunVersionPopupAction:(id)sender
+{
     NSString *standardRun = [[standardRunPopupMenu stringValue] uppercaseString];
     NSString *standardRunVer = [[standardRunVersionPopupMenu stringValue] uppercaseString];
     [standardRunVersionPopupMenu setStringValue:standardRunVer];
 
-    //Create new SR version if does not exist
-    if ([standardRunVersionPopupMenu indexOfItemWithObjectValue:standardRunVer] == NSNotFound && [standardRunVer isNotEqualTo:@""]){
-
-        if([standardRun isEqualToString:@"DIAGNOSTIC"]){
+    // Create new SR version if does not exist
+    if ([standardRunVersionPopupMenu indexOfItemWithObjectValue:standardRunVer] == NSNotFound && [standardRunVer isNotEqualTo:@""]) {
+        if ([standardRun isEqualToString:@"DIAGNOSTIC"]) {
             NSLog(@"You cannot create a version for a DIAGNOSTIC run.\n");
             return;
         }
 
         BOOL cancel = ORRunAlertPanel([NSString stringWithFormat:@"Creating new Version: \"%@\" of Standard Run: \"%@\"", standardRunVer, standardRun], @"Is this really what you want?",@"Cancel",@"Yes, Make New Version",nil);
-        if(cancel){
+        if (cancel) {
             [standardRunVersionPopupMenu selectItemWithObjectValue:[model standardRunVersion]];
-        }
-        else{
+        } else {
             [standardRunVersionPopupMenu addItemWithObjectValue:standardRunVer];
             [standardRunVersionPopupMenu selectItemWithObjectValue:standardRunVer];
             [model saveStandardRun:standardRun withVersion:standardRunVer];
         }
     }
     
-    //Set run type name
-    if(![[model standardRunVersion] isEqualToString:standardRunVer]){
+    // Set run type name
+    if (![[model standardRunVersion] isEqualToString:standardRunVer]) {
         [model setStandardRunVersion:standardRunVer];
     }
 }
@@ -1794,7 +1786,6 @@ snopGreenColor;
 //and display the values in the GUI.
 -(void) displayThresholdsFromDB
 {
-
     /* Get models */
     NSArray*  objs = [[(ORAppDelegate*)[NSApp delegate] document] collectObjectsOfClass:NSClassFromString(@"ORMTCModel")];
     ORMTCModel* mtcModel;
@@ -1879,7 +1870,6 @@ snopGreenColor;
             [[runTypeWordSRMatrix cellAtRow:ibit column:0] setState:0];
         }
     }
-
 }
 
 - (IBAction) refreshStandardRunsAction:(id)sender
@@ -1893,7 +1883,7 @@ snopGreenColor;
     [standardRunPopupMenu removeAllItems];
     [standardRunVersionPopupMenu removeAllItems];
 
-    //Populate run type popup menu
+    // Populate run type popup menu
     for(NSString* aStandardRunType in [model standardRunCollection]){
         [standardRunPopupMenu addItemWithObjectValue:aStandardRunType];
     }
@@ -1901,26 +1891,23 @@ snopGreenColor;
 
 -(void) refreshStandardRunVersions
 {
-
     [standardRunVersionPopupMenu deselectItemAtIndex:[standardRunVersionPopupMenu indexOfSelectedItem]];
     [standardRunVersionPopupMenu removeAllItems];
 
     NSString* standardRunVersion = [model standardRunVersion];
-    //Populate run version popup menu
-    for(NSString* aStandardRunVersion in [[model standardRunCollection] objectForKey:[model standardRunType]]){
+    // Populate run version popup menu
+    for (NSString* aStandardRunVersion in [[model standardRunCollection] objectForKey:[model standardRunType]]) {
         [standardRunVersionPopupMenu addItemWithObjectValue:aStandardRunVersion];
     }
 
-    if([standardRunVersionPopupMenu numberOfItems] == 0 || standardRunVersion == nil || [standardRunVersion isEqualToString:@""]){
+    if ([standardRunVersionPopupMenu numberOfItems] == 0 || standardRunVersion == nil || [standardRunVersion isEqualToString:@""]) {
         return;
     }
-    if([standardRunVersionPopupMenu indexOfItemWithObjectValue:standardRunVersion] == NSNotFound){
+    if ([standardRunVersionPopupMenu indexOfItemWithObjectValue:standardRunVersion] == NSNotFound) {
         [standardRunVersionPopupMenu selectItemWithObjectValue:standardRunVersion];
         return;
-    }
-    else{
+    } else {
         [standardRunVersionPopupMenu selectItemWithObjectValue:standardRunVersion];
     }
-
 }
 @end

--- a/Source/Experiments/SNOP/SNOPController.m
+++ b/Source/Experiments/SNOP/SNOPController.m
@@ -1671,24 +1671,19 @@ snopGreenColor;
 
 - (IBAction)loadStandardRunFromDBAction:(id)sender
 {
-    
     NSString *standardRun = [standardRunPopupMenu objectValueOfSelectedItem];
     NSString *standardRunVer = [standardRunVersionPopupMenu objectValueOfSelectedItem];
 
     [model loadStandardRun:standardRun withVersion: standardRunVer];
     [model loadSettingsInHW];
-    
 }
 
 - (IBAction)saveStandardRunToDBAction:(id)sender
 {
-    
     NSString *standardRun = [standardRunPopupMenu objectValueOfSelectedItem];
     NSString *standardRunVer = [standardRunVersionPopupMenu objectValueOfSelectedItem];
     
     [model saveStandardRun:standardRun withVersion:standardRunVer];
-    [self displayThresholdsFromDB];
-    
 }
 
 // Create a new SR item if doesn't exist, set the runType string value and query the DB to display the trigger configuration

--- a/Source/Experiments/SNOP/SNOPModel.m
+++ b/Source/Experiments/SNOP/SNOPModel.m
@@ -100,8 +100,6 @@ resync;
 
 #pragma mark ¥¥¥Initialization
 
-/* This method is obsolete and rarely called.
- For initialization you should use initWithCoder */
 - (id) init
 {
     
@@ -304,6 +302,8 @@ resync;
     [self setLastStandardRunType:[decoder decodeObjectForKey:@"SNOPlastStandardRunType"]];
     [self setLastStandardRunVersion:[decoder decodeObjectForKey:@"SNOPlastStandardRunVersion"]];
     [self setLastRunTypeWordHex:[decoder decodeObjectForKey:@"SNOPlastRunTypeWordHex"]];
+    [self setStandardRunType:[decoder decodeObjectForKey:@"SNOPStandardRunType"]];
+    [self setStandardRunVersion:[decoder decodeObjectForKey:@"SNOPStandardRunVersion"]];
 
     //ECA
     [anECARun setECA_pattern:[decoder decodeIntForKey:@"SNOPECApattern"]];
@@ -409,11 +409,6 @@ resync;
 {
     /* Get the standard runs from the database. */
     [self refreshStandardRunsFromDB];
-
-    /* Load the last standard run. */
-    [self setStandardRunType:[self lastStandardRunType]];
-    [self setStandardRunVersion:[self lastStandardRunVersion]];
-
     [[ORGlobal sharedGlobal] setCanQuitDuringRun:YES];
 }
 
@@ -1556,6 +1551,8 @@ static NSComparisonResult compareXL3s(ORXL3Model *xl3_1, ORXL3Model *xl3_2, void
     [encoder encodeObject:[self lastStandardRunType] forKey:@"SNOPlastStandardRunType"];
     [encoder encodeObject:[self lastStandardRunVersion] forKey:@"SNOPlastStandardRunVersion"];
     [encoder encodeObject:[self lastRunTypeWordHex] forKey:@"SNOPlastRunTypeWordHex"];
+    [encoder encodeObject:[self standardRunType] forKey:@"SNOPStandardRunType"];
+    [encoder encodeObject:[self standardRunVersion] forKey:@"SNOPStandardRunVersion"];
 
     //ECA
     [encoder encodeInt:[anECARun ECA_pattern] forKey:@"SNOPECApattern"];
@@ -1952,11 +1949,10 @@ static NSComparisonResult compareXL3s(ORXL3Model *xl3_1, ORXL3Model *xl3_2, void
 
 -(BOOL) refreshStandardRunsFromDB
 {
-
-    //Prune the Standard Runs collection
+    // Prune the Standard Runs collection
     [standardRunCollection removeAllObjects];
 
-    //First add Off-line standard runs
+    // First add Off-line standard runs
     NSMutableDictionary* runSettings = [[NSMutableDictionary alloc] init];
     NSMutableDictionary* versionCollection = [[NSMutableDictionary alloc] init];
     NSNumber* diagRunType = [[NSNumber alloc] initWithInt:kDiagnosticRun];
@@ -1988,7 +1984,7 @@ static NSComparisonResult compareXL3s(ORXL3Model *xl3_1, ORXL3Model *xl3_2, void
     data = [NSURLConnection sendSynchronousRequest:request returningResponse:&response error:&error];
     ret = [[[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding] autorelease];
     NSDictionary *theStandardRuns = [NSJSONSerialization JSONObjectWithData:[ret dataUsingEncoding:NSUTF8StringEncoding] options:0 error:&error];
-    //JSON formatting error
+    // JSON formatting error
     if (error != nil) {
         NSLogColor([NSColor redColor], @"Error reading standard runs from "
                    "database: %@\n", [error localizedDescription]);
@@ -1998,21 +1994,21 @@ static NSComparisonResult compareXL3s(ORXL3Model *xl3_1, ORXL3Model *xl3_2, void
         return false;
     }
 
-    //If SR not found select diagnostic run
-    if ([[theStandardRuns valueForKey:@"error"] isEqualToString:@"not_found"] || error != nil) {
+    // If SR not found select diagnostic run
+    if ([[theStandardRuns valueForKey:@"error"] isEqualToString:@"not_found"]) {
         [[NSNotificationCenter defaultCenter] postNotificationName:ORSNOPModelSRCollectionChangedNotification object:self];
         [self setStandardRunType:@"DIAGNOSTIC"];
         NSLogColor([NSColor redColor],@"Error querying couchDB, please check the settings are correct and you have connection. \n");
         return false;
     }
 
-    //Query succeded
-    for(id aStandardRun in [theStandardRuns valueForKey:@"rows"]){
+    // Query succeded
+    for (id aStandardRun in [theStandardRuns valueForKey:@"rows"]) {
         NSString *runtype = [[aStandardRun valueForKey:@"key"] objectAtIndex:1];
         NSString *runversion = [[aStandardRun valueForKey:@"key"] objectAtIndex:2];
         NSDictionary *runsettings = [aStandardRun valueForKey:@"doc"];
-        if([runtype isEqualToString:@"DIAGNOSTIC"]) continue; //Diagnostic is a protected name
-        if([standardRunCollection objectForKey:runtype] == nil){
+        if ([runtype isEqualToString:@"DIAGNOSTIC"]) continue; // Diagnostic is a protected name
+        if ([standardRunCollection objectForKey:runtype] == nil) {
             [standardRunCollection setObject:[[NSMutableDictionary alloc] init] forKey:runtype];
         }
         [[standardRunCollection objectForKey:runtype] setObject:runsettings forKey:runversion];
@@ -2022,42 +2018,34 @@ static NSComparisonResult compareXL3s(ORXL3Model *xl3_1, ORXL3Model *xl3_2, void
     [[NSNotificationCenter defaultCenter] postNotificationName:ORSNOPModelSRCollectionChangedNotification object:self];
 
     /* Update standard run type */
-    //Check if DB is empty
-    if([standardRunCollection count] == 0){
+    if ([standardRunCollection count] == 0) {
+        /* Database is empty, so we set the standard run version to the empty string. */
         [self setStandardRunType:@""];
         return false;
-    }
-    //Check if previous selected run exists
-    else if([standardRunCollection objectForKey:[self standardRunType]] == nil){
-        //If not, select first on the list
+    } else if([standardRunCollection objectForKey:[self standardRunType]] == nil){
+        /* The current type is not in the standard runs anymore, so we select the first version. */
         [self setStandardRunType:[[standardRunCollection keyEnumerator] nextObject]];
-    }
-    else{
+    } else {
         [self setStandardRunType:[self standardRunType]];
     }
 
     /* Update standard run version */
-    //Check if DB is empty
-    if([[standardRunCollection objectForKey:[self standardRunType]] count] == 0){
+    if ([[standardRunCollection objectForKey:[self standardRunType]] count] == 0){
+        /* Database is empty, so we set the standard run version to the empty string. */
         [self setStandardRunVersion:@""];
-    }
-    //Check if previous selected run exists
-    else if([standardRunCollection objectForKey:[self standardRunType]] == nil){
-        //If not, select first on the list
+    } else if ([[standardRunCollection objectForKey:[self standardRunType]] objectForKey:[self standardRunVersion]] == nil) {
+        /* The current version is not in the standard runs anymore, so we select the first version. */
         [self setStandardRunVersion:[[[standardRunCollection objectForKey:[self standardRunType]] keyEnumerator] nextObject]];
-    }
-    else{
+    } else {
         [self setStandardRunVersion:[self standardRunVersion]];
     }
 
     return true;
-
 }
 
 // Load Detector Settings from the DB into the Models
 -(BOOL) loadStandardRun:(NSString*)runTypeName withVersion:(NSString*)runVersion
 {
-
     NSMutableDictionary* runSettings = [[[self standardRunCollection] objectForKey:runTypeName] objectForKey:runVersion];
     if(runSettings == nil){
         NSLogColor([NSColor redColor], @"Standard run %@(%@) does NOT exists in DB. \n",runTypeName, runVersion);
@@ -2107,7 +2095,6 @@ static NSComparisonResult compareXL3s(ORXL3Model *xl3_1, ORXL3Model *xl3_2, void
         NSLog(@"Error retrieving Standard Runs information: \n %@ \n", e);
         return false;
     }
-    
 }
 
 //Save MTC settings in a Standard Run table in CouchDB for later use by the Run Scripts or the user

--- a/Source/Experiments/SNOP/SNOPModel.m
+++ b/Source/Experiments/SNOP/SNOPModel.m
@@ -407,7 +407,13 @@ resync;
 
 - (void) awakeAfterDocumentLoaded
 {
-    [[self findController] refreshStandardRunsAction:nil];
+    /* Get the standard runs from the database. */
+    [self refreshStandardRunsFromDB];
+
+    /* Load the last standard run. */
+    [self setStandardRunType:[self lastStandardRunType]];
+    [self setStandardRunVersion:[self lastStandardRunVersion]];
+
     [[ORGlobal sharedGlobal] setCanQuitDuringRun:YES];
 }
 

--- a/Source/Experiments/SNOP/SNOPModel.m
+++ b/Source/Experiments/SNOP/SNOPModel.m
@@ -2100,24 +2100,21 @@ static NSComparisonResult compareXL3s(ORXL3Model *xl3_1, ORXL3Model *xl3_2, void
 //Save MTC settings in a Standard Run table in CouchDB for later use by the Run Scripts or the user
 -(BOOL) saveStandardRun:(NSString*)runTypeName withVersion:(NSString*)runVersion
 {
-    
-    //Check that runTypeName is properly set:
-    if(runTypeName == nil || runVersion == nil){
+    // Check that runTypeName is properly set:
+    if (runTypeName == nil || runVersion == nil) {
         ORRunAlertPanel(@"Invalid Standard Run Name",@"Please, set a valid name in the popup menus and click enter",@"OK",nil,nil);
         return false;
-    }
-    else if([runTypeName isEqualToString:@"DIAGNOSTIC"]){
+    } else if([runTypeName isEqualToString:@"DIAGNOSTIC"]) {
         NSLog(@"You cannot save a DIAGNOSTIC run. \n");
         return false;
-    }
-    else{
+    } else {
         BOOL cancel = ORRunAlertPanel([NSString stringWithFormat:@"Overwriting stored values for run \"%@\" with version \"%@\"",
                                        runTypeName,runVersion],
                                       @"Is this really what you want?",@"Cancel",@"Yes, Save it",nil);
-        if(cancel) return false;
+        if (cancel) return false;
     }
 
-    //Get RC model
+    // Get RC model
     NSArray*  objs = [[(ORAppDelegate*)[NSApp delegate] document] collectObjectsOfClass:NSClassFromString(@"ORRunModel")];
     ORRunModel* runControlModel;
     if ([objs count]) {
@@ -2126,7 +2123,8 @@ static NSComparisonResult compareXL3s(ORXL3Model *xl3_1, ORXL3Model *xl3_2, void
         NSLogColor([NSColor redColor], @"couldn't find RC model. Please add it to the experiment and restart the run.\n");
         return 0;
     }
-    //Get MTC model
+
+    // Get MTC model
     objs = [[(ORAppDelegate*)[NSApp delegate] document] collectObjectsOfClass:NSClassFromString(@"ORMTCModel")];
     ORMTCModel* mtc;
     if ([objs count]) {
@@ -2136,7 +2134,7 @@ static NSComparisonResult compareXL3s(ORXL3Model *xl3_1, ORXL3Model *xl3_2, void
         return 0;
     }
 
-    //Build run table
+    // Build run table
     NSMutableDictionary *detectorSettings = [NSMutableDictionary dictionaryWithCapacity:200];
 
     [detectorSettings setObject:@"standard_run" forKey:@"type"];
@@ -2145,12 +2143,12 @@ static NSComparisonResult compareXL3s(ORXL3Model *xl3_1, ORXL3Model *xl3_2, void
     [detectorSettings setObject:runVersion forKey:@"run_version"];
     NSNumber *date = [NSNumber numberWithDouble:[[NSDate date] timeIntervalSince1970]];
     [detectorSettings setObject:date forKey:@"time_stamp"];
-    //Do not touch the data quality bits
+    // Do not touch the data quality bits
     unsigned long currentRunTypeWord = [runControlModel runType];
     currentRunTypeWord &= ~0xFFE00000;
     [detectorSettings setObject:[NSNumber numberWithUnsignedLong:currentRunTypeWord] forKey:@"run_type_word"];
 
-    //Save MTC/D parameters, trigger masks and MTC/A+ thresholds
+    // Save MTC/D parameters, trigger masks and MTC/A+ thresholds
     NSMutableDictionary* mtc_serial = [[mtc serializeToDictionary] retain];
     [detectorSettings addEntriesFromDictionary:mtc_serial];
     [mtc_serial release];
@@ -2159,7 +2157,6 @@ static NSComparisonResult compareXL3s(ORXL3Model *xl3_1, ORXL3Model *xl3_2, void
     [[self orcaDbRefWithEntryDB:self withDB:[self orcaDBName]] addDocument:detectorSettings tag:@"kStandardRunPosted"];
 
     return true;
-
 }
 
 //Ship GUI settings to hardware

--- a/Source/Experiments/SNOP/SNOPModel.m
+++ b/Source/Experiments/SNOP/SNOPModel.m
@@ -1423,10 +1423,9 @@ static NSComparisonResult compareXL3s(ORXL3Model *xl3_1, ORXL3Model *xl3_2, void
                 [self parseSmellieRunFileDocs:aResult];
             } else if ([aTag isEqualToString:@"Message"]) {
                 [aResult prettyPrint:@"CouchDB Message:"];
-            }
-            //Standard Runs querying
-            else if ([aTag isEqualToString:@"kStandardRunPosted"]) {
-                NSLog(@"Standard Run saved. \n");
+            } else if ([aTag isEqualToString:@"kStandardRunPosted"]) {
+                /* Standard run was successfully posted. */
+                NSLog(@"Standard Run saved.\n");
                 [self refreshStandardRunsFromDB];
             } else {
                 [aResult prettyPrint:@"CouchDB"];


### PR DESCRIPTION
This pull request updates the SNO+ model to load the last standard run type and version saved to the Orca file when Orca boots up. This fixes #326.

This hasn't been tested yet.