### PR TITLE
SNO+: Only ramp down of supply A turns off crate triggers.

### DIFF
--- a/Source/Objects/Custom Hardware/SNO+/XL3/XL3_LinkController.m
+++ b/Source/Objects/Custom Hardware/SNO+/XL3/XL3_LinkController.m
@@ -1596,13 +1596,13 @@ static NSDictionary* xl3Ops;
 - (IBAction)hvRampDownAction:(id)sender
 {
     [[sender window] makeFirstResponder:tabView];
-    if ([model isTriggerON]) {
-        [model hvTriggersOFF];
-    }
     if ([hvPowerSupplyMatrix selectedColumn] == 0) {
+        if ([model isTriggerON]) {
+            [model hvTriggersOFF];
+        }
         [model setHvANextStepValue:0];
-    }
-    else {
+    } else {
+        //FIXME: do we handle triggers for supply B?
         [model setHvBNextStepValue:0];
     }
 }


### PR DESCRIPTION
Previously supply 16B would cause crate 16 triggers to turn off. Turning
off triggers for OWL PMTs on crate 16B ramp down not implemented yet
(unchanged from previous). Fixes #344.