### PR TITLE
SNO+: update CAEN controller to load settings even if the user hasn't pressed enter

### DIFF
--- a/Source/Objects/Custom Hardware/SNO+/CAEN/SNOCaenController.m
+++ b/Source/Objects/Custom Hardware/SNO+/CAEN/SNOCaenController.m
@@ -743,6 +743,8 @@ static int chanConfigToMaskBit[kNumChanConfigBits] = {1,3,4,6,11};
 
 - (IBAction) initBoard: (id) sender
 {
+    [self endEditing];
+
 	@try {
 		[model initBoard];
 		NSLog(@"Caen 1720 Card %d inited\n",[model slot]);


### PR DESCRIPTION
Fixes #353. Tested at the teststand on March 13, 2017 .