### PR TITLE
Added keep alive thread to TUBii model

### DIFF
--- a/Source/Objects/Custom Hardware/SNO+/TUBii/TUBiiModel.h
+++ b/Source/Objects/Custom Hardware/SNO+/TUBii/TUBiiModel.h
@@ -109,6 +109,7 @@ struct TUBiiState { //A struct that allows users of TUBiiModel to get/set all of
     RedisClient *connection;
     int portNumber;
     NSString* strHostName;//"192.168.80.25";
+    NSThread* _keepAliveThread;
 }
 @property (readonly) BOOL solitaryObject; //Prevents there from being two TUBiis
 @property (nonatomic) int portNumber;
@@ -134,6 +135,7 @@ struct TUBiiState { //A struct that allows users of TUBiiModel to get/set all of
 @property (nonatomic) BOOL TUBiiIsLOSrc;
 @property (nonatomic) BOOL CounterMode;
 @property (nonatomic) struct TUBiiState CurrentState; //Get/Sets a struct that fully specifies TUBii's Current state
+@property (nonatomic,retain) NSThread* keepAliveThread;
 
 #pragma mark •••Initialization
 - (id) init;
@@ -142,12 +144,14 @@ struct TUBiiState { //A struct that allows users of TUBiiModel to get/set all of
 - (void) makeMainController;
 - (void) encodeWithCoder:(NSCoder *)aCoder;
 - (void) dealloc;
+- (void) awakeAfterDocumentLoaded;
 - (BOOL) solitaryObject;
 
 - (float) ConvertBitsToValue:(NSUInteger)bits NBits: (int) nBits MinVal: (float) minVal MaxVal: (float) maxVal;
 - (NSUInteger) ConvertValueToBits: (float) value NBits: (int) nBits MinVal: (float) minVal MaxVal: (float) maxVal;
 
 - (void) sendOkCmd:(NSString* const)aCmd;
+- (void) sendOkCmd:(NSString* const)aCmd print:(BOOL)printCheck;
 - (int) sendIntCmd:(NSString* const)aCmd;
 - (NSUInteger) MTCAMimic_VoltsToBits: (float) VoltageValue;
 - (float) MTCAMimic_BitsToVolts: (NSUInteger) BitValue;
@@ -192,6 +196,9 @@ struct TUBiiState { //A struct that allows users of TUBiiModel to get/set all of
                                    CounterLZBOn: (bool) LZB
                                   CounterTestOn: (bool) TestMode
                                CounterInhibitOn: (bool) Inhibit;
+-(void)activateKeepAlive;
+-(void)pulseKeepAlive:(id)passed;
+-(void)killKeepAlive;
 @end
 
 extern NSString* ORTubiiLock;

--- a/Source/Objects/Custom Hardware/SNO+/TUBii/TUBiiModel.m
+++ b/Source/Objects/Custom Hardware/SNO+/TUBii/TUBiiModel.m
@@ -30,6 +30,8 @@ NSString* ORTubiiLock				= @"ORTubiiLock";
 @implementation TUBiiModel
 #pragma mark •••Synthesized Variables
 
+@synthesize keepAliveThread = _keepAliveThread;
+
 - (void) setUpImage
 {
     NSImage* img = [NSImage imageNamed:@"tubii"];
@@ -147,14 +149,27 @@ NSString* ORTubiiLock				= @"ORTubiiLock";
     [self ResetFifo]; //Maybe take this out eventually? I'm not sure
     [self setDataReadout:YES];
 }
+
+- (void) awakeAfterDocumentLoaded
+{
+    [self activateKeepAlive];
+}
+
 #pragma mark •••Network Communication
 - (void) sendOkCmd:(NSString* const)aCmd {
+    [self sendOkCmd:aCmd print:YES];
+}
+- (void) sendOkCmd:(NSString* const)aCmd print:(BOOL)printCheck{
     @try {
-        NSLog(@"Sending %@ to TUBii\n",aCmd);
+        if(printCheck){
+            NSLog(@"Sending %@ to TUBii\n",aCmd);
+        }
         [connection okCommand: [aCmd UTF8String]];
     }
     @catch (NSException *exception) {
-        NSLogColor([NSColor redColor],@"Command: %@ failed.  Reason: %@\n", aCmd,[exception reason]);
+        if(printCheck){
+            NSLogColor([NSColor redColor],@"Command: %@ failed.  Reason: %@\n", aCmd,[exception reason]);
+        }
     }
 }
 - (int) sendIntCmd: (NSString* const) aCmd {
@@ -737,4 +752,59 @@ NSString* ORTubiiLock				= @"ORTubiiLock";
     aState.controlReg = [self controlReg];
     return aState;
 }
+
+//////////////////////////////////////////
+// Keep alive stuff -
+// If ORCA dies we want to force tubii from
+// sending triggers to the ellie system
+-(void)activateKeepAlive
+{
+    /*
+     Start a thread to constantly send a keep alive signal to the smellie interlock server
+     */
+    [self setKeepAliveThread:[[[NSThread alloc] initWithTarget:self selector:@selector(pulseKeepAlive:) object:nil] autorelease]];
+    [[self keepAliveThread] start];
+}
+
+-(void)pulseKeepAlive:(id)passed
+{
+    /*
+     A fuction to be run in a thread, continually sending keep alive pulses to the interlock server
+     */
+    NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
+    
+    int counter = 0;
+    while (![[self keepAliveThread] isCancelled]) {
+        @try{
+            dispatch_sync(dispatch_get_main_queue(), ^{
+                [self sendOkCmd:@"keepAlive" print:NO];
+            });
+        } @catch(NSException* e) {
+            NSLogColor([NSColor redColor], @"[TUBii]: Problem sending keep alive to TUBii server, reason: %@\n", [e reason]);
+            break;
+        }
+        [NSThread sleepForTimeInterval:0.5];
+
+        // This is a very long running thread need to relase the pool every so often
+        if(counter == 1000){
+            [pool release];
+            pool = [[NSAutoreleasePool alloc] init];
+            counter = 0;
+        }
+        counter = counter + 1;
+    }
+    NSLog(@"[TUBii]: Stopped sending keep-alive to TUBii - ELLIE pulses will be shut off\n");
+    [pool release];
+}
+
+-(void)killKeepAlive
+{
+    /*
+     Stop pulsing the keep alive and disarm the interlock
+     */
+    [[self keepAliveThread] cancel];
+    NSLog(@"[TUBii]: Killing keep alive - ELLIE pulses will be shut off\n");
+}
+
+
 @end


### PR DESCRIPTION
This PR is to provide a similar emergency stop for TELLIE as we have for SMELLIE via the keep alive ORCA sends to the lasers interlock server. The idea being, if TUBii misses a keep alive (possibly due to ORCA dying), it stops sending triggers to the ELLIE systems. 

I spoke with @icoulter at the collab meeting about this and I believe he's already implemented the back end, although I'll leave it to him to confirm. One thing I don't know is the function on the TUBii server ORCA should be calling. As a place holder I've used "keepAlive", but I expect to have to update it. 