### PR TITLE
SMELLIE: Properly handle exceptions passed back by smellie server

### DIFF
--- a/Source/Experiments/SNOP/SNOPController.h
+++ b/Source/Experiments/SNOP/SNOPController.h
@@ -160,7 +160,6 @@
     // Detector State
     IBOutlet WebView* detectorState;
 }
-
 @property (nonatomic) BOOL tellieStandardSequenceFlag;
 @property (nonatomic,retain) NSDictionary *tellieFireSettings;
 @property (nonatomic,retain) NSMutableDictionary *tellieRunFileList;
@@ -242,3 +241,4 @@
 @end
 
 extern NSString* ORSNOPRequestHVStatus;
+extern NSString* ORRunWaitFinished;

--- a/Source/Objects/Custom Hardware/SNO+/ELLIE/ELLIEController.m
+++ b/Source/Objects/Custom Hardware/SNO+/ELLIE/ELLIEController.m
@@ -166,7 +166,7 @@ NSString* ORTELLIERunStart = @"ORTELLIERunStarted";
     [tellieGeneralTriggerDelayTf setDelegate:self];
     [tellieGeneralNoPulsesTf setDelegate:self];
     [tellieGeneralFreqTf setDelegate:self];
-    [tellieGeneralTriggerDelayTf setStringValue:@"700"];
+    [tellieGeneralTriggerDelayTf setStringValue:@"650"];
 
 
     [tellieChannelTf setDelegate:self];
@@ -178,13 +178,13 @@ NSString* ORTELLIERunStart = @"ORTELLIERunStarted";
     [tellieNoPulsesTf setDelegate:self];
     [tellieExpertNodeTf setDelegate:self];
     [telliePhotonsTf setDelegate:self];
-    [tellieTriggerDelayTf setStringValue:@"700"];
+    [tellieTriggerDelayTf setStringValue:@"650"];
 
     // Build custom run tab
     [tellieBuildPushToDB setEnabled:NO];
     [tellieBuildOpMode removeAllItems];
     [tellieBuildOpMode addItemsWithTitles:@[@"Slave", @"Master"]];
-    [tellieBuildTrigDelay setStringValue:@"700"];
+    [tellieBuildTrigDelay setStringValue:@"650"];
     for(int i=0; i<100; i++){
         if(i<92){
             [[tellieBuildNodeSelection cellWithTag:i] setEnabled:YES];

--- a/Source/Objects/Custom Hardware/SNO+/ELLIE/ELLIEModel.h
+++ b/Source/Objects/Custom Hardware/SNO+/ELLIE/ELLIEModel.h
@@ -135,6 +135,8 @@
 -(void) startTellieMultiRun:(NSArray*)fireCommandArray;
 -(void) startTellieRun:(NSDictionary*)fireCommands;
 -(void) stopTellieRun;
+-(void) waitForTellieRunToFinish;
+-(void) tellieTidyUp;
 
 // TELLIE database interactions
 -(void) pushInitialTellieRunDocument;
@@ -171,6 +173,8 @@
 -(void) startSmellieRunThread:(NSDictionary*)smellieSettings;
 -(void) startSmellieRun:(NSDictionary*)smellieSettings;
 -(void) stopSmellieRun;
+-(void) waitForSmellieRunToFinish;
+-(void) smellieTidyUp;
 -(NSNumber*)estimateSmellieRunTime:(NSDictionary*)smellieSettings;
 
 // SMELLIE database interactions


### PR DESCRIPTION
This PR addresses the issue that exceptions on the SMELLIE server were not being properly caught by ORCA. The server actually catches its own (internally thrown) exceptions and wraps them into a sting before passing back to ORCA. A standard try / catch in ORCA is therefore not effective.  

Two other minor issues that came up in testing are also addressed: 

Non-expert ELLIE daq users had tried to use the 'standard' stop run button in the SNOPController to stop the ELLIE system firing. I've added a check in that button push to make sure that, if required, the appropriate ELLIE stop methods are called before the run stops. 

Extended the timeout on the TELLIE server. Since moving the tellie server to SNOROP communication between the server and the TELLIE hardware is taking significantly longer than has been observed with Mac or Ubuntu systems. The ELLIE group are working on speed ups, but a extended timeout is necessary in the  short term. 