### PR TITLE
SNO+: changed start/resync logic and some GUI improvements

### DIFF
--- a/Source/Experiments/SNOP/ECARun.m
+++ b/Source/Experiments/SNOP/ECARun.m
@@ -143,7 +143,7 @@ NSString* ORECARunFinishedNotification = @"ORECARunFinishedNotification";
         if ([objs count]) {
             anMTCModel = [objs objectAtIndex:0];
             [anMTCModel setPgtRate:[[self ECA_rate] floatValue]]; //UNCOMMENT THIS LINE BEFORE COMMISSIONING
-            [anMTCModel loadPulserRateToHardware];
+            [anMTCModel loadPulserRateToHardware]; //UNCOMMENT THIS LINE BEFORE COMMISSIONING
         }
     }
 

--- a/Source/Experiments/SNOP/SNOP.xib
+++ b/Source/Experiments/SNOP/SNOP.xib
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="6254" systemVersion="13F1077" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="7706" systemVersion="14B25" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
     <dependencies>
         <deployment identifier="macosx"/>
         <development version="5100" identifier="xcode"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="6254"/>
-        <plugIn identifier="com.apple.WebKitIBPlugin" version="6254"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="7706"/>
+        <plugIn identifier="com.apple.WebKitIBPlugin" version="7706"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="SNOPController">
@@ -91,6 +91,7 @@
                 <outlet property="timeStartedField" destination="3770" id="rbE-Hw-cDc"/>
                 <outlet property="timedRunCB" destination="1344" id="1352"/>
                 <outlet property="triggerStatusMatrix" destination="Eyd-55-S8p" id="XRq-61-gjI"/>
+                <outlet property="triggersOFFButton" destination="266-Dd-MIl" id="Kne-La-m2D"/>
                 <outlet property="window" destination="5" id="950"/>
                 <outlet property="xl3Host" destination="AIC-b9-zSX" id="DnO-GW-xgy"/>
                 <outlet property="xl3Port" destination="hDG-wd-Xw9" id="1iH-de-4g5"/>
@@ -3845,11 +3846,11 @@
                     </textFieldCell>
                 </textField>
                 <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" setsMaxLayoutWidthAtFirstLayout="YES" id="hZV-C1-iie">
-                    <rect key="frame" x="18" y="10" width="642" height="51"/>
+                    <rect key="frame" x="18" y="27" width="642" height="34"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="justified" id="tKB-wq-DlE">
                         <font key="font" metaFont="system"/>
-                        <string key="title">- Modify Standard Run: go to Maintenance Run or stop the run. Then select the Standard Run you want to modify from the dropdown menu and click 'Load Standard Run'. Change the desired settings and click 'Overwrite Standard Run'.</string>
+                        <string key="title">- Modify Standard Run: select the Standard Run you want to modify from the dropdown menu and click 'Load Standard Run'. Change the desired settings and click 'Overwrite Standard Run'.</string>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>

--- a/Source/Experiments/SNOP/SNOP.xib
+++ b/Source/Experiments/SNOP/SNOP.xib
@@ -59,6 +59,7 @@
                 <outlet property="pingCratesButton" destination="drG-95-YYb" id="Aug-97-auQ"/>
                 <outlet property="rampDownCrateButton" destination="vcZ-IJ-Cct" id="noe-Li-2Q6"/>
                 <outlet property="repeatRunCB" destination="1339" id="1354"/>
+                <outlet property="resyncRunButton" destination="eox-6c-ihd" id="K4U-Io-B29"/>
                 <outlet property="runBar" destination="MBu-zu-x36" id="iTV-aT-8hr"/>
                 <outlet property="runNumberField" destination="3752" id="NlG-fq-pyu"/>
                 <outlet property="runStatusField" destination="3733" id="LhC-Ec-9HL"/>
@@ -119,8 +120,8 @@
                                     <rect key="frame" x="10" y="33" width="361" height="245"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
-                                        <button toolTip="Start/restart the standard run selected on the right panel" id="1253">
-                                            <rect key="frame" x="45" y="207" width="226" height="37"/>
+                                        <button toolTip="Start/Restart the standard run selected on the menu on the right." id="1253">
+                                            <rect key="frame" x="45" y="207" width="140" height="37"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <animations/>
                                             <buttonCell key="cell" type="bevel" title="START" bezelStyle="regularSquare" alignment="center" borderStyle="border" inset="2" id="2541">
@@ -344,7 +345,7 @@
                                                 <color key="backgroundColor" red="0.25796978300000001" green="0.50936399129999999" blue="0.89733270200000004" alpha="1" colorSpace="calibratedRGB"/>
                                             </textFieldCell>
                                         </textField>
-                                        <button toolTip="Stop run" id="1258">
+                                        <button toolTip="Stop run. XSnoed and TUB will be lose, so we should only do this if extrictly required." id="1258">
                                             <rect key="frame" x="275" y="207" width="79" height="37"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <animations/>
@@ -366,6 +367,18 @@
                                             </buttonCell>
                                             <connections>
                                                 <action selector="runsLockAction:" target="-2" id="MFs-mm-seY"/>
+                                            </connections>
+                                        </button>
+                                        <button id="eox-6c-ihd">
+                                            <rect key="frame" x="182" y="207" width="95" height="37"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <string key="toolTip">Stop run and start standard run selected on the menu on the right. Induces a dead time and should only be used when things get out of sync.</string>
+                                            <buttonCell key="cell" type="bevel" title="RESYNC" bezelStyle="regularSquare" alignment="center" borderStyle="border" inset="2" id="Ter-hb-XSn">
+                                                <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                                <font key="font" metaFont="system"/>
+                                            </buttonCell>
+                                            <connections>
+                                                <action selector="startRunAction:" target="-2" id="C6C-06-Atc"/>
                                             </connections>
                                         </button>
                                     </subviews>

--- a/Source/Experiments/SNOP/SNOP.xib
+++ b/Source/Experiments/SNOP/SNOP.xib
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="7706" systemVersion="14B25" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="6254" systemVersion="13F1077" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
     <dependencies>
         <deployment identifier="macosx"/>
         <development version="5100" identifier="xcode"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="7706"/>
-        <plugIn identifier="com.apple.WebKitIBPlugin" version="7706"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="6254"/>
+        <plugIn identifier="com.apple.WebKitIBPlugin" version="6254"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="SNOPController">
@@ -59,7 +59,6 @@
                 <outlet property="pingCratesButton" destination="drG-95-YYb" id="Aug-97-auQ"/>
                 <outlet property="rampDownCrateButton" destination="vcZ-IJ-Cct" id="noe-Li-2Q6"/>
                 <outlet property="repeatRunCB" destination="1339" id="1354"/>
-                <outlet property="resyncRunButton" destination="VHx-5C-HlN" id="t2u-ao-6Ph"/>
                 <outlet property="runBar" destination="MBu-zu-x36" id="iTV-aT-8hr"/>
                 <outlet property="runNumberField" destination="3752" id="NlG-fq-pyu"/>
                 <outlet property="runStatusField" destination="3733" id="LhC-Ec-9HL"/>
@@ -73,6 +72,7 @@
                 <outlet property="smellieStopRunButton" destination="3548" id="3612"/>
                 <outlet property="snopView" destination="6" id="Vn9-RA-Mde"/>
                 <outlet property="standardRunLoadButton" destination="ySv-iP-Vo5" id="yYU-zM-j8N"/>
+                <outlet property="standardRunLoadinHWButton" destination="Crj-yn-wMV" id="cQP-hI-LHo"/>
                 <outlet property="standardRunPopupMenu" destination="xjE-ug-crJ" id="6RP-6D-4Dl"/>
                 <outlet property="standardRunSaveButton" destination="sQD-Yo-L3O" id="e4J-4j-lMT"/>
                 <outlet property="standardRunThresCurrentValues" destination="aqZ-km-AbR" id="WKc-EH-TpC"/>
@@ -90,6 +90,7 @@
                 <outlet property="timeLimitField" destination="1342" id="1353"/>
                 <outlet property="timeStartedField" destination="3770" id="rbE-Hw-cDc"/>
                 <outlet property="timedRunCB" destination="1344" id="1352"/>
+                <outlet property="triggerStatusMatrix" destination="Eyd-55-S8p" id="XRq-61-gjI"/>
                 <outlet property="window" destination="5" id="950"/>
                 <outlet property="xl3Host" destination="AIC-b9-zSX" id="DnO-GW-xgy"/>
                 <outlet property="xl3Port" destination="hDG-wd-Xw9" id="1iH-de-4g5"/>
@@ -117,8 +118,8 @@
                                     <rect key="frame" x="10" y="33" width="361" height="245"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
-                                        <button toolTip="start/restart run" id="1253">
-                                            <rect key="frame" x="45" y="207" width="144" height="37"/>
+                                        <button toolTip="Start/restart the standard run selected on the right panel" id="1253">
+                                            <rect key="frame" x="45" y="207" width="226" height="37"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <animations/>
                                             <buttonCell key="cell" type="bevel" title="START" bezelStyle="regularSquare" alignment="center" borderStyle="border" inset="2" id="2541">
@@ -279,18 +280,6 @@
                                             <autoresizingMask key="autoresizingMask"/>
                                             <animations/>
                                         </customView>
-                                        <button toolTip="stop run" id="VHx-5C-HlN">
-                                            <rect key="frame" x="193" y="207" width="79" height="37"/>
-                                            <autoresizingMask key="autoresizingMask"/>
-                                            <animations/>
-                                            <buttonCell key="cell" type="bevel" title="RESYNC" bezelStyle="regularSquare" imagePosition="overlaps" alignment="center" state="on" borderStyle="border" inset="2" id="0IS-is-zEN">
-                                                <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                                <font key="font" metaFont="system"/>
-                                            </buttonCell>
-                                            <connections>
-                                                <action selector="resyncRunAction:" target="-2" id="Dts-ba-02a"/>
-                                            </connections>
-                                        </button>
                                         <progressIndicator verticalHuggingPriority="750" maxValue="100" bezeled="NO" controlSize="small" style="bar" id="MBu-zu-x36">
                                             <rect key="frame" x="23" y="35" width="315" height="12"/>
                                             <autoresizingMask key="autoresizingMask"/>
@@ -354,7 +343,7 @@
                                                 <color key="backgroundColor" red="0.25796978300000001" green="0.50936399129999999" blue="0.89733270200000004" alpha="1" colorSpace="calibratedRGB"/>
                                             </textFieldCell>
                                         </textField>
-                                        <button toolTip="stop run" id="1258">
+                                        <button toolTip="Stop run" id="1258">
                                             <rect key="frame" x="275" y="207" width="79" height="37"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <animations/>
@@ -437,6 +426,69 @@
                             </tabViewItem>
                         </tabViewItems>
                     </tabView>
+                    <tabView id="piT-mW-S89">
+                        <rect key="frame" x="13" y="10" width="381" height="263"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                        <animations/>
+                        <font key="font" metaFont="system"/>
+                        <tabViewItems>
+                            <tabViewItem label="Detector control" identifier="1" id="sHF-Zg-ohR">
+                                <view key="view" id="02S-l8-M0K">
+                                    <rect key="frame" x="10" y="33" width="361" height="217"/>
+                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                    <subviews>
+                                        <button id="266-Dd-MIl">
+                                            <rect key="frame" x="15" y="111" width="333" height="55"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                            <animations/>
+                                            <buttonCell key="cell" type="bevel" title="TRIGGERS OFF" bezelStyle="regularSquare" imagePosition="overlaps" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="y3E-wc-fQv">
+                                                <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                                <font key="font" size="14" name="EuphemiaUCAS-Bold"/>
+                                            </buttonCell>
+                                            <connections>
+                                                <action selector="hvMasterTriggersOFF:" target="-2" id="uh1-wY-dHE"/>
+                                            </connections>
+                                        </button>
+                                        <textField verticalHuggingPriority="750" id="fHi-qS-g5A">
+                                            <rect key="frame" x="17" y="12" width="329" height="36"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                            <animations/>
+                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" alignment="center" title="PMT HV is OFF" drawsBackground="YES" id="GSL-gk-28T">
+                                                <font key="font" metaFont="system" size="22"/>
+                                                <color key="textColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" red="0.25796978300000001" green="0.50936399129999999" blue="0.89733270200000004" alpha="1" colorSpace="calibratedRGB"/>
+                                            </textFieldCell>
+                                        </textField>
+                                        <button id="zmA-F4-wTd">
+                                            <rect key="frame" x="15" y="53" width="333" height="55"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                            <animations/>
+                                            <buttonCell key="cell" type="bevel" title="PANIC DOWN" bezelStyle="regularSquare" imagePosition="overlaps" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="A2d-ym-1VI">
+                                                <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                                <font key="font" size="14" name="EuphemiaUCAS-Bold"/>
+                                            </buttonCell>
+                                            <connections>
+                                                <action selector="hvMasterPanicAction:" target="-2" id="Dmd-aj-sUv"/>
+                                            </connections>
+                                        </button>
+                                        <button id="drG-95-YYb">
+                                            <rect key="frame" x="15" y="169" width="158" height="47"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                            <animations/>
+                                            <buttonCell key="cell" type="bevel" title="Ping Crates" bezelStyle="regularSquare" imagePosition="overlaps" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="Nbm-1z-7bg">
+                                                <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                                <font key="font" metaFont="system"/>
+                                            </buttonCell>
+                                            <connections>
+                                                <action selector="pingCratesAction:" target="-2" id="gaE-se-Lfq"/>
+                                            </connections>
+                                        </button>
+                                    </subviews>
+                                    <animations/>
+                                </view>
+                            </tabViewItem>
+                        </tabViewItems>
+                    </tabView>
                     <tabView controlSize="small" id="101">
                         <rect key="frame" x="394" y="10" width="793" height="673"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -491,7 +543,7 @@
                                                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                         </textFieldCell>
                                                     </textField>
-                                                    <matrix verticalHuggingPriority="750" mode="highlight" allowsEmptySelection="NO" autosizesCells="NO" id="zuQ-GY-eWY">
+                                                    <matrix toolTip="Run type word of the selected standard run" verticalHuggingPriority="750" mode="highlight" allowsEmptySelection="NO" autosizesCells="NO" id="zuQ-GY-eWY">
                                                         <rect key="frame" x="122" y="72" width="20" height="512"/>
                                                         <autoresizingMask key="autoresizingMask"/>
                                                         <animations/>
@@ -637,7 +689,7 @@
                                                             <action selector="runTypeWordAction:" target="-2" id="Xer-fp-uZc"/>
                                                         </connections>
                                                     </matrix>
-                                                    <matrix verticalHuggingPriority="750" mode="highlight" allowsEmptySelection="NO" autosizesCells="NO" id="3935">
+                                                    <matrix toolTip="Current run type word" verticalHuggingPriority="750" mode="highlight" allowsEmptySelection="NO" autosizesCells="NO" id="3935">
                                                         <rect key="frame" x="8" y="72" width="119" height="512"/>
                                                         <autoresizingMask key="autoresizingMask"/>
                                                         <animations/>
@@ -790,15 +842,15 @@
                                             <color key="borderColor" white="0.0" alpha="0.41999999999999998" colorSpace="calibratedWhite"/>
                                             <color key="fillColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                         </box>
-                                        <box autoresizesSubviews="NO" title="Select a Standard Run or create a new one" borderType="line" id="3680">
-                                            <rect key="frame" x="2" y="340" width="618" height="289"/>
+                                        <box autoresizesSubviews="NO" borderType="line" id="3680">
+                                            <rect key="frame" x="2" y="340" width="618" height="309"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <view key="contentView">
-                                                <rect key="frame" x="1" y="1" width="616" height="273"/>
+                                                <rect key="frame" x="1" y="1" width="616" height="293"/>
                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                 <subviews>
                                                     <textField verticalHuggingPriority="750" id="3685">
-                                                        <rect key="frame" x="91" y="76" width="4" height="17"/>
+                                                        <rect key="frame" x="91" y="86" width="4" height="17"/>
                                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                         <animations/>
                                                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" id="3694">
@@ -807,8 +859,8 @@
                                                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                         </textFieldCell>
                                                     </textField>
-                                                    <comboBox verticalHuggingPriority="750" id="xjE-ug-crJ">
-                                                        <rect key="frame" x="18" y="206" width="189" height="22"/>
+                                                    <comboBox toolTip="Standard run name. Click 'Refresh standard runs' if empty." verticalHuggingPriority="750" id="xjE-ug-crJ">
+                                                        <rect key="frame" x="18" y="216" width="189" height="22"/>
                                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                         <animations/>
                                                         <comboBoxCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" placeholderString="Standard Run" drawsBackground="YES" numberOfVisibleItems="10" id="12x-oz-P6Z">
@@ -820,8 +872,8 @@
                                                             <action selector="standardRunPopupAction:" target="-2" id="B24-L4-eyd"/>
                                                         </connections>
                                                     </comboBox>
-                                                    <comboBox verticalHuggingPriority="750" id="0tV-8Q-LGs">
-                                                        <rect key="frame" x="18" y="158" width="189" height="22"/>
+                                                    <comboBox toolTip="Standard run version (not available for non-experts). Click 'Refresh Standard Runs' if empty." verticalHuggingPriority="750" id="0tV-8Q-LGs">
+                                                        <rect key="frame" x="18" y="168" width="189" height="22"/>
                                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                         <animations/>
                                                         <comboBoxCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" placeholderString="Test Run" drawsBackground="YES" numberOfVisibleItems="10" id="HKw-bJ-vsh">
@@ -834,7 +886,7 @@
                                                         </connections>
                                                     </comboBox>
                                                     <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" setsMaxLayoutWidthAtFirstLayout="YES" id="qNy-JH-zTn">
-                                                        <rect key="frame" x="16" y="230" width="74" height="14"/>
+                                                        <rect key="frame" x="16" y="240" width="74" height="14"/>
                                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                         <animations/>
                                                         <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" alignment="left" title="Run Name:" id="9Vj-zg-dZz">
@@ -844,7 +896,7 @@
                                                         </textFieldCell>
                                                     </textField>
                                                     <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" setsMaxLayoutWidthAtFirstLayout="YES" id="xdp-to-RxG">
-                                                        <rect key="frame" x="16" y="187" width="147" height="14"/>
+                                                        <rect key="frame" x="16" y="197" width="147" height="14"/>
                                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                         <animations/>
                                                         <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" alignment="left" title="Test Run (experts only):" id="eCY-x0-2L5">
@@ -853,8 +905,8 @@
                                                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                         </textFieldCell>
                                                     </textField>
-                                                    <matrix verticalHuggingPriority="750" mode="highlight" allowsEmptySelection="NO" id="aqZ-km-AbR">
-                                                        <rect key="frame" x="315" y="5" width="67" height="250"/>
+                                                    <matrix toolTip="Current settings. This does NOT necessarily reflects the current state of the hardware" verticalHuggingPriority="750" mode="highlight" allowsEmptySelection="NO" id="aqZ-km-AbR">
+                                                        <rect key="frame" x="315" y="15" width="67" height="250"/>
                                                         <autoresizingMask key="autoresizingMask"/>
                                                         <animations/>
                                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
@@ -934,7 +986,7 @@
                                                         </connections>
                                                     </matrix>
                                                     <matrix verticalHuggingPriority="750" mode="highlight" allowsEmptySelection="NO" id="1C9-Y7-cRf">
-                                                        <rect key="frame" x="221" y="3" width="86" height="250"/>
+                                                        <rect key="frame" x="221" y="13" width="86" height="250"/>
                                                         <autoresizingMask key="autoresizingMask"/>
                                                         <animations/>
                                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
@@ -1011,11 +1063,11 @@
                                                         </cells>
                                                     </matrix>
                                                     <matrix verticalHuggingPriority="750" mode="highlight" allowsEmptySelection="NO" id="LGP-uV-afe">
-                                                        <rect key="frame" x="467" y="3" width="48" height="250"/>
+                                                        <rect key="frame" x="467" y="13" width="131" height="250"/>
                                                         <autoresizingMask key="autoresizingMask"/>
                                                         <animations/>
                                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                        <size key="cellSize" width="48" height="19"/>
+                                                        <size key="cellSize" width="131" height="19"/>
                                                         <size key="intercellSpacing" width="0.0" height="2"/>
                                                         <textFieldCell key="prototype" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Label" id="3E9-4a-aA7">
                                                             <font key="font" metaFont="smallSystem"/>
@@ -1088,7 +1140,7 @@
                                                         </cells>
                                                     </matrix>
                                                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="l6U-aI-Rnh">
-                                                        <rect key="frame" x="311" y="259" width="75" height="14"/>
+                                                        <rect key="frame" x="311" y="269" width="75" height="14"/>
                                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                         <animations/>
                                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Current value" id="n5W-I2-K9j">
@@ -1097,8 +1149,8 @@
                                                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                         </textFieldCell>
                                                     </textField>
-                                                    <button verticalHuggingPriority="750" id="Gv3-u0-KqL">
-                                                        <rect key="frame" x="13" y="242" width="158" height="28"/>
+                                                    <button toolTip="Populate the menus below" verticalHuggingPriority="750" id="Gv3-u0-KqL">
+                                                        <rect key="frame" x="53" y="252" width="158" height="28"/>
                                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                         <animations/>
                                                         <buttonCell key="cell" type="push" title="Refresh Standard Runs" bezelStyle="rounded" alignment="center" controlSize="small" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="kjE-bk-bEs">
@@ -1109,8 +1161,8 @@
                                                             <action selector="refreshStandardRunsAction:" target="-2" id="47T-Sq-O6v"/>
                                                         </connections>
                                                     </button>
-                                                    <button toolTip="This button will save MTCD/A settings like thresholds and trigger masks" verticalHuggingPriority="750" allowsExpansionToolTips="YES" id="sQD-Yo-L3O">
-                                                        <rect key="frame" x="32" y="95" width="158" height="28"/>
+                                                    <button toolTip="Save the current settings for the selected standard run" verticalHuggingPriority="750" allowsExpansionToolTips="YES" id="sQD-Yo-L3O">
+                                                        <rect key="frame" x="24" y="105" width="174" height="28"/>
                                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                         <animations/>
                                                         <buttonCell key="cell" type="push" title="Overwrite Standard Run" bezelStyle="rounded" alignment="center" controlSize="small" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="NCG-Lr-klR">
@@ -1121,8 +1173,8 @@
                                                             <action selector="saveStandardRunToDBAction:" target="-2" id="Tq3-yC-Oo0"/>
                                                         </connections>
                                                     </button>
-                                                    <button verticalHuggingPriority="750" id="ySv-iP-Vo5">
-                                                        <rect key="frame" x="31" y="123" width="158" height="28"/>
+                                                    <button toolTip="Load the selected standard run whose settings are displayed in the 'DB value' column. This does NOT load settings into hardware" verticalHuggingPriority="750" id="ySv-iP-Vo5">
+                                                        <rect key="frame" x="24" y="133" width="174" height="28"/>
                                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                         <animations/>
                                                         <buttonCell key="cell" type="push" title="Load Standard Run" bezelStyle="rounded" alignment="center" controlSize="small" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="N75-hx-Szw">
@@ -1133,8 +1185,19 @@
                                                             <action selector="loadStandardRunFromDBAction:" target="-2" id="SJW-Zh-0Ce"/>
                                                         </connections>
                                                     </button>
+                                                    <button toolTip="Load the current settings displayed in the 'Current value' column into hardware" verticalHuggingPriority="750" id="Crj-yn-wMV">
+                                                        <rect key="frame" x="24" y="27" width="174" height="28"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <buttonCell key="cell" type="push" title="Load current settings in HW" bezelStyle="rounded" alignment="center" controlSize="small" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="oRA-DD-VCl">
+                                                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                        </buttonCell>
+                                                        <connections>
+                                                            <action selector="loadCurrentSettingsInHW:" target="-2" id="S1k-W1-To4"/>
+                                                        </connections>
+                                                    </button>
                                                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="Uqm-n9-en5">
-                                                        <rect key="frame" x="402" y="259" width="52" height="14"/>
+                                                        <rect key="frame" x="402" y="269" width="52" height="14"/>
                                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                         <animations/>
                                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="DB value" id="Vr6-PR-f3D">
@@ -1143,8 +1206,8 @@
                                                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                         </textFieldCell>
                                                     </textField>
-                                                    <matrix verticalHuggingPriority="750" mode="highlight" allowsEmptySelection="NO" id="hkr-OH-tez">
-                                                        <rect key="frame" x="381" y="3" width="86" height="250"/>
+                                                    <matrix toolTip="Settings stored in the selected standard run" verticalHuggingPriority="750" mode="highlight" allowsEmptySelection="NO" id="hkr-OH-tez">
+                                                        <rect key="frame" x="381" y="13" width="86" height="250"/>
                                                         <autoresizingMask key="autoresizingMask"/>
                                                         <animations/>
                                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
@@ -1220,6 +1283,17 @@
                                                             </column>
                                                         </cells>
                                                     </matrix>
+                                                    <button toolTip="Click 'Refresh Standard Runs' if the menus have no items" horizontalHuggingPriority="750" verticalHuggingPriority="750" id="eIS-LN-d9H">
+                                                        <rect key="frame" x="16" y="254" width="25" height="25"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <buttonCell key="cell" type="help" bezelStyle="helpButton" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="o5K-Vc-Obh">
+                                                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                                            <font key="font" metaFont="system"/>
+                                                        </buttonCell>
+                                                        <connections>
+                                                            <action selector="toggle:" target="GP4-io-1nq" id="Mp0-B0-ze8"/>
+                                                        </connections>
+                                                    </button>
                                                 </subviews>
                                                 <animations/>
                                             </view>
@@ -1975,612 +2049,51 @@
                                     <rect key="frame" x="10" y="25" width="773" height="635"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
-                                        <matrix verticalHuggingPriority="750" mode="highlight" allowsEmptySelection="NO" autosizesCells="NO" id="2830">
-                                            <rect key="frame" x="18" y="166" width="435" height="400"/>
-                                            <autoresizingMask key="autoresizingMask"/>
-                                            <animations/>
-                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                            <size key="cellSize" width="87" height="20"/>
-                                            <textFieldCell key="prototype" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Label" id="2831">
-                                                <font key="font" metaFont="smallSystem"/>
-                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                            </textFieldCell>
-                                            <cells>
-                                                <column>
-                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="0" id="2829">
-                                                        <font key="font" metaFont="smallSystem"/>
-                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                    </textFieldCell>
-                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="1" title="1" id="2843">
-                                                        <font key="font" metaFont="smallSystem"/>
-                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                    </textFieldCell>
-                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="2" title="2" id="2842">
-                                                        <font key="font" metaFont="smallSystem"/>
-                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                    </textFieldCell>
-                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="3" title="3" id="2850">
-                                                        <font key="font" metaFont="smallSystem"/>
-                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                    </textFieldCell>
-                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="4" title="4" id="2838">
-                                                        <font key="font" metaFont="smallSystem"/>
-                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                    </textFieldCell>
-                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="5" title="5" id="2848">
-                                                        <font key="font" metaFont="smallSystem"/>
-                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                    </textFieldCell>
-                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="6" title="6" id="2834">
-                                                        <font key="font" metaFont="smallSystem"/>
-                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                    </textFieldCell>
-                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="7" title="7" id="2839">
-                                                        <font key="font" metaFont="smallSystem"/>
-                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                    </textFieldCell>
-                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="8" title="8" id="2835">
-                                                        <font key="font" metaFont="smallSystem"/>
-                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                    </textFieldCell>
-                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="9" title="9" id="2840">
-                                                        <font key="font" metaFont="smallSystem"/>
-                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                    </textFieldCell>
-                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="10" title="10" id="2844">
-                                                        <font key="font" metaFont="smallSystem"/>
-                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                    </textFieldCell>
-                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="11" title="11" id="2841">
-                                                        <font key="font" metaFont="smallSystem"/>
-                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                    </textFieldCell>
-                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="12" title="12" id="2847">
-                                                        <font key="font" metaFont="smallSystem"/>
-                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                    </textFieldCell>
-                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="13" title="13" id="2836">
-                                                        <font key="font" metaFont="smallSystem"/>
-                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                    </textFieldCell>
-                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="14" title="14" id="2837">
-                                                        <font key="font" metaFont="smallSystem"/>
-                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                    </textFieldCell>
-                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="15" title="15" id="2846">
-                                                        <font key="font" metaFont="smallSystem"/>
-                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                    </textFieldCell>
-                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="16" title="16A" id="2849">
-                                                        <font key="font" metaFont="smallSystem"/>
-                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                    </textFieldCell>
-                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="19" title="16B" id="2851">
-                                                        <font key="font" metaFont="smallSystem"/>
-                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                    </textFieldCell>
-                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="17" title="17" id="2845">
-                                                        <font key="font" metaFont="smallSystem"/>
-                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                    </textFieldCell>
-                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="18" title="18" id="2833">
-                                                        <font key="font" metaFont="smallSystem"/>
-                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                    </textFieldCell>
-                                                </column>
-                                                <column>
-                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="OFF" id="2858">
-                                                        <font key="font" metaFont="smallSystem"/>
-                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                    </textFieldCell>
-                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="ON" id="2862">
-                                                        <font key="font" metaFont="smallSystem"/>
-                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                    </textFieldCell>
-                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="Label" id="2854">
-                                                        <font key="font" metaFont="smallSystem"/>
-                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                    </textFieldCell>
-                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="Label" id="2868">
-                                                        <font key="font" metaFont="smallSystem"/>
-                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                    </textFieldCell>
-                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="Label" id="2852">
-                                                        <font key="font" metaFont="smallSystem"/>
-                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                    </textFieldCell>
-                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="Label" id="2864">
-                                                        <font key="font" metaFont="smallSystem"/>
-                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                    </textFieldCell>
-                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="Label" id="2871">
-                                                        <font key="font" metaFont="smallSystem"/>
-                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                    </textFieldCell>
-                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="Label" id="2869">
-                                                        <font key="font" metaFont="smallSystem"/>
-                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                    </textFieldCell>
-                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="Label" id="2867">
-                                                        <font key="font" metaFont="smallSystem"/>
-                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                    </textFieldCell>
-                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="Label" id="2855">
-                                                        <font key="font" metaFont="smallSystem"/>
-                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                    </textFieldCell>
-                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="Label" id="2856">
-                                                        <font key="font" metaFont="smallSystem"/>
-                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                    </textFieldCell>
-                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="Label" id="2859">
-                                                        <font key="font" metaFont="smallSystem"/>
-                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                    </textFieldCell>
-                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="Label" id="2863">
-                                                        <font key="font" metaFont="smallSystem"/>
-                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                    </textFieldCell>
-                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="Label" id="2857">
-                                                        <font key="font" metaFont="smallSystem"/>
-                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                    </textFieldCell>
-                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="Label" id="2866">
-                                                        <font key="font" metaFont="smallSystem"/>
-                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                    </textFieldCell>
-                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="Label" id="2865">
-                                                        <font key="font" metaFont="smallSystem"/>
-                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                    </textFieldCell>
-                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="Label" id="2860">
-                                                        <font key="font" metaFont="smallSystem"/>
-                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                    </textFieldCell>
-                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="Label" id="2853">
-                                                        <font key="font" metaFont="smallSystem"/>
-                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                    </textFieldCell>
-                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="Label" id="2870">
-                                                        <font key="font" metaFont="smallSystem"/>
-                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                    </textFieldCell>
-                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="Label" id="2861">
-                                                        <font key="font" metaFont="smallSystem"/>
-                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                    </textFieldCell>
-                                                </column>
-                                                <column>
-                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="0.0 V" id="2883">
-                                                        <font key="font" metaFont="smallSystem"/>
-                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                    </textFieldCell>
-                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="2000.0 V" id="2879">
-                                                        <font key="font" metaFont="smallSystem"/>
-                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                    </textFieldCell>
-                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="Label" id="2891">
-                                                        <font key="font" metaFont="smallSystem"/>
-                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                    </textFieldCell>
-                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="Label" id="2887">
-                                                        <font key="font" metaFont="smallSystem"/>
-                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                    </textFieldCell>
-                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="Label" id="2878">
-                                                        <font key="font" metaFont="smallSystem"/>
-                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                    </textFieldCell>
-                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="Label" id="2890">
-                                                        <font key="font" metaFont="smallSystem"/>
-                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                    </textFieldCell>
-                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="Label" id="2876">
-                                                        <font key="font" metaFont="smallSystem"/>
-                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                    </textFieldCell>
-                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="Label" id="2882">
-                                                        <font key="font" metaFont="smallSystem"/>
-                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                    </textFieldCell>
-                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="Label" id="2874">
-                                                        <font key="font" metaFont="smallSystem"/>
-                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                    </textFieldCell>
-                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="Label" id="2877">
-                                                        <font key="font" metaFont="smallSystem"/>
-                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                    </textFieldCell>
-                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="Label" id="2889">
-                                                        <font key="font" metaFont="smallSystem"/>
-                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                    </textFieldCell>
-                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="Label" id="2880">
-                                                        <font key="font" metaFont="smallSystem"/>
-                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                    </textFieldCell>
-                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="Label" id="2886">
-                                                        <font key="font" metaFont="smallSystem"/>
-                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                    </textFieldCell>
-                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="Label" id="2884">
-                                                        <font key="font" metaFont="smallSystem"/>
-                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                    </textFieldCell>
-                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="Label" id="2872">
-                                                        <font key="font" metaFont="smallSystem"/>
-                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                    </textFieldCell>
-                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="Label" id="2873">
-                                                        <font key="font" metaFont="smallSystem"/>
-                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                    </textFieldCell>
-                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="Label" id="2885">
-                                                        <font key="font" metaFont="smallSystem"/>
-                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                    </textFieldCell>
-                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="Label" id="2881">
-                                                        <font key="font" metaFont="smallSystem"/>
-                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                    </textFieldCell>
-                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="Label" id="2888">
-                                                        <font key="font" metaFont="smallSystem"/>
-                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                    </textFieldCell>
-                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="Label" id="2875">
-                                                        <font key="font" metaFont="smallSystem"/>
-                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                    </textFieldCell>
-                                                </column>
-                                                <column>
-                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="0.0 V" id="2909">
-                                                        <font key="font" metaFont="smallSystem"/>
-                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                    </textFieldCell>
-                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="2000.0 V" id="2900">
-                                                        <font key="font" metaFont="smallSystem"/>
-                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                    </textFieldCell>
-                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="Label" id="2892">
-                                                        <font key="font" metaFont="smallSystem"/>
-                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                    </textFieldCell>
-                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="Label" id="2911">
-                                                        <font key="font" metaFont="smallSystem"/>
-                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                    </textFieldCell>
-                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="Label" id="2895">
-                                                        <font key="font" metaFont="smallSystem"/>
-                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                    </textFieldCell>
-                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="Label" id="2906">
-                                                        <font key="font" metaFont="smallSystem"/>
-                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                    </textFieldCell>
-                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="Label" id="2893">
-                                                        <font key="font" metaFont="smallSystem"/>
-                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                    </textFieldCell>
-                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="Label" id="2901">
-                                                        <font key="font" metaFont="smallSystem"/>
-                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                    </textFieldCell>
-                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="Label" id="2904">
-                                                        <font key="font" metaFont="smallSystem"/>
-                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                    </textFieldCell>
-                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="Label" id="2898">
-                                                        <font key="font" metaFont="smallSystem"/>
-                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                    </textFieldCell>
-                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="Label" id="2899">
-                                                        <font key="font" metaFont="smallSystem"/>
-                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                    </textFieldCell>
-                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="Label" id="2907">
-                                                        <font key="font" metaFont="smallSystem"/>
-                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                    </textFieldCell>
-                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="Label" id="2897">
-                                                        <font key="font" metaFont="smallSystem"/>
-                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                    </textFieldCell>
-                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="Label" id="2910">
-                                                        <font key="font" metaFont="smallSystem"/>
-                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                    </textFieldCell>
-                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="Label" id="2908">
-                                                        <font key="font" metaFont="smallSystem"/>
-                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                    </textFieldCell>
-                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="Label" id="2903">
-                                                        <font key="font" metaFont="smallSystem"/>
-                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                    </textFieldCell>
-                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="Label" id="2896">
-                                                        <font key="font" metaFont="smallSystem"/>
-                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                    </textFieldCell>
-                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="Label" id="2902">
-                                                        <font key="font" metaFont="smallSystem"/>
-                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                    </textFieldCell>
-                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="Label" id="2894">
-                                                        <font key="font" metaFont="smallSystem"/>
-                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                    </textFieldCell>
-                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="Label" id="2905">
-                                                        <font key="font" metaFont="smallSystem"/>
-                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                    </textFieldCell>
-                                                </column>
-                                                <column>
-                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="0 mA" id="2928">
-                                                        <font key="font" metaFont="smallSystem"/>
-                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                    </textFieldCell>
-                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="0 mA" id="2927">
-                                                        <font key="font" metaFont="smallSystem"/>
-                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                    </textFieldCell>
-                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="Label" id="2920">
-                                                        <font key="font" metaFont="smallSystem"/>
-                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                    </textFieldCell>
-                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="Label" id="2923">
-                                                        <font key="font" metaFont="smallSystem"/>
-                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                    </textFieldCell>
-                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="Label" id="2931">
-                                                        <font key="font" metaFont="smallSystem"/>
-                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                    </textFieldCell>
-                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="Label" id="2930">
-                                                        <font key="font" metaFont="smallSystem"/>
-                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                    </textFieldCell>
-                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="Label" id="2924">
-                                                        <font key="font" metaFont="smallSystem"/>
-                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                    </textFieldCell>
-                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="Label" id="2934">
-                                                        <font key="font" metaFont="smallSystem"/>
-                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                    </textFieldCell>
-                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="Label" id="2929">
-                                                        <font key="font" metaFont="smallSystem"/>
-                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                    </textFieldCell>
-                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="Label" id="2917">
-                                                        <font key="font" metaFont="smallSystem"/>
-                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                    </textFieldCell>
-                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="Label" id="2922">
-                                                        <font key="font" metaFont="smallSystem"/>
-                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                    </textFieldCell>
-                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="Label" id="2932">
-                                                        <font key="font" metaFont="smallSystem"/>
-                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                    </textFieldCell>
-                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="Label" id="2933">
-                                                        <font key="font" metaFont="smallSystem"/>
-                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                    </textFieldCell>
-                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="Label" id="2925">
-                                                        <font key="font" metaFont="smallSystem"/>
-                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                    </textFieldCell>
-                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="Label" id="2916">
-                                                        <font key="font" metaFont="smallSystem"/>
-                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                    </textFieldCell>
-                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="Label" id="2921">
-                                                        <font key="font" metaFont="smallSystem"/>
-                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                    </textFieldCell>
-                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="Label" id="2918">
-                                                        <font key="font" metaFont="smallSystem"/>
-                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                    </textFieldCell>
-                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="Label" id="2919">
-                                                        <font key="font" metaFont="smallSystem"/>
-                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                    </textFieldCell>
-                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="Label" id="2935">
-                                                        <font key="font" metaFont="smallSystem"/>
-                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                    </textFieldCell>
-                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="Label" id="2926">
-                                                        <font key="font" metaFont="smallSystem"/>
-                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                    </textFieldCell>
-                                                </column>
-                                            </cells>
-                                        </matrix>
                                         <textField verticalHuggingPriority="750" id="2947">
-                                            <rect key="frame" x="153" y="574" width="39" height="14"/>
+                                            <rect key="frame" x="19" y="540" width="64" height="14"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <animations/>
-                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Switch" id="2948">
+                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Crate/Rack" id="2948">
                                                 <font key="font" metaFont="smallSystem"/>
                                                 <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                             </textFieldCell>
                                         </textField>
                                         <textField verticalHuggingPriority="750" id="2949">
-                                            <rect key="frame" x="231" y="574" width="49" height="14"/>
+                                            <rect key="frame" x="112" y="540" width="57" height="14"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <animations/>
-                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Nominal" id="2950">
+                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="HV Status" id="2950">
+                                                <font key="font" metaFont="smallSystem"/>
+                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
+                                        <textField verticalHuggingPriority="750" id="gCC-Md-uma">
+                                            <rect key="frame" x="267" y="541" width="67" height="14"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="HV Nominal" id="hJ3-i3-7c7">
                                                 <font key="font" metaFont="smallSystem"/>
                                                 <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                             </textFieldCell>
                                         </textField>
                                         <textField verticalHuggingPriority="750" id="2951">
-                                            <rect key="frame" x="339" y="574" width="28" height="14"/>
+                                            <rect key="frame" x="372" y="541" width="47" height="14"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <animations/>
-                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Now" id="2952">
-                                                <font key="font" metaFont="smallSystem"/>
-                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                            </textFieldCell>
-                                        </textField>
-                                        <textField verticalHuggingPriority="750" id="2953">
-                                            <rect key="frame" x="423" y="574" width="38" height="14"/>
-                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                            <animations/>
-                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Now" id="2954">
-                                                <font key="font" metaFont="smallSystem"/>
-                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                            </textFieldCell>
-                                        </textField>
-                                        <box autoresizesSubviews="NO" title="Global HV Controls" borderType="line" id="3971">
-                                            <rect key="frame" x="90" y="43" width="291" height="68"/>
-                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                            <view key="contentView">
-                                                <rect key="frame" x="1" y="1" width="289" height="52"/>
-                                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                                                <subviews>
-                                                    <button verticalHuggingPriority="750" id="2942">
-                                                        <rect key="frame" x="12" y="11" width="112" height="32"/>
-                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                                        <animations/>
-                                                        <buttonCell key="cell" type="push" title="HV Status" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="2943">
-                                                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                                            <font key="font" metaFont="system"/>
-                                                        </buttonCell>
-                                                        <connections>
-                                                            <action selector="hvMasterStatus:" target="-2" id="2957"/>
-                                                        </connections>
-                                                    </button>
-                                                </subviews>
-                                                <animations/>
-                                            </view>
-                                            <animations/>
-                                            <color key="borderColor" white="0.0" alpha="0.41999999999999998" colorSpace="calibratedWhite"/>
-                                            <color key="fillColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
-                                        </box>
-                                        <textField verticalHuggingPriority="750" id="4041">
-                                            <rect key="frame" x="492" y="574" width="57" height="14"/>
-                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                            <animations/>
-                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="XL3 Mode" id="4042">
+                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="HV Now" id="2952">
                                                 <font key="font" metaFont="smallSystem"/>
                                                 <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                             </textFieldCell>
                                         </textField>
                                         <matrix verticalHuggingPriority="750" mode="highlight" allowsEmptySelection="NO" autosizesCells="NO" id="4194">
-                                            <rect key="frame" x="499" y="171" width="38" height="394"/>
+                                            <rect key="frame" x="583" y="137" width="59" height="394"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <animations/>
                                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                            <size key="cellSize" width="38" height="14"/>
+                                            <size key="cellSize" width="59" height="14"/>
                                             <size key="intercellSpacing" width="0.0" height="6"/>
                                             <textFieldCell key="prototype" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Label" id="4195">
                                                 <font key="font" metaFont="smallSystem"/>
@@ -2589,102 +2102,102 @@
                                             </textFieldCell>
                                             <cells>
                                                 <column>
-                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Label" id="4002">
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="Normal" id="4002">
                                                         <font key="font" metaFont="smallSystem"/>
                                                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                     </textFieldCell>
-                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Label" id="4004">
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="???" id="4004">
                                                         <font key="font" metaFont="smallSystem"/>
                                                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                     </textFieldCell>
-                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Label" id="4006">
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="???" id="4006">
                                                         <font key="font" metaFont="smallSystem"/>
                                                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                     </textFieldCell>
-                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Label" id="4008">
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="???" id="4008">
                                                         <font key="font" metaFont="smallSystem"/>
                                                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                     </textFieldCell>
-                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Label" id="4010">
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="???" id="4010">
                                                         <font key="font" metaFont="smallSystem"/>
                                                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                     </textFieldCell>
-                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Label" id="4012">
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="???" id="4012">
                                                         <font key="font" metaFont="smallSystem"/>
                                                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                     </textFieldCell>
-                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Label" id="4014">
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="???" id="4014">
                                                         <font key="font" metaFont="smallSystem"/>
                                                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                     </textFieldCell>
-                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Label" id="4016">
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="???" id="4016">
                                                         <font key="font" metaFont="smallSystem"/>
                                                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                     </textFieldCell>
-                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Label" id="4018">
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="???" id="4018">
                                                         <font key="font" metaFont="smallSystem"/>
                                                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                     </textFieldCell>
-                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Label" id="4020">
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="???" id="4020">
                                                         <font key="font" metaFont="smallSystem"/>
                                                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                     </textFieldCell>
-                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Label" id="4022">
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="???" id="4022">
                                                         <font key="font" metaFont="smallSystem"/>
                                                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                     </textFieldCell>
-                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Label" id="4024">
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="???" id="4024">
                                                         <font key="font" metaFont="smallSystem"/>
                                                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                     </textFieldCell>
-                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Label" id="4026">
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="???" id="4026">
                                                         <font key="font" metaFont="smallSystem"/>
                                                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                     </textFieldCell>
-                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Label" id="4028">
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="???" id="4028">
                                                         <font key="font" metaFont="smallSystem"/>
                                                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                     </textFieldCell>
-                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Label" id="4030">
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="???" id="4030">
                                                         <font key="font" metaFont="smallSystem"/>
                                                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                     </textFieldCell>
-                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Label" id="4034">
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="???" id="4034">
                                                         <font key="font" metaFont="smallSystem"/>
                                                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                     </textFieldCell>
-                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Label" id="4032">
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="???" id="4032">
                                                         <font key="font" metaFont="smallSystem"/>
                                                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                     </textFieldCell>
-                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Label" id="4193">
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="???" id="4193">
                                                         <font key="font" metaFont="smallSystem"/>
                                                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                     </textFieldCell>
-                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Label" id="4038">
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="???" id="4038">
                                                         <font key="font" metaFont="smallSystem"/>
                                                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                     </textFieldCell>
-                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Label" id="4071">
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="???" id="4071">
                                                         <font key="font" metaFont="smallSystem"/>
                                                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
@@ -2692,34 +2205,8 @@
                                                 </column>
                                             </cells>
                                         </matrix>
-                                        <box autoresizesSubviews="NO" title="XL3 Mode" borderType="line" id="4066">
-                                            <rect key="frame" x="422" y="43" width="177" height="68"/>
-                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                            <view key="contentView">
-                                                <rect key="frame" x="1" y="1" width="175" height="52"/>
-                                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                                                <subviews>
-                                                    <button verticalHuggingPriority="750" id="4067">
-                                                        <rect key="frame" x="15" y="11" width="145" height="32"/>
-                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                                        <animations/>
-                                                        <buttonCell key="cell" type="push" title="Check XL3 Mode" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="4068">
-                                                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                                            <font key="font" metaFont="system"/>
-                                                        </buttonCell>
-                                                        <connections>
-                                                            <action selector="updatexl3Mode:" target="-2" id="4069"/>
-                                                        </connections>
-                                                    </button>
-                                                </subviews>
-                                                <animations/>
-                                            </view>
-                                            <animations/>
-                                            <color key="borderColor" white="0.0" alpha="0.41999999999999998" colorSpace="calibratedWhite"/>
-                                            <color key="fillColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
-                                        </box>
                                         <textField hidden="YES" horizontalHuggingPriority="251" verticalHuggingPriority="750" id="ZIv-V5-16l">
-                                            <rect key="frame" x="565" y="574" width="115" height="14"/>
+                                            <rect key="frame" x="650" y="540" width="115" height="14"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Not in Maintenance" id="v4r-4r-nCv">
                                                 <font key="font" metaFont="smallSystem"/>
@@ -2728,11 +2215,11 @@
                                             </textFieldCell>
                                         </textField>
                                         <matrix verticalHuggingPriority="750" mode="track" allowsEmptySelection="NO" autorecalculatesCellSize="YES" id="vcZ-IJ-Cct">
-                                            <rect key="frame" x="559" y="169" width="124" height="396"/>
+                                            <rect key="frame" x="644" y="135" width="132" height="396"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <animations/>
                                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                            <size key="cellSize" width="119" height="16"/>
+                                            <size key="cellSize" width="123" height="16"/>
                                             <size key="intercellSpacing" width="5" height="4"/>
                                             <buttonCell key="prototype" type="radio" title="Radio" imagePosition="left" alignment="left" controlSize="mini" inset="2" id="giJ-Gh-5bp">
                                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -2804,11 +2291,11 @@
                                                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                                         <font key="font" metaFont="miniSystem"/>
                                                     </buttonCell>
-                                                    <buttonCell type="push" title="Ramp Down Crate 16" bezelStyle="rounded" alignment="center" controlSize="mini" borderStyle="border" inset="2" id="K1W-nl-SWX">
+                                                    <buttonCell type="push" title="Ramp Down Crate 16A" bezelStyle="rounded" alignment="center" controlSize="mini" borderStyle="border" inset="2" id="K1W-nl-SWX">
                                                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                                         <font key="font" metaFont="miniSystem"/>
                                                     </buttonCell>
-                                                    <buttonCell type="push" bezelStyle="rounded" alignment="center" controlSize="mini" enabled="NO" borderStyle="border" inset="2" id="Qfl-qd-Dye">
+                                                    <buttonCell type="push" title="Ramp Down Crate 16B" bezelStyle="rounded" alignment="center" controlSize="mini" borderStyle="border" inset="2" id="Qfl-qd-Dye">
                                                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                                         <font key="font" metaFont="miniSystem"/>
                                                     </buttonCell>
@@ -2825,6 +2312,785 @@
                                             <connections>
                                                 <action selector="rampDownSingleCrateAction:" target="-2" id="IqH-vw-fjZ"/>
                                             </connections>
+                                        </matrix>
+                                        <textField verticalHuggingPriority="750" id="2953">
+                                            <rect key="frame" x="459" y="541" width="44" height="14"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                            <animations/>
+                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Current" id="2954">
+                                                <font key="font" metaFont="smallSystem"/>
+                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
+                                        <matrix verticalHuggingPriority="750" mode="highlight" allowsEmptySelection="NO" autosizesCells="NO" id="Eyd-55-S8p">
+                                            <rect key="frame" x="523" y="137" width="59" height="394"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                            <size key="cellSize" width="59" height="14"/>
+                                            <size key="intercellSpacing" width="0.0" height="6"/>
+                                            <textFieldCell key="prototype" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Label" id="nof-mh-snL">
+                                                <font key="font" metaFont="smallSystem"/>
+                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                            <cells>
+                                                <column>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="OFF" id="scx-Z2-bH8">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="???" id="Aid-6Q-26h">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="???" id="d9Z-BG-Fwd">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="???" id="XDn-Ah-ehb">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="???" id="uZJ-tP-W8I">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="???" id="7ex-9Q-hDl">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="???" id="C2t-1r-pob">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="???" id="123-WJ-wPn">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="???" id="0H2-dv-PrF">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="???" id="gEA-OG-I2b">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="???" id="lFy-pk-7Pb">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="???" id="6H8-SD-9Mf">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="???" id="afr-2N-gkc">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="???" id="bot-8g-Omt">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="???" id="M0b-8e-HLu">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="???" id="2uL-Sz-hyp">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="???" id="juW-vv-W2Z">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="???" id="bLc-Vz-LYY">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="???" id="TdZ-7z-xxG">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="???" id="kJy-Po-oR9">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                </column>
+                                            </cells>
+                                        </matrix>
+                                        <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" setsMaxLayoutWidthAtFirstLayout="YES" id="r1H-OR-dSC">
+                                            <rect key="frame" x="526" y="535" width="52" height="34"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                            <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" alignment="center" title="Trigger Status" id="aBp-T4-ULz">
+                                                <font key="font" metaFont="smallSystem"/>
+                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
+                                        <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" setsMaxLayoutWidthAtFirstLayout="YES" id="pLG-B3-W5u">
+                                            <rect key="frame" x="190" y="526" width="61" height="42"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                            <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" alignment="center" title="OWLs HV Status" id="Vj4-LX-AUp">
+                                                <font key="font" metaFont="smallSystem"/>
+                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
+                                        <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" setsMaxLayoutWidthAtFirstLayout="YES" id="d4Z-rD-3Tb">
+                                            <rect key="frame" x="586" y="535" width="52" height="34"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                            <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" alignment="center" title="XL3 Mode" id="GPm-BT-BeT">
+                                                <font key="font" metaFont="smallSystem"/>
+                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
+                                        <matrix verticalHuggingPriority="750" mode="highlight" allowsEmptySelection="NO" autosizesCells="NO" id="2830">
+                                            <rect key="frame" x="-3" y="131" width="504" height="400"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <animations/>
+                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                            <size key="cellSize" width="84" height="20"/>
+                                            <textFieldCell key="prototype" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Label" id="2831">
+                                                <font key="font" metaFont="smallSystem"/>
+                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                            <cells>
+                                                <column>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="0/1" id="2829">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="1" title="1/1" id="2843">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="2" title="2/2" id="2842">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="3" title="3/2" id="2850">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="4" title="4/3" id="2838">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="5" title="5/4" id="2848">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="6" title="6/4" id="2834">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="7" title="7/5" id="2839">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="8" title="8/5" id="2835">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="9" title="9/6" id="2840">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="10" title="10/6" id="2844">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="11" title="11/7" id="2841">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="12" title="12/8" id="2847">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="13" title="13/8" id="2836">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="14" title="14/9" id="2837">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="15" title="15/9" id="2846">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="16" title="16A/11" id="2849">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="19" title="16B (OWLs)/11" id="2851">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="17" title="17/12" id="2845">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="18" title="18/12" id="2833">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                </column>
+                                                <column>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="OFF" id="2858">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="ON" id="2862">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="???" id="2854">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="???" id="2868">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="???" id="2852">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="???" id="2864">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="???" id="2871">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="???" id="2869">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="???" id="2867">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="???" id="2855">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="???" id="2856">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="???" id="2859">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="???" id="2863">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="???" id="2857">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="???" id="2866">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="???" id="2865">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="???" id="2860">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="???" id="2853">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="???" id="2870">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="???" id="2861">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                </column>
+                                                <column>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" id="2883">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" id="2879">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" id="2891">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="OWLs OFF" id="2887">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" id="2878">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" id="2890">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" id="2876">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" id="2882">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" id="2874">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" id="2877">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" id="2889">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" id="2880">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" id="2886">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="???" id="2884">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" id="2872">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" id="2873">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" id="2885">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" id="2881">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" id="2888">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="???" id="2875">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                </column>
+                                                <column>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="2010.0 V" id="2909">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="???" id="2900">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="???" id="2892">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="???" id="2911">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="???" id="2895">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="???" id="2906">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="???" id="2893">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="???" id="2901">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="???" id="2904">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="???" id="2898">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="???" id="2899">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="???" id="2907">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="???" id="2897">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="???" id="2910">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="???" id="2908">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="???" id="2903">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="???" id="2896">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="???" id="2902">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="???" id="2894">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="???" id="2905">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                </column>
+                                                <column>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="2000.0 V" id="2928">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="???" id="2927">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="???" id="2920">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="???" id="2923">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="???" id="2931">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="???" id="2930">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="???" id="2924">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="???" id="2934">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="???" id="2929">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="???" id="2917">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="???" id="2922">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="???" id="2932">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="???" id="2933">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="???" id="2925">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="???" id="2916">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="???" id="2921">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="???" id="2918">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="???" id="2919">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="???" id="2935">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="???" id="2926">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                </column>
+                                                <column>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="60mA" id="BWU-Am-LAa">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="???" id="YoD-Hx-67q">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="???" id="M8D-jC-lES">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="???" id="NeV-OV-r47">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="???" id="7Zf-7l-SSV">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="???" id="eYS-WI-8Iq">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="???" id="tN5-MW-IRH">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="???" id="sqM-hO-k7l">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="???" id="YVX-yG-bOl">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="???" id="aXn-j6-Wu9">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="???" id="oJJ-nV-wgL">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="???" id="fF6-gK-Ks1">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="???" id="iTk-ou-nG7">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="???" id="ODk-Nu-VSa">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="???" id="4kc-hx-5Rc">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="???" id="HBo-H9-QjQ">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="???" id="8Sk-iv-LyD">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="???" id="1Yq-mA-35y">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="???" id="4H9-hf-fdL">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <textFieldCell controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" tag="-1" title="???" id="5px-Dj-jqc">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                </column>
+                                            </cells>
                                         </matrix>
                                     </subviews>
                                     <animations/>
@@ -3547,69 +3813,6 @@
                             <outlet property="delegate" destination="-2" id="347"/>
                         </connections>
                     </tabView>
-                    <tabView id="piT-mW-S89">
-                        <rect key="frame" x="13" y="10" width="381" height="263"/>
-                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                        <animations/>
-                        <font key="font" metaFont="system"/>
-                        <tabViewItems>
-                            <tabViewItem label="Detector control" identifier="1" id="sHF-Zg-ohR">
-                                <view key="view" id="02S-l8-M0K">
-                                    <rect key="frame" x="10" y="33" width="361" height="217"/>
-                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                                    <subviews>
-                                        <button id="266-Dd-MIl">
-                                            <rect key="frame" x="15" y="111" width="333" height="55"/>
-                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                            <animations/>
-                                            <buttonCell key="cell" type="bevel" title="TRIGGERS OFF" bezelStyle="regularSquare" imagePosition="overlaps" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="y3E-wc-fQv">
-                                                <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                                <font key="font" size="14" name="EuphemiaUCAS-Bold"/>
-                                            </buttonCell>
-                                            <connections>
-                                                <action selector="hvMasterTriggersOFF:" target="-2" id="uh1-wY-dHE"/>
-                                            </connections>
-                                        </button>
-                                        <textField verticalHuggingPriority="750" id="fHi-qS-g5A">
-                                            <rect key="frame" x="17" y="12" width="329" height="36"/>
-                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                            <animations/>
-                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" alignment="center" title="PMT HV is OFF" drawsBackground="YES" id="GSL-gk-28T">
-                                                <font key="font" metaFont="system" size="22"/>
-                                                <color key="textColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                                <color key="backgroundColor" red="0.25796978300000001" green="0.50936399129999999" blue="0.89733270200000004" alpha="1" colorSpace="calibratedRGB"/>
-                                            </textFieldCell>
-                                        </textField>
-                                        <button id="zmA-F4-wTd">
-                                            <rect key="frame" x="15" y="53" width="333" height="55"/>
-                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                            <animations/>
-                                            <buttonCell key="cell" type="bevel" title="PANIC DOWN" bezelStyle="regularSquare" imagePosition="overlaps" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="A2d-ym-1VI">
-                                                <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                                <font key="font" size="14" name="EuphemiaUCAS-Bold"/>
-                                            </buttonCell>
-                                            <connections>
-                                                <action selector="hvMasterPanicAction:" target="-2" id="Dmd-aj-sUv"/>
-                                            </connections>
-                                        </button>
-                                        <button id="drG-95-YYb">
-                                            <rect key="frame" x="15" y="169" width="158" height="47"/>
-                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                            <animations/>
-                                            <buttonCell key="cell" type="bevel" title="Ping Crates" bezelStyle="regularSquare" imagePosition="overlaps" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="Nbm-1z-7bg">
-                                                <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                                <font key="font" metaFont="system"/>
-                                            </buttonCell>
-                                            <connections>
-                                                <action selector="pingCratesAction:" target="-2" id="gaE-se-Lfq"/>
-                                            </connections>
-                                        </button>
-                                    </subviews>
-                                    <animations/>
-                                </view>
-                            </tabViewItem>
-                        </tabViewItems>
-                    </tabView>
                 </subviews>
                 <animations/>
             </view>
@@ -3628,6 +3831,69 @@
             <real key="minimum" value="1024"/>
             <real key="maximum" value="65535"/>
         </numberFormatter>
+        <customView id="Buq-Sm-vC8" userLabel="Drawer Content View">
+            <rect key="frame" x="0.0" y="-5" width="678" height="178"/>
+            <autoresizingMask key="autoresizingMask"/>
+            <subviews>
+                <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" setsMaxLayoutWidthAtFirstLayout="YES" id="7Zn-p7-TDj">
+                    <rect key="frame" x="18" y="121" width="642" height="17"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="- Create new Standard Run: enter a new name in the dropdown menu and click enter" id="raV-Pp-2bZ">
+                        <font key="font" metaFont="system"/>
+                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                </textField>
+                <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" setsMaxLayoutWidthAtFirstLayout="YES" id="hZV-C1-iie">
+                    <rect key="frame" x="18" y="10" width="642" height="51"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="justified" id="tKB-wq-DlE">
+                        <font key="font" metaFont="system"/>
+                        <string key="title">- Modify Standard Run: go to Maintenance Run or stop the run. Then select the Standard Run you want to modify from the dropdown menu and click 'Load Standard Run'. Change the desired settings and click 'Overwrite Standard Run'.</string>
+                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                </textField>
+                <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" setsMaxLayoutWidthAtFirstLayout="YES" id="cJM-fE-OZE">
+                    <rect key="frame" x="18" y="65" width="642" height="51"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="justified" id="UT6-Qw-Q9P">
+                        <font key="font" metaFont="system"/>
+                        <string key="title">- Load Standard Run settings: choose an existing Standard Run from the dropdown menu and click 'Load Standard Run'. This will NOT load settings in hardware until you click 'Load current settings in HW'.</string>
+                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                </textField>
+                <button horizontalHuggingPriority="750" verticalHuggingPriority="750" id="c62-Gs-Cip">
+                    <rect key="frame" x="18" y="149" width="25" height="25"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <buttonCell key="cell" type="help" bezelStyle="helpButton" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="ATu-cC-oHa">
+                        <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                        <font key="font" metaFont="system"/>
+                    </buttonCell>
+                </button>
+                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="UKF-Iu-cpE">
+                    <rect key="frame" x="47" y="146" width="275" height="27"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Standard Runs Help (only experts)" id="r9u-zV-0Ob">
+                        <font key="font" metaFont="system" size="16"/>
+                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                </textField>
+            </subviews>
+            <point key="canvasLocation" x="680" y="859"/>
+        </customView>
+        <drawer preferredEdge="maxY" leadingOffset="200" trailingOffset="280" id="GP4-io-1nq">
+            <size key="contentSize" width="500" height="200"/>
+            <size key="minContentSize" width="500" height="200"/>
+            <size key="maxContentSize" width="500" height="200"/>
+            <connections>
+                <outlet property="contentView" destination="Buq-Sm-vC8" id="1Fe-mc-B3E"/>
+                <outlet property="delegate" destination="-2" id="XTq-ev-f47"/>
+                <outlet property="parentWindow" destination="5" id="OQr-PE-viv"/>
+            </connections>
+        </drawer>
     </objects>
     <resources>
         <image name="Locked" width="33" height="36"/>

--- a/Source/Experiments/SNOP/SNOPController.h
+++ b/Source/Experiments/SNOP/SNOPController.h
@@ -55,6 +55,7 @@
     
     //Danger zone
     IBOutlet NSButton *panicDownButton;
+    IBOutlet NSButton *triggersOFFButton;
     IBOutlet NSTextField *detectorHVStatus;
     
     IBOutlet NSButton *pingCratesButton;

--- a/Source/Experiments/SNOP/SNOPController.h
+++ b/Source/Experiments/SNOP/SNOPController.h
@@ -42,11 +42,14 @@
     int displayUnitsDecider[10];
     int thresholdsFromDB[10];
 
-    IBOutlet NSMatrix* hvStatusMatrix;
-    
+    //HV Master
+    IBOutlet NSMatrix *hvStatusMatrix;
+    IBOutlet NSMatrix *triggerStatusMatrix;
+    IBOutlet NSMatrix *globalxl3Mode;
+    IBOutlet NSMatrix *rampDownCrateButton;
+
     //Run control (the rest is in the ORExperimentController)
     IBOutlet StopLightView *lightBoardView;
-    IBOutlet NSButton *resyncRunButton;
 
     //Quick links
     
@@ -61,20 +64,16 @@
     IBOutlet NSComboBox *standardRunVersionPopupMenu;
     IBOutlet NSButton *standardRunLoadButton;
     IBOutlet NSButton *standardRunSaveButton;
+    IBOutlet NSButton *standardRunLoadinHWButton;
     IBOutlet NSMatrix *standardRunThresCurrentValues;
     IBOutlet NSMatrix *standardRunThresStoredValues;
     IBOutlet NSMatrix *standardRunThreshLabels;
-
 
     //Run Types Information
     IBOutlet NSMatrix*  runTypeWordMatrix;
     IBOutlet NSMatrix *runTypeWordSRMatrix;
     IBOutlet NSTextField *inMaintenanceLabel;
 
-    //Xl3 Mode
-    IBOutlet NSMatrix * globalxl3Mode;
-    IBOutlet NSMatrix *rampDownCrateButton;
-    
     //smellie buttons ---------
     IBOutlet NSComboBox *smellieRunFileNameField;
     IBOutlet NSTextField *loadedSmellieRunNameLabel;
@@ -178,7 +177,9 @@
 - (void) updateWindow;
 
 #pragma mark ¥¥¥Interface
+- (void) XL3ModeChanged:(NSNotification*)aNote;
 - (void) hvStatusChanged:(NSNotification*)aNote;
+- (void) triggerStatusChanged:(NSNotification*)aNote;
 - (void) dbOrcaDBIPChanged:(NSNotification*)aNote;
 - (void) dbDebugDBIPChanged:(NSNotification*)aNote;
 
@@ -205,7 +206,6 @@
 
 - (IBAction) hvMasterPanicAction:(id)sender;
 - (IBAction) hvMasterTriggersOFF:(id)sender;
-- (IBAction) hvMasterStatus:(id)sender;
 
 - (IBAction) pingCratesAction:(id)sender;
 
@@ -224,9 +224,6 @@
 - (IBAction)startTellieRunAction:(id)sender;
 - (IBAction) stopTellieRunAction:(id)sender;
 - (void)startTellieRunNotification:(NSNotification *)notification;
-
-//xl3 mode status
-- (IBAction)updatexl3Mode:(id)sender;
 
 #pragma mark ¥¥¥Details Interface Management
 - (void) tabView:(NSTabView*)aTabView didSelectTabViewItem:(NSTabViewItem*)tabViewItem;

--- a/Source/Experiments/SNOP/SNOPController.h
+++ b/Source/Experiments/SNOP/SNOPController.h
@@ -50,6 +50,7 @@
 
     //Run control (the rest is in the ORExperimentController)
     IBOutlet StopLightView *lightBoardView;
+    IBOutlet NSButton *resyncRunButton;
 
     //Quick links
     

--- a/Source/Experiments/SNOP/SNOPController.m
+++ b/Source/Experiments/SNOP/SNOPController.m
@@ -1497,9 +1497,11 @@ err:
     
     //Enable or disable fields
     [standardRunThresCurrentValues setEnabled:!lockedOrNotRunningMaintenance];
-    [standardRunSaveButton setEnabled:!lockedOrNotRunningMaintenance];
-    [standardRunLoadButton setEnabled:!lockedOrNotRunningMaintenance];
+    [standardRunSaveButton setEnabled:!locked];
+    [standardRunLoadButton setEnabled:!locked];
     [standardRunLoadinHWButton setEnabled:!lockedOrNotRunningMaintenance];
+    [triggersOFFButton setEnabled:notRunningOrInMaintenance];
+
     //Do not lock detector state bits to the operator
     for(int irow=0;irow<21;irow++){
         [[runTypeWordMatrix cellAtRow:irow column:0] setEnabled:!lockedOrNotRunningMaintenance];

--- a/Source/Experiments/SNOP/SNOPController.m
+++ b/Source/Experiments/SNOP/SNOPController.m
@@ -1234,10 +1234,7 @@ err:
     ////////////
     // Roll over into maintenance run
     if([[model lastStandardRunType] isEqualToString:@"SMELLIE"]){
-        [model setStandardRunType:@"MAINTENANCE"];
-        [model loadStandardRun:[model standardRunType] withVersion:[model standardRunVersion]];
-        [model loadSettingsInHW];
-        [self startRunAction:self];
+        [model startStandardRun:@"MAINTENANCE" withVersion:@"DEFAULT"];
     }
 }
 
@@ -1439,10 +1436,7 @@ err:
     if([[model lastStandardRunType] isEqualToString:@"TELLIE"]){
         // If user was running a TELLIE standard sequence, roll over into maintinance run
         if([self tellieStandardSequenceFlag]){
-            [model setStandardRunType:@"MAINTENANCE"];
-            [model loadStandardRun:[model standardRunType] withVersion:[model standardRunVersion]];
-            [model loadSettingsInHW];
-            [self startRunAction:self];
+            [model startStandardRun:@"MAINTENANCE" withVersion:@"DEFAULT"];
         // If user is using the ellie gui simply start a new run as they'll likely need to run
         // more sequences. Reasonable as this is an 'expert' level operation. Proceedures
         // will dictate the user should start a new standard run manualy when they're finished

--- a/Source/Experiments/SNOP/SNOPController.m
+++ b/Source/Experiments/SNOP/SNOPController.m
@@ -496,14 +496,6 @@ snopGreenColor;
 - (IBAction) startRunAction:(id)sender
 {
 
-    /* Start/Restart forces a resync */
-
-    /* A resync run does a hard stop and start without the user having to hit
-     * stop run and then start run. Doing this resets the GTID, which resyncs
-     * crate 9 after it goes out of sync :). */
-
-    [model setResync:YES];
-
     //If we are in OPERATOR mode we don't allow other version than DEFAULT
     BOOL locked = [gSecurity isLocked:ORSNOPRunsLockNotification];
     if(locked) { //Operator Mode
@@ -531,6 +523,19 @@ snopGreenColor;
 
     //Start the standard run and stop run initialization if failed
     if(![model startStandardRun:[model standardRunType] withVersion:[model standardRunVersion]]) return;
+
+}
+
+- (IBAction)resyncRunAction:(id)sender
+{
+
+    /* A resync run does a hard stop and start without the user having to hit
+     * stop run and then start run. Doing this resets the GTID, which resyncs
+     * crate 9 after it goes out of sync :). */
+
+    [model setResync:YES];
+
+    [self startRunAction:nil];
 
 }
 
@@ -566,6 +571,7 @@ err:
         [startRunButton setTitle:@"RESTART"];
         [lightBoardView setState:kGoLight];
         [runStatusField setStringValue:@"Running"];
+        [resyncRunButton setEnabled:true];
         [runNumberField setStringValue:[runControl fullRunNumberString]];
         [doggy_icon start_animation];
 	}
@@ -573,6 +579,7 @@ err:
         [startRunButton setTitle:@"START"];
         [lightBoardView setState:kStoppedLight];
         [runStatusField setStringValue:@"Stopped"];
+        [resyncRunButton setEnabled:false];
         [doggy_icon stop_animation];
 	}
 	else if([runControl runningState] == eRunStarting || [runControl runningState] == eRunStopping || [runControl runningState] == eRunBetweenSubRuns){
@@ -580,6 +587,7 @@ err:
             //The run started so update the display
             [runStatusField setStringValue:@"Starting"];
             [startRunButton setEnabled:false];
+            [resyncRunButton setEnabled:false];
             [startRunButton setTitle:@"STARTING..."];
         }
         else {
@@ -1483,7 +1491,7 @@ err:
     BOOL runInProgress				= [gOrcaGlobals runInProgress];
     BOOL locked						= [gSecurity isLocked:ORSNOPRunsLockNotification];
     BOOL lockedOrNotRunningMaintenance = [gSecurity runInProgressButNotType:eMaintenanceRunType orIsLocked:ORSNOPRunsLockNotification];
-    BOOL notRunningOrInMaintenance = [model isNotRunningOrIsInMaintenance];
+    BOOL notRunningOrInMaintenance = isNotRunningOrIsInMaintenance();
 
     //[softwareTriggerButton setEnabled: !locked && !runInProgress];
     [runsLockButton setState: locked];

--- a/Source/Experiments/SNOP/SNOPController.m
+++ b/Source/Experiments/SNOP/SNOPController.m
@@ -521,15 +521,13 @@ snopGreenColor;
     if( !((dbruntypeword & kMaintenanceRun) || (dbruntypeword & kDiagnosticRun)) ){
         //Make sure we are not polling
         NSArray* xl3s = [[(ORAppDelegate*)[NSApp delegate] document] collectObjectsOfClass:NSClassFromString(@"ORXL3Model")];
-        bool xl3ispolling = false;
         for(ORXL3Model *anXL3 in xl3s){
-            if([anXL3 isPollingXl3]) xl3ispolling = true;
+            if([anXL3 isPollingXl3]) {
+                NSLog(@"Stopping XL3 polling on crate %d\n",[anXL3 crateNumber]);
+                [anXL3 setIsPollingXl3:false];
+            }
         }
-        if(xl3ispolling){
-            NSLog(@"Stopping XL3 polling \n");
-            [model stopXL3Polling];
-        }
-   }
+    }
 
     //Start the standard run and stop run initialization if failed
     if(![model startStandardRun:[model standardRunType] withVersion:[model standardRunVersion]]) return;

--- a/Source/Experiments/SNOP/SNOPController.m
+++ b/Source/Experiments/SNOP/SNOPController.m
@@ -87,6 +87,7 @@ snopGreenColor;
     doggy_icon = [[RunStatusIcon alloc] init];
     [self initializeUnits];
     return self;
+
 }
 - (void) dealloc
 {
@@ -223,7 +224,6 @@ snopGreenColor;
 
 }
 
-
 - (NSString*) defaultPrimaryMapFilePath
 {
     return @"~/SNOP";
@@ -258,9 +258,6 @@ snopGreenColor;
     [runControl getCurrentRunNumber]; //this should be done by the base class... but it is not
     //Sync SR with MTC
 
-    //Update XL3 state
-    [self updatexl3Mode:nil];
-
     [doggy_icon start_animation];
 
     [self initializeUnits];
@@ -268,22 +265,16 @@ snopGreenColor;
     //Update runtype word
     [self refreshRunWordLabels:nil];
     [self runTypeWordChanged:nil];
-    //Lock Standard Runs menus at init
-    if([model standardRunType] == nil){
-        [standardRunVersionPopupMenu setEnabled:false];
-    }
-    else{
-        [model refreshStandardRunsFromDB];
-    }
-
+    
     if(!doggy_icon)
     {
         doggy_icon = [[RunStatusIcon alloc] init];
     }
-    //Pull the information from the SMELLIE DB
+
     [super awakeFromNib];
     [self performSelector:@selector(updateWindow)withObject:self afterDelay:0.1];
 }
+
 - (void) initializeUnits {
     for(int i=0;i<10;i++) {
         displayUnitsDecider[i] = UNITS_UNDECIDED;
@@ -316,7 +307,22 @@ snopGreenColor;
                      selector : @selector(hvStatusChanged:)
                          name : ORXL3ModelHVNominalVoltageChanged
                         object: nil];
-    
+
+    [notifyCenter addObserver : self
+                     selector : @selector(XL3ModeChanged:)
+                         name : ORXL3ModelStateChanged
+                        object: nil];
+
+    [notifyCenter addObserver : self
+                     selector : @selector(XL3ModeChanged:)
+                         name : ORXL3ModelXl3ModeChanged
+                        object: nil];
+
+    [notifyCenter addObserver : self
+                     selector : @selector(triggerStatusChanged:)
+                         name : ORXL3ModelTriggerStatusChanged
+                        object: nil];
+
     [notifyCenter addObserver :self
                      selector : @selector(stopSmellieRunAction:)
                          name : ORSMELLIERunFinished
@@ -431,7 +437,10 @@ snopGreenColor;
 - (void) updateWindow
 {
     [super updateWindow];
+    [model refreshStandardRunsFromDB];
     [self hvStatusChanged:nil];
+    [self triggerStatusChanged:nil];
+    [self XL3ModeChanged:nil];
     [self dbOrcaDBIPChanged:nil];
     [self dbDebugDBIPChanged:nil];
     [self runStatusChanged:nil];
@@ -454,11 +463,10 @@ snopGreenColor;
 
     NSString* standardRun = [model standardRunType];
     if([standardRunPopupMenu numberOfItems] == 0 || standardRun == nil || [standardRun isEqualToString:@""]){
-        return;
+        //Nothing
     }
-    if([standardRunPopupMenu indexOfItemWithObjectValue:standardRun] == NSNotFound){
+    else if([standardRunPopupMenu indexOfItemWithObjectValue:standardRun] == NSNotFound){
         NSLogColor([NSColor redColor],@"Standard Run \"%@\" does not exist. \n", standardRun);
-        return;
     }
     else{
         [standardRunPopupMenu selectItemWithObjectValue:standardRun];
@@ -487,60 +495,46 @@ snopGreenColor;
 
 - (IBAction) startRunAction:(id)sender
 {
-    //Load selected SR in case the user didn't click enter
-    NSString *standardRun = [[standardRunPopupMenu objectValueOfSelectedItem] copy];
-    NSString *standardRunVersion = [[standardRunVersionPopupMenu objectValueOfSelectedItem] copy];
-    
-    //Load selected version run:
-    //If we are in operator mode we ALWAYS load the DEFAULTs
-    //The expert mode has the freedom to load any test run. This is dangerous
-    //but hopefully we won't need to run in expert mode for physics data and in any
-    //case the expert will know this!
-    BOOL locked = [gSecurity isLocked:ORSNOPRunsLockNotification];
-    if(locked) { //Operator Mode
-        standardRunVersion = @"DEFAULT";
-    } else{ //Expert Mode
-        //Nothing
-    }
 
-    //Handle no SR cases
-    if([standardRun isEqualToString:@""] || standardRun == nil){
-        NSLogColor([NSColor redColor],@"Standard Run not set. Enter a valid name. \n");
-        [standardRun release];
-        [standardRunVersion release];
-        return;
-    }
-    if([standardRunVersion isEqualToString:@""] || standardRunVersion == nil){
-        NSLogColor([NSColor redColor],@"Standard Run Version not set. Enter a valid name. \n");
-        [standardRun release];
-        [standardRunVersion release];
-        return;
-    }
-    
-    [model startStandardRun:standardRun withVersion:standardRunVersion];
-    [standardRun release];
-    [standardRunVersion release];
-}
+    /* Start/Restart forces a resync */
 
-- (IBAction)resyncRunAction:(id)sender
-{
     /* A resync run does a hard stop and start without the user having to hit
      * stop run and then start run. Doing this resets the GTID, which resyncs
      * crate 9 after it goes out of sync :). */
 
-    //Load the standard run and stop run initialization if failed
-    if(![model loadStandardRun:[model standardRunType] withVersion:[model standardRunVersion]]) return;
-
     [model setResync:YES];
 
-    if ([[model document] isDocumentEdited]) {
-        [[model document] afterSaveDo:@selector(restartRun) withTarget:runControl];
-        [[model document] saveDocument:nil];
-    } else {
-        [runControl restartRun];
+    //If we are in OPERATOR mode we don't allow other version than DEFAULT
+    BOOL locked = [gSecurity isLocked:ORSNOPRunsLockNotification];
+    if(locked) { //Operator Mode
+        [model setStandardRunVersion:@"DEFAULT"];
     }
-}
 
+    /* If we are not going to maintenance we shouldn't be polling */
+    unsigned long dbruntypeword = 0;
+    NSMutableDictionary* runSettings = [[[model standardRunCollection] objectForKey:[model standardRunType]] objectForKey:[model standardRunVersion]];
+    if(runSettings != nil){
+        //Get the run type word of the next run
+        dbruntypeword = [[runSettings valueForKey:@"run_type_word"] unsignedLongValue];
+    }
+
+    if( !((dbruntypeword & kMaintenanceRun) || (dbruntypeword & kDiagnosticRun)) ){
+        //Make sure we are not polling
+        NSArray* xl3s = [[(ORAppDelegate*)[NSApp delegate] document] collectObjectsOfClass:NSClassFromString(@"ORXL3Model")];
+        bool xl3ispolling = false;
+        for(ORXL3Model *anXL3 in xl3s){
+            if([anXL3 isPollingXl3]) xl3ispolling = true;
+        }
+        if(xl3ispolling){
+            NSLog(@"Stopping XL3 polling \n");
+            [model stopXL3Polling];
+        }
+   }
+
+    //Start the standard run and stop run initialization if failed
+    if(![model startStandardRun:[model standardRunType] withVersion:[model standardRunVersion]]) return;
+
+}
 
 - (IBAction) stopRunAction:(id)sender
 {
@@ -574,14 +568,13 @@ err:
         [startRunButton setTitle:@"RESTART"];
         [lightBoardView setState:kGoLight];
         [runStatusField setStringValue:@"Running"];
-        [resyncRunButton setEnabled:true];
+        [runNumberField setStringValue:[runControl fullRunNumberString]];
         [doggy_icon start_animation];
 	}
 	else if([runControl runningState] == eRunStopped){
         [startRunButton setTitle:@"START"];
         [lightBoardView setState:kStoppedLight];
         [runStatusField setStringValue:@"Stopped"];
-        [resyncRunButton setEnabled:false];
         [doggy_icon stop_animation];
 	}
 	else if([runControl runningState] == eRunStarting || [runControl runningState] == eRunStopping || [runControl runningState] == eRunBetweenSubRuns){
@@ -589,7 +582,6 @@ err:
             //The run started so update the display
             [runStatusField setStringValue:@"Starting"];
             [startRunButton setEnabled:false];
-            [resyncRunButton setEnabled:false];
             [startRunButton setTitle:@"STARTING..."];
         }
         else {
@@ -623,6 +615,9 @@ err:
 
 - (void) hvStatusChanged:(NSNotification*)aNote
 {
+
+    NSArray *OWLRows = [NSArray arrayWithObjects:@3,@13,@19,nil];
+
     if (!aNote) {
         //collect all instances of xl3 objects in Orca
         NSArray* xl3s = [[(ORAppDelegate*)[NSApp delegate] document] collectObjectsOfClass:NSClassFromString(@"ORXL3Model")];
@@ -650,11 +645,11 @@ err:
                     [[hvStatusMatrix cellAtRow:mRow column:1] setTextColor:[NSColor blackColor]];
 		    hvMask &= ~(1 << [xl3 crateNumber]);
                 }
-                [[hvStatusMatrix cellAtRow:mRow column:2] setStringValue:
-                 [NSString stringWithFormat:@"%d V",(unsigned int)[xl3 hvNominalVoltageA]]];
                 [[hvStatusMatrix cellAtRow:mRow column:3] setStringValue:
-                 [NSString stringWithFormat:@"%d V",(unsigned int)[xl3 hvAVoltageReadValue]]];
+                 [NSString stringWithFormat:@"%d V",(unsigned int)[xl3 hvNominalVoltageA]]];
                 [[hvStatusMatrix cellAtRow:mRow column:4] setStringValue:
+                 [NSString stringWithFormat:@"%d V",(unsigned int)[xl3 hvAVoltageReadValue]]];
+                [[hvStatusMatrix cellAtRow:mRow column:5] setStringValue:
                  [NSString stringWithFormat:@"%3.1f mA",[xl3 hvACurrentReadValue]]];
             }
             if ([xl3 crateNumber] == 16) {//16B
@@ -672,12 +667,24 @@ err:
                         [[hvStatusMatrix cellAtRow:mRow column:1] setTextColor:[NSColor blackColor]];
 			hvMask &= ~(1 << 19);
                     }
-                    [[hvStatusMatrix cellAtRow:mRow column:2] setStringValue:
-                     [NSString stringWithFormat:@"%d V",(unsigned int)[xl3 hvNominalVoltageB]]];
                     [[hvStatusMatrix cellAtRow:mRow column:3] setStringValue:
-                     [NSString stringWithFormat:@"%d V",(unsigned int)[xl3 hvBVoltageReadValue]]];
+                     [NSString stringWithFormat:@"%d V",(unsigned int)[xl3 hvNominalVoltageB]]];
                     [[hvStatusMatrix cellAtRow:mRow column:4] setStringValue:
+                     [NSString stringWithFormat:@"%d V",(unsigned int)[xl3 hvBVoltageReadValue]]];
+                    [[hvStatusMatrix cellAtRow:mRow column:5] setStringValue:
                      [NSString stringWithFormat:@"%3.1f mA",[xl3 hvBCurrentReadValue]]];
+
+                    //Update OWL HV status in crates with OWLs
+                    for (id owlRow in OWLRows) {
+                        if ([xl3 hvBSwitch]) {
+                            [[hvStatusMatrix cellAtRow:[owlRow intValue] column:2] setStringValue:@"OWLs ON"];
+                            [[hvStatusMatrix cellAtRow:[owlRow intValue] column:2] setTextColor:[NSColor redColor]];
+                        }
+                        else {
+                            [[hvStatusMatrix cellAtRow:[owlRow intValue] column:2] setStringValue:@"OWLs OFF"];
+                            [[hvStatusMatrix cellAtRow:[owlRow intValue] column:2] setTextColor:[NSColor blackColor]];
+                        }
+                    }
                 }
             }
         }
@@ -694,9 +701,10 @@ err:
                 if (found) {
                     [[hvStatusMatrix cellAtRow:mRow column:1] setStringValue:@"???"];
                     [[hvStatusMatrix cellAtRow:mRow column:1] setTextColor:[NSColor blackColor]];
-                    [[hvStatusMatrix cellAtRow:mRow column:2] setStringValue:@"??? V"];
+                    [[hvStatusMatrix cellAtRow:mRow column:2] setTextColor:[NSColor blackColor]];
                     [[hvStatusMatrix cellAtRow:mRow column:3] setStringValue:@"??? V"];
-                    [[hvStatusMatrix cellAtRow:mRow column:4] setStringValue:@"??? mA"];
+                    [[hvStatusMatrix cellAtRow:mRow column:4] setStringValue:@"??? V"];
+                    [[hvStatusMatrix cellAtRow:mRow column:5] setStringValue:@"??? mA"];
                 }
             }
         }
@@ -718,11 +726,11 @@ err:
                 [[hvStatusMatrix cellAtRow:mRow column:1] setTextColor:[NSColor blackColor]];
 		hvMask &= ~(1 << [[aNote object] crateNumber]);
             }
-            [[hvStatusMatrix cellAtRow:mRow column:2] setStringValue:
-             [NSString stringWithFormat:@"%d V",(unsigned int)[[aNote object] hvNominalVoltageA]]];
             [[hvStatusMatrix cellAtRow:mRow column:3] setStringValue:
-             [NSString stringWithFormat:@"%d V",(unsigned int)[[aNote object] hvAVoltageReadValue]]];
+             [NSString stringWithFormat:@"%d V",(unsigned int)[[aNote object] hvNominalVoltageA]]];
             [[hvStatusMatrix cellAtRow:mRow column:4] setStringValue:
+             [NSString stringWithFormat:@"%d V",(unsigned int)[[aNote object] hvAVoltageReadValue]]];
+            [[hvStatusMatrix cellAtRow:mRow column:5] setStringValue:
              [NSString stringWithFormat:@"%3.1f mA",[[aNote object] hvACurrentReadValue]]];
         }
         if ([[aNote object] crateNumber] == 16) {//16B
@@ -740,13 +748,27 @@ err:
                     [[hvStatusMatrix cellAtRow:mRow column:1] setTextColor:[NSColor blackColor]];
 		    hvMask &= ~(1 << 19);
                 }
-                [[hvStatusMatrix cellAtRow:mRow column:2] setStringValue:
-                 [NSString stringWithFormat:@"%d V",(unsigned int)[[aNote object] hvNominalVoltageB]]];
                 [[hvStatusMatrix cellAtRow:mRow column:3] setStringValue:
-                 [NSString stringWithFormat:@"%d V",(unsigned int)[[aNote object] hvBVoltageReadValue]]];
+                 [NSString stringWithFormat:@"%d V",(unsigned int)[[aNote object] hvNominalVoltageB]]];
                 [[hvStatusMatrix cellAtRow:mRow column:4] setStringValue:
+                 [NSString stringWithFormat:@"%d V",(unsigned int)[[aNote object] hvBVoltageReadValue]]];
+                [[hvStatusMatrix cellAtRow:mRow column:5] setStringValue:
                  [NSString stringWithFormat:@"%3.1f mA",[[aNote object] hvBCurrentReadValue]]];
             }
+
+            //Update OWL HV status in crates with OWLs
+            for (id owlRow in OWLRows) {
+                
+                if ([[aNote object] hvBSwitch]) {
+                    [[hvStatusMatrix cellAtRow:[owlRow intValue] column:2] setStringValue:@"OWLs ON"];
+                    [[hvStatusMatrix cellAtRow:[owlRow intValue] column:2] setTextColor:[NSColor redColor]];
+                }
+                else {
+                    [[hvStatusMatrix cellAtRow:[owlRow intValue] column:2] setStringValue:@"OWLs OFF"];
+                    [[hvStatusMatrix cellAtRow:[owlRow intValue] column:2] setTextColor:[NSColor blackColor]];
+                }
+            }
+
         }
     }
 
@@ -760,8 +782,55 @@ err:
         [detectorHVStatus setBackgroundColor:snopBlueColor];
         [panicDownButton setEnabled:0];
     }
+
 }
 
+- (void) triggerStatusChanged:(NSNotification*)aNote
+{
+    NSArray* xl3s = [[(ORAppDelegate*)[NSApp delegate] document] collectObjectsOfClass:NSClassFromString(@"ORXL3Model")];
+    for (ORXL3Model* xl3 in xl3s) {
+        //Take care of crate 17 and 18
+        int row = [xl3 crateNumber];
+        if (row > 16) row++;
+        [[triggerStatusMatrix cellAtRow:row column:0] setStringValue:[xl3 isTriggerON]?@"ON":@"OFF"];
+        if( [xl3 isTriggerON] ) [[triggerStatusMatrix cellAtRow:row column:0] setTextColor:[NSColor redColor]];
+        else [[triggerStatusMatrix cellAtRow:row column:0] setTextColor:[NSColor blackColor]];
+        if (row++ == 16){
+            [[triggerStatusMatrix cellAtRow:row column:0] setStringValue:[xl3 isTriggerON]?@"ON":@"OFF"];
+            if( [xl3 isTriggerON] ) [[triggerStatusMatrix cellAtRow:row column:0] setTextColor:[NSColor redColor]];
+            else [[triggerStatusMatrix cellAtRow:row column:0] setTextColor:[NSColor blackColor]];
+        }
+    }
+}
+
+- (void) XL3ModeChanged:(NSNotification*)aNote
+{
+    int i =0;
+    NSArray* xl3s = [[(ORAppDelegate*)[NSApp delegate] document] collectObjectsOfClass:NSClassFromString(@"ORXL3Model")];
+    for (id xl3 in xl3s) {
+        ORXL3Model * anXl3 = xl3;
+        //[xl3 xl3Mode];
+        NSString *xl3ModeDescription;
+        if([anXl3 xl3Mode] == 1)        xl3ModeDescription = [NSString stringWithFormat:@"Init"];
+        else if ([anXl3 xl3Mode] == 2)  xl3ModeDescription = [NSString stringWithFormat:@"Normal"];
+        else if ([anXl3 xl3Mode] == 3)  xl3ModeDescription = [NSString stringWithFormat:@"CGT"];
+        else                            xl3ModeDescription = [NSString stringWithFormat:@"???"];
+
+        if([anXl3 crateNumber] == 16){
+            i++;
+            [[globalxl3Mode cellAtRow:16 column:0] setStringValue:xl3ModeDescription];
+            if(i>0){
+                [[globalxl3Mode cellAtRow:17 column:0] setStringValue:xl3ModeDescription];
+            }
+        }
+        else if ([anXl3 crateNumber] > 16){
+            [[globalxl3Mode cellAtRow:([anXl3 crateNumber]+1) column:0] setStringValue:xl3ModeDescription];
+        }
+        else{
+            [[globalxl3Mode cellAtRow:[anXl3 crateNumber] column:0] setStringValue:xl3ModeDescription];
+        }
+    }
+}
 
 #pragma mark ¥¥¥Interface Management
 - (IBAction) orcaDBIPAddressAction:(id)sender
@@ -837,61 +906,28 @@ err:
     NSArray* xl3s = [[(ORAppDelegate*)[NSApp delegate] document] collectObjectsOfClass:NSClassFromString(@"ORXL3Model")];
     int crateNumber = [sender selectedRow];
 
-    //Handle crates 17 and 18
-    if(crateNumber > 16) crateNumber--;
-    
+    //Handle crates 16B, 17 and 18
+    NSString *HVBlabel = @"";
+    if(crateNumber > 16){
+        if(crateNumber == 17) HVBlabel = @"B";
+        crateNumber--;
+    }
+
     //Confirm
-    BOOL cancel = ORRunAlertPanel([NSString stringWithFormat:@"Ramp Down Crate %i?",crateNumber],@"Is this really what you want?",@"Cancel",@"Yes",nil);
+    BOOL cancel = ORRunAlertPanel([NSString stringWithFormat:@"Ramp Down Crate %i%@?",crateNumber,HVBlabel],@"Is this really what you want?",@"Cancel",@"Yes",nil);
     if (cancel) return;
     for (id xl3 in xl3s) {
-
         if ([xl3 crateNumber] != crateNumber) continue;
-        
         if ([xl3 isTriggerON]) {
             [xl3 hvTriggersOFF];
         }
-        [xl3 setHvANextStepValue:0];
-        [xl3 setHvBNextStepValue:0];
+        if([HVBlabel isEqualToString:@"B"]) [xl3 setHvBNextStepValue:0];
+        else [xl3 setHvANextStepValue:0];
         return;
-
     }
 
     NSLogColor([NSColor redColor],@"XL3 %i not found. Unable to Ramp Down. \n",crateNumber);
     
-}
-
-- (IBAction)updatexl3Mode:(id)sender
-{
-    int i =0;
-    NSArray* xl3s = [[(ORAppDelegate*)[NSApp delegate] document] collectObjectsOfClass:NSClassFromString(@"ORXL3Model")];
-    for (id xl3 in xl3s) {
-        ORXL3Model * anXl3 = xl3;
-        //[xl3 xl3Mode];
-        NSString *xl3ModeDescription;
-        if([anXl3 xl3Mode] == 1)        xl3ModeDescription = [NSString stringWithFormat:@"init"];
-        else if ([anXl3 xl3Mode] == 2)  xl3ModeDescription = [NSString stringWithFormat:@"normal"];
-        else if ([anXl3 xl3Mode] == 3)  xl3ModeDescription = [NSString stringWithFormat:@"CGT"];
-        else                            xl3ModeDescription = [NSString stringWithFormat:@"unknown"];
-        
-        if([anXl3 crateNumber] == 16){
-            i++;
-            [[globalxl3Mode cellAtRow:16 column:0] setStringValue:xl3ModeDescription];
-            if(i>0){
-                [[globalxl3Mode cellAtRow:17 column:0] setStringValue:xl3ModeDescription];
-            }
-        }
-        else if ([anXl3 crateNumber] > 16){
-            [[globalxl3Mode cellAtRow:([anXl3 crateNumber]+1) column:0] setStringValue:xl3ModeDescription];
-        }
-        else{
-            [[globalxl3Mode cellAtRow:[anXl3 crateNumber] column:0] setStringValue:xl3ModeDescription];
-        }
-        //setStringValue:[xl3 xl3Mode] stringValue]];
-        /*if([anXl3 crateNumber] >= 16); //skip for 16B
-         {
-         [[globalxl3Mode cellAtRow:[anXl3 crateNumber] column:0] setStringValue:xl3ModeDescription];
-         }*/
-    }
 }
 
 - (IBAction) reportAction:(id)sender
@@ -921,11 +957,6 @@ err:
     if(cancel) return;
 
     [model hvMasterTriggersOFF];
-}
-
-- (IBAction)hvMasterStatus:(id)sender
-{
-    [[NSNotificationCenter defaultCenter] postNotificationName:ORSNOPRequestHVStatus object:self];
 }
 
 #pragma mark ¥¥¥Table Data Source
@@ -1195,9 +1226,12 @@ err:
     }
 
     ////////////
-    // Roll over into maintinance run
+    // Roll over into maintenance run
     if([[model lastStandardRunType] isEqualToString:@"SMELLIE"]){
-        [model startStandardRun:@"MAINTENANCE" withVersion:@"DEFAULT"];
+        [model setStandardRunType:@"MAINTENANCE"];
+        [model loadStandardRun:[model standardRunType] withVersion:[model standardRunVersion]];
+        [model loadSettingsInHW];
+        [self startRunAction:self];
     }
 }
 
@@ -1395,11 +1429,14 @@ err:
     }
 
     ////////////
-    // Handle end of run sqeuencing
+    // Handle end of run sequencing
     if([[model lastStandardRunType] isEqualToString:@"TELLIE"]){
         // If user was running a TELLIE standard sequence, roll over into maintinance run
         if([self tellieStandardSequenceFlag]){
-            [model startStandardRun:@"MAINTENANCE" withVersion:@"DEFAULT"];
+            [model setStandardRunType:@"MAINTENANCE"];
+            [model loadStandardRun:[model standardRunType] withVersion:[model standardRunVersion]];
+            [model loadSettingsInHW];
+            [self startRunAction:self];
         // If user is using the ellie gui simply start a new run as they'll likely need to run
         // more sequences. Reasonable as this is an 'expert' level operation. Proceedures
         // will dictate the user should start a new standard run manualy when they're finished
@@ -1448,20 +1485,23 @@ err:
     BOOL runInProgress				= [gOrcaGlobals runInProgress];
     BOOL locked						= [gSecurity isLocked:ORSNOPRunsLockNotification];
     BOOL lockedOrNotRunningMaintenance = [gSecurity runInProgressButNotType:eMaintenanceRunType orIsLocked:ORSNOPRunsLockNotification];
-    BOOL notRunningOrInMaintenance = [model isNotRunningOrInMaintenance];
+    BOOL notRunningOrInMaintenance = [model isNotRunningOrIsInMaintenance];
 
     //[softwareTriggerButton setEnabled: !locked && !runInProgress];
     [runsLockButton setState: locked];
     
-    //Select default standard run if in operator mode
+    /* Select default standard run if in operator mode.
+     Do it only when the lock status changes */
     if(locked
        && [standardRunPopupMenu numberOfItems] != 0
-       && ![[model standardRunVersion] isEqualToString:@"DEFAULT"]) [model setStandardRunVersion:@"DEFAULT"];
+       && ![[model standardRunVersion] isEqualToString:@"DEFAULT"]
+       && [aNotification isEqualTo:ORSNOPRunsLockNotification]) [model setStandardRunVersion:@"DEFAULT"];
     
     //Enable or disable fields
     [standardRunThresCurrentValues setEnabled:!lockedOrNotRunningMaintenance];
     [standardRunSaveButton setEnabled:!lockedOrNotRunningMaintenance];
     [standardRunLoadButton setEnabled:!lockedOrNotRunningMaintenance];
+    [standardRunLoadinHWButton setEnabled:!lockedOrNotRunningMaintenance];
     //Do not lock detector state bits to the operator
     for(int irow=0;irow<21;irow++){
         [[runTypeWordMatrix cellAtRow:irow column:0] setEnabled:!lockedOrNotRunningMaintenance];
@@ -1489,9 +1529,8 @@ err:
     [debugDBPswd setEnabled:!lockedOrNotRunningMaintenance];
     [debugDBName setEnabled:!lockedOrNotRunningMaintenance];
     [debugDBPort setEnabled:!lockedOrNotRunningMaintenance];
-    [debugDBClearButton setEnabled:!lockedOrNotRunningMaintenance];    
+    [debugDBClearButton setEnabled:!lockedOrNotRunningMaintenance];
     [rampDownCrateButton setEnabled:notRunningOrInMaintenance];
-    [[rampDownCrateButton cellAtRow:17 column:0] setEnabled:false]; //Never enable 16B button
     [inMaintenanceLabel setHidden:notRunningOrInMaintenance];
 
     //Display status
@@ -1783,6 +1822,10 @@ err:
     NSString *standardRunVer = [standardRunVersionPopupMenu objectValueOfSelectedItem];
 
     [model loadStandardRun:standardRun withVersion: standardRunVer];
+}
+
+- (IBAction)loadCurrentSettingsInHW:(id)sender
+{
     [model loadSettingsInHW];
 }
 
@@ -1939,7 +1982,7 @@ err:
     [thresholdFormatter setFormat:@"##0.0"];
     
     //If in DIAGNOSTIC run: display null threshold values
-    if([[model standardRunType] isEqualToString:@"DIAGNOSTIC"]){
+    if(dbruntypeword & kDiagnosticRun){
         for (int i=0; i<[standardRunThresStoredValues numberOfRows];i++) {
             [[standardRunThresStoredValues cellAtRow:i column:0] setStringValue:@"--"];
             [[standardRunThresStoredValues cellAtRow:i column:0] setTextColor:[self snopRedColor]];
@@ -2019,14 +2062,18 @@ err:
         [standardRunVersionPopupMenu addItemWithObjectValue:aStandardRunVersion];
     }
 
+    //If there are no versions -> Nothing
     if ([standardRunVersionPopupMenu numberOfItems] == 0 || standardRunVersion == nil || [standardRunVersion isEqualToString:@""]) {
-        return;
+        //Nothing
     }
-    if ([standardRunVersionPopupMenu indexOfItemWithObjectValue:standardRunVersion] == NSNotFound) {
-        [standardRunVersionPopupMenu selectItemWithObjectValue:standardRunVersion];
-        return;
-    } else {
+    //If previous selected version do not exist -> select DEFAULT
+    else if ([standardRunVersionPopupMenu indexOfItemWithObjectValue:standardRunVersion] == NSNotFound) {
+        [standardRunVersionPopupMenu selectItemWithObjectValue:@"DEFAULT"];
+    }
+    //else -> recover previous version
+    else {
         [standardRunVersionPopupMenu selectItemWithObjectValue:standardRunVersion];
     }
 }
+
 @end

--- a/Source/Experiments/SNOP/SNOPModel.h
+++ b/Source/Experiments/SNOP/SNOPModel.h
@@ -204,7 +204,6 @@
 - (void) couchDBResult:(id)aResult tag:(NSString*)aTag op:(id)anOp;
 
 - (void) pingCrates;
-- (void) stopXL3Polling;
 
 #pragma mark ¥¥orcascript helpers
 - (BOOL) isNotRunningOrIsInMaintenance;

--- a/Source/Experiments/SNOP/SNOPModel.h
+++ b/Source/Experiments/SNOP/SNOPModel.h
@@ -44,6 +44,8 @@
 #define kNumOfCrates 19 //number of Crates in SNO+
 #define STANDARD_RUN_VERSION 1 //Increase if Standard Runs table structure is changed
 
+BOOL isNotRunningOrIsInMaintenance();
+
 @interface SNOPModel: ORExperimentModel <snotDbDelegate>
 {
 	int viewType;
@@ -206,7 +208,6 @@
 - (void) pingCrates;
 
 #pragma mark ¥¥orcascript helpers
-- (BOOL) isNotRunningOrIsInMaintenance;
 - (void) zeroPedestalMasks;
 - (void) updatePedestalMasks:(unsigned int)pattern;
 - (void) hvMasterTriggersOFF;

--- a/Source/Experiments/SNOP/SNOPModel.h
+++ b/Source/Experiments/SNOP/SNOPModel.h
@@ -204,9 +204,10 @@
 - (void) couchDBResult:(id)aResult tag:(NSString*)aTag op:(id)anOp;
 
 - (void) pingCrates;
+- (void) stopXL3Polling;
 
 #pragma mark ¥¥orcascript helpers
-- (BOOL) isNotRunningOrInMaintenance;
+- (BOOL) isNotRunningOrIsInMaintenance;
 - (void) zeroPedestalMasks;
 - (void) updatePedestalMasks:(unsigned int)pattern;
 - (void) hvMasterTriggersOFF;

--- a/Source/Experiments/SNOP/SNOPModel.m
+++ b/Source/Experiments/SNOP/SNOPModel.m
@@ -811,7 +811,7 @@ err:
     }
 
     state = RUNNING;
-    if(start == COLD_START){
+    if(start != ROLLOVER_START){
         
         [self setLastStandardRunType:[self standardRunType]];
         [self setLastStandardRunVersion:[self standardRunVersion]];

--- a/Source/Experiments/SNOP/SNOPModel.m
+++ b/Source/Experiments/SNOP/SNOPModel.m
@@ -1213,14 +1213,6 @@ static NSComparisonResult compareXL3s(ORXL3Model *xl3_1, ORXL3Model *xl3_2, void
     }
 }
 
-- (void) stopXL3Polling
-{
-    NSArray* xl3s = [[(ORAppDelegate*)[NSApp delegate] document] collectObjectsOfClass:NSClassFromString(@"ORXL3Model")];
-    for(ORXL3Model *anXL3 in xl3s){
-        if([anXL3 isPollingXl3]) [anXL3 setIsPollingXl3:false];
-    }
-}
-
 - (void) updateRHDRSruct
 {
     //form run info

--- a/Source/Experiments/SNOP/SNOPModel.m
+++ b/Source/Experiments/SNOP/SNOPModel.m
@@ -800,12 +800,16 @@ err:
     }
 
     state = RUNNING;
-    [self setLastStandardRunType:[self standardRunType]];
-    [self setLastStandardRunVersion:[self standardRunVersion]];
-    [self setLastRunTypeWord:[self runTypeWord]];
-    NSString* _lastRunTypeWord = [NSString stringWithFormat:@"0x%X",(int)[self runTypeWord]];
-    [self setLastRunTypeWordHex:_lastRunTypeWord]; //FIXME: revisit if we go over 32 bits
+    if(start == COLD_START){
+        
+        [self setLastStandardRunType:[self standardRunType]];
+        [self setLastStandardRunVersion:[self standardRunVersion]];
+        [self setLastRunTypeWord:[self runTypeWord]];
+        NSString* _lastRunTypeWord = [NSString stringWithFormat:@"0x%X",(int)[self runTypeWord]];
+        [self setLastRunTypeWordHex:_lastRunTypeWord]; //FIXME: revisit if we go over 32 bits
 
+    }
+    
     [self updateRHDRSruct];
     [self shipRHDRRecord];
 
@@ -1206,6 +1210,14 @@ static NSComparisonResult compareXL3s(ORXL3Model *xl3_1, ORXL3Model *xl3_2, void
         NSLogColor([NSColor redColor],
                    @"error setting the pulser rate. error: "
                     "%@ reason: %@\n", [e name], [e reason]);
+    }
+}
+
+- (void) stopXL3Polling
+{
+    NSArray* xl3s = [[(ORAppDelegate*)[NSApp delegate] document] collectObjectsOfClass:NSClassFromString(@"ORXL3Model")];
+    for(ORXL3Model *anXL3 in xl3s){
+        if([anXL3 isPollingXl3]) [anXL3 setIsPollingXl3:false];
     }
 }
 
@@ -1863,10 +1875,10 @@ static NSComparisonResult compareXL3s(ORXL3Model *xl3_1, ORXL3Model *xl3_2, void
     if([[standardRunCollection objectForKey:standardRunType] count] == 0){
         [self setStandardRunVersion:@""];
     }
-    //Check if previous selected run version exists
-    else if([[standardRunCollection objectForKey:standardRunType] objectForKey:standardRunVersion] == nil){
-        //If not, select first on the list
-        [self setStandardRunVersion:[[[standardRunCollection objectForKey:standardRunType] keyEnumerator] nextObject]];
+    //If EXPERT mode: check if previous selected run version exists
+    if([[standardRunCollection objectForKey:standardRunType] objectForKey:standardRunVersion] == nil){
+        //If not, select DEFAULT
+        [self setStandardRunVersion:@"DEFAULT"];
     }
     else{
         [self setStandardRunVersion:[self standardRunVersion]];
@@ -2032,16 +2044,18 @@ static NSComparisonResult compareXL3s(ORXL3Model *xl3_1, ORXL3Model *xl3_2, void
     link = [urlString stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
     request = [NSURLRequest requestWithURL:[NSURL URLWithString:link] cachePolicy:0 timeoutInterval:2];
     data = [NSURLConnection sendSynchronousRequest:request returningResponse:&response error:&error];
+    if (error != nil) {
+        NSLogColor([NSColor redColor], @"Error reading standard runs from "
+                   "database: %@\n", [error localizedDescription]);
+        goto err;
+    }
     ret = [[[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding] autorelease];
     NSDictionary *theStandardRuns = [NSJSONSerialization JSONObjectWithData:[ret dataUsingEncoding:NSUTF8StringEncoding] options:0 error:&error];
     // JSON formatting error
     if (error != nil) {
         NSLogColor([NSColor redColor], @"Error reading standard runs from "
                    "database: %@\n", [error localizedDescription]);
-        [[NSNotificationCenter defaultCenter] postNotificationName:ORSNOPModelSRCollectionChangedNotification object:self];
-        [self setStandardRunType:@"DIAGNOSTIC"];
-        [self setStandardRunVersion:@"DEFAULT"];
-        return false;
+        goto err;
     }
 
     // If SR not found select diagnostic run
@@ -2084,13 +2098,21 @@ static NSComparisonResult compareXL3s(ORXL3Model *xl3_1, ORXL3Model *xl3_2, void
         /* Database is empty, so we set the standard run version to the empty string. */
         [self setStandardRunVersion:@""];
     } else if ([[standardRunCollection objectForKey:[self standardRunType]] objectForKey:[self standardRunVersion]] == nil) {
-        /* The current version is not in the standard runs anymore, so we select the first version. */
-        [self setStandardRunVersion:[[[standardRunCollection objectForKey:[self standardRunType]] keyEnumerator] nextObject]];
+        /* The current version is not in the standard runs anymore, so we select the DEFAULT version. */
+        [self setStandardRunVersion:@"DEFAULT"];
     } else {
         [self setStandardRunVersion:[self standardRunVersion]];
     }
 
     return true;
+
+err:
+
+    [[NSNotificationCenter defaultCenter] postNotificationName:ORSNOPModelSRCollectionChangedNotification object:self];
+    [self setStandardRunType:@"DIAGNOSTIC"];
+    [self setStandardRunVersion:@"DEFAULT"];
+    return false;
+
 }
 
 // Load Detector Settings from the DB into the Models
@@ -2237,7 +2259,7 @@ static NSComparisonResult compareXL3s(ORXL3Model *xl3_1, ORXL3Model *xl3_2, void
 
 }
 
-- (BOOL) isNotRunningOrInMaintenance
+- (BOOL) isNotRunningOrIsInMaintenance
 {
     
     return (![gOrcaGlobals runInProgress] ||

--- a/Source/Experiments/SNOP/SNOPModel.m
+++ b/Source/Experiments/SNOP/SNOPModel.m
@@ -68,6 +68,17 @@ NSString* ORSNOPModelSRCollectionChangedNotification = @"ORSNOPModelSRCollection
 NSString* ORSNOPModelSRChangedNotification = @"ORSNOPModelSRChangedNotification";
 NSString* ORSNOPModelSRVersionChangedNotification = @"ORSNOPModelSRVersionChangedNotification";
 
+
+BOOL isNotRunningOrIsInMaintenance()
+{
+
+    return (![gOrcaGlobals runInProgress] ||
+            (([gOrcaGlobals runType] & kMaintenanceRun) ||
+             ([gOrcaGlobals runType] & kDiagnosticRun)));
+    
+}
+
+
 @implementation SNOPModel
 
 @synthesize
@@ -847,7 +858,7 @@ err:
 
     if (![[userInfo objectForKey:@"willRestart"] boolValue] || resync) {
         state = STOPPING;
-	resync = NO;
+        resync = NO;
     }
 
     switch (state) {
@@ -2250,16 +2261,6 @@ err:
     NSLog(@"Settings loaded in Hardware \n");
 
 }
-
-- (BOOL) isNotRunningOrIsInMaintenance
-{
-    
-    return (![gOrcaGlobals runInProgress] ||
-            (([gOrcaGlobals runType] & kMaintenanceRun) ||
-            ([gOrcaGlobals runType] & kDiagnosticRun)));
-    
-}
-
 
 @end
 @implementation SNOPDecoderForRHDR

--- a/Source/Objects/Custom Hardware/SNO+/CAEN/SNOCaenController.m
+++ b/Source/Objects/Custom Hardware/SNO+/CAEN/SNOCaenController.m
@@ -605,8 +605,9 @@ static int chanConfigToMaskBit[kNumChanConfigBits] = {1,3,4,6,11};
 	[fpIOLVDS3Matrix setEnabled:!lockedOrRunningMaintenance]; 
 	[fpIOPatternLatchMatrix setEnabled:!lockedOrRunningMaintenance]; 
 	[fpIOTrgInMatrix setEnabled:!lockedOrRunningMaintenance]; 
-	[fpIOTrgOutMatrix setEnabled:!lockedOrRunningMaintenance]; 
-	[fpIOGetButton setEnabled:!lockedOrRunningMaintenance]; 
+    [fpIOTrgOutMatrix setEnabled:!lockedOrRunningMaintenance];
+    [fpIOTrgOutModeMatrix setEnabled:!lockedOrRunningMaintenance];
+	[fpIOGetButton setEnabled:!lockedOrRunningMaintenance];
 	[fpIOSetButton setEnabled:!lockedOrRunningMaintenance]; 
     [postTriggerSettingTextField setEnabled:!lockedOrRunningMaintenance]; 
     [triggerSourceMaskMatrix setEnabled:!lockedOrRunningMaintenance]; 
@@ -618,7 +619,7 @@ static int chanConfigToMaskBit[kNumChanConfigBits] = {1,3,4,6,11};
     [eventSizePopUp setEnabled:!lockedOrRunningMaintenance]; 
     [loadThresholdsButton setEnabled:!lockedOrRunningMaintenance]; 
     [initButton setEnabled:!lockedOrRunningMaintenance]; 
-	
+
 	//these must NOT or can not be changed when run in progress
     [customSizeTextField setEnabled:!locked && !runInProgress && [model isCustomSize]]; 
 	[customSizeButton setEnabled:!locked && !runInProgress]; 

--- a/Source/Objects/Custom Hardware/SNO+/Fec32/ORFec32Controller.m
+++ b/Source/Objects/Custom Hardware/SNO+/Fec32/ORFec32Controller.m
@@ -745,12 +745,16 @@
 
 - (IBAction) incCardAction:(id)sender
 {
-	[self incModelSortedBy:@selector(globalCardNumberCompare:)];
+    bool isFECLocked = [gSecurity isLocked:ORFecLock];
+    [self incModelSortedBy:@selector(globalCardNumberCompare:)];
+    [gSecurity setLock:ORFecLock to:isFECLocked];
 }
 
 - (IBAction) decCardAction:(id)sender
 {
-	[self decModelSortedBy:@selector(globalCardNumberCompare:)];
+    bool isFECLocked = [gSecurity isLocked:ORFecLock];
+    [self decModelSortedBy:@selector(globalCardNumberCompare:)];
+    [gSecurity setLock:ORFecLock to:isFECLocked];
 }
 
 - (IBAction) pmtStateClickAction:(id)sender

--- a/Source/Objects/Custom Hardware/SNO+/FecDaughterCard/ORFecDaughterCardController.m
+++ b/Source/Objects/Custom Hardware/SNO+/FecDaughterCard/ORFecDaughterCardController.m
@@ -434,12 +434,16 @@
 
 - (IBAction) incCardAction:(id)sender
 {
-	[self incModelSortedBy:@selector(globalCardNumberCompare:)];
+    bool isDBLocked = [gSecurity isLocked:ORDBLock];
+    [self incModelSortedBy:@selector(globalCardNumberCompare:)];
+    [gSecurity setLock:ORDBLock to:isDBLocked];
 }
 
 - (IBAction) decCardAction:(id)sender
 {
-	[self decModelSortedBy:@selector(globalCardNumberCompare:)];
+    bool isDBLocked = [gSecurity isLocked:ORDBLock];
+    [self decModelSortedBy:@selector(globalCardNumberCompare:)];
+    [gSecurity setLock:ORDBLock to:isDBLocked];
 }
 
 - (IBAction) rp1Action:(id)sender

--- a/Source/Objects/Custom Hardware/SNO+/MTC/ORMTCController.m
+++ b/Source/Objects/Custom Hardware/SNO+/MTC/ORMTCController.m
@@ -827,10 +827,12 @@
             value = [model getThresholdOfType: threshold_index inUnits:units];
         } @catch (NSException *exception) {
             NSLogColor([NSColor redColor], @"Failed to interpret field with tag %i, Reason: %@\n. Aborting after %i changes already made\n", i,[exception reason],i-FIRST_NHIT_TAG);
+            [self basicLockChanged:nil];
             return;
         }
         [[nhitMatrix cellWithTag:i] setFloatValue: value];
     }
+    [self basicLockChanged:nil];
 }
 
 - (void) changeESUMThresholdDisplay: (int) units
@@ -849,10 +851,12 @@
             value = [model getThresholdOfType: threshold_index inUnits:units];
         } @catch (NSException *exception) {
             NSLogColor([NSColor redColor], @"Failed to interpret field with tag %i, Reason: %@\n. Aborting after %i changes already made\n", i,[exception reason],i-FIRST_ESUM_TAG);
+            [self basicLockChanged:nil];
             return;
         }
         [[esumMatrix cellWithTag:i] setFloatValue: value];
     }
+    [self basicLockChanged:nil];
 }
 
 - (int) convert_view_threshold_index_to_model_index: (int) view_index

--- a/Source/Objects/Custom Hardware/SNO+/XL3/ORXL3Model.m
+++ b/Source/Objects/Custom Hardware/SNO+/XL3/ORXL3Model.m
@@ -98,8 +98,6 @@ NSString* ORXL3ModelXl3VltThresholdInInitChanged = @"ORXL3ModelXl3VltThresholdIn
 NSString* ORXL3Lock = @"ORXL3Lock";
 NSString* ORXL3ModelStateChanged = @"ORXL3ModelStateChanged";
 
-extern NSString* ORSNOPRequestHVStatus;
-
 @interface ORXL3Model (private)
 - (void) doBasicOp;
 - (NSString*) stringDate;
@@ -205,11 +203,6 @@ isLoaded = isLoaded;
 {
     NSNotificationCenter* notifyCenter = [NSNotificationCenter defaultCenter];
     
-    [notifyCenter addObserver : self
-                     selector : @selector(readHVStatus)
-                         name : ORSNOPRequestHVStatus
-                       object : nil];
-
     [notifyCenter addObserver : self
                      selector : @selector(connectionStateChanged)
                          name : XL3_LinkConnectionChanged

--- a/Source/Objects/Custom Hardware/SNO+/XL3/XL3_Link.xib
+++ b/Source/Objects/Custom Hardware/SNO+/XL3/XL3_Link.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="6751" systemVersion="13F1603" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="7706" systemVersion="14B25" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
     <dependencies>
         <deployment version="1050" identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="6751"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="7706"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="XL3_LinkController">
@@ -81,6 +81,7 @@
                 <outlet property="hvRelayMaskMatrix" destination="4342" id="4408"/>
                 <outlet property="hvRelayOpenButton" destination="4065" id="4522"/>
                 <outlet property="hvRelayStatusField" destination="4322" id="4326"/>
+                <outlet property="hvRunStateLabel" destination="nYF-wV-RLu" id="vpI-jc-Xb0"/>
                 <outlet property="hvStepDownButton" destination="4225" id="u0j-OG-kSP"/>
                 <outlet property="hvStepUpButton" destination="4226" id="3CC-g8-yx2"/>
                 <outlet property="hvStopRampButton" destination="4211" id="jdS-vX-rCj"/>
@@ -118,6 +119,8 @@
                 <outlet property="overCurentStatus" destination="nDX-Ck-6ls" id="uoq-t2-vqI"/>
                 <outlet property="overVoltageStatus" destination="mAt-JU-fI7" id="ytT-co-c9m"/>
                 <outlet property="owlStatus" destination="9RR-r0-pTH" id="9Ms-wD-UZ9"/>
+                <outlet property="pollNowButton" destination="3995" id="Dan-9c-Vpb"/>
+                <outlet property="pollRunStateLabel" destination="88l-T7-32r" id="Erz-GK-bN0"/>
                 <outlet property="rampDownStatus" destination="YN6-hm-7Mx" id="uKv-V0-GAy"/>
                 <outlet property="rampUpStatus" destination="jvJ-o1-vqb" id="SCs-u9-Sxl"/>
                 <outlet property="repeatCountField" destination="3406" id="3489"/>
@@ -128,6 +131,8 @@
                 <outlet property="selectSlotMaskButton" destination="3642" id="18J-W7-qNC"/>
                 <outlet property="selectedRegisterPU" destination="3426" id="3454"/>
                 <outlet property="setpointTolStatus" destination="Cy4-zc-HLm" id="xKF-KN-euS"/>
+                <outlet property="startPollButton" destination="3998" id="8ae-r0-moT"/>
+                <outlet property="stopPollButton" destination="4001" id="KMx-Oc-AoV"/>
                 <outlet property="tabView" destination="841" id="3668"/>
                 <outlet property="toggleConnectButton" destination="3925" id="3959"/>
                 <outlet property="window" destination="839" id="923"/>
@@ -1437,6 +1442,15 @@
                                                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                         </textFieldCell>
                                                     </textField>
+                                                    <textField hidden="YES" horizontalHuggingPriority="251" verticalHuggingPriority="750" id="88l-T7-32r">
+                                                        <rect key="frame" x="120" y="94" width="127" height="17"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Not in Maintenance" id="dFd-OL-yyd">
+                                                            <font key="font" metaFont="system"/>
+                                                            <color key="textColor" red="1" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
                                                 </subviews>
                                             </view>
                                             <color key="borderColor" white="0.0" alpha="0.41999999999999998" colorSpace="calibratedWhite"/>
@@ -2029,7 +2043,7 @@
                                                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="nDX-Ck-6ls">
                                                         <rect key="frame" x="144" y="59" width="133" height="14"/>
                                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                                        <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Over Current: > 65.0 mA" id="duX-LR-vjq">
+                                                        <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Over Current: &gt; 65.0 mA" id="duX-LR-vjq">
                                                             <font key="font" metaFont="smallSystem"/>
                                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
@@ -2047,7 +2061,7 @@
                                                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="l3H-Di-bGy">
                                                         <rect key="frame" x="353" y="44" width="82" height="14"/>
                                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                                        <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="When: > 100 V" id="tBA-pr-ncZ">
+                                                        <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="When: &gt; 100 V" id="tBA-pr-ncZ">
                                                             <font key="font" metaFont="smallSystem"/>
                                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
@@ -2074,7 +2088,7 @@
                                                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="mAt-JU-fI7">
                                                         <rect key="frame" x="144" y="14" width="126" height="14"/>
                                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                                        <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Over Voltage: > 2600 V" id="fPQ-kK-98d">
+                                                        <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Over Voltage: &gt; 2600 V" id="fPQ-kK-98d">
                                                             <font key="font" metaFont="smallSystem"/>
                                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
@@ -3022,6 +3036,15 @@
                                                 <action selector="loadNominalSettingsAction:" target="-2" id="Yty-Zs-nKZ"/>
                                             </connections>
                                         </button>
+                                        <textField hidden="YES" horizontalHuggingPriority="251" verticalHuggingPriority="750" id="nYF-wV-RLu">
+                                            <rect key="frame" x="320" y="183" width="127" height="17"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Not in Maintenance" id="zq8-pe-HAA">
+                                                <font key="font" metaFont="system"/>
+                                                <color key="textColor" red="1" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
                                     </subviews>
                                 </view>
                             </tabViewItem>
@@ -3187,7 +3210,7 @@
         <image name="Unlocked" width="33" height="36"/>
         <image name="dec" width="18" height="18"/>
         <image name="inc" width="18" height="18"/>
-        <image name="triggers_off" width="458.39999389648438" height="172.80000305175781"/>
-        <image name="triggers_on" width="458.39999389648438" height="172.80000305175781"/>
+        <image name="triggers_off" width="448" height="165.60000610351562"/>
+        <image name="triggers_on" width="448" height="166.39999389648438"/>
     </resources>
 </document>

--- a/Source/Objects/Custom Hardware/SNO+/XL3/XL3_LinkController.h
+++ b/Source/Objects/Custom Hardware/SNO+/XL3/XL3_LinkController.h
@@ -92,6 +92,11 @@
     IBOutlet NSTextField*           monPollCMOSRatesMaskField; 
     IBOutlet NSTextField*           monPollPMTCurrentsMaskField; 
     IBOutlet NSTextField*           monPollFECVoltagesMaskField;
+
+    IBOutlet NSTextField *pollRunStateLabel;
+    IBOutlet NSButton *pollNowButton;
+    IBOutlet NSButton *startPollButton;
+    IBOutlet NSButton *stopPollButton;
     IBOutlet NSPopUpButton*         monPollingRatePU;
     IBOutlet NSButton*              monIsPollingVerboseButton;
     IBOutlet NSButton*              monIsPollingWithRunButton;
@@ -111,6 +116,7 @@
     IBOutlet NSButton* monVltThresholdInInitButton;
     IBOutlet NSButton* monVltThresholdSetButton;
     //hv
+    IBOutlet NSTextField *hvRunStateLabel;
     IBOutlet NSButtonCell *hvAcceptReadbackButton;
     IBOutlet NSButton *hvOnButton;
     IBOutlet NSButton *hvOffButton;

--- a/Source/Objects/Custom Hardware/SNO+/XL3/XL3_LinkController.m
+++ b/Source/Objects/Custom Hardware/SNO+/XL3/XL3_LinkController.m
@@ -403,17 +403,8 @@ static NSDictionary* xl3Ops;
 #pragma mark •••Interface Management
 - (void) xl3LockChanged:(NSNotification*)aNotification
 {
-    //Get SNOP Model
-    NSArray*  objs = [[(ORAppDelegate*)[NSApp delegate] document] collectObjectsOfClass:NSClassFromString(@"SNOPModel")];
-    SNOPModel* aSNOPModel = nil;
-    if ([objs count]) {
-        aSNOPModel = [objs objectAtIndex:0];
-    } else {
-        NSLogColor([NSColor redColor], @"xl3LockChanged: Couldn't find SNOP model. Please add it to the experiment and restart the run.\n");
-    }
 
-    BOOL notRunningOrInMaintenance = true; //default if no snopmodel found
-    if (aSNOPModel) notRunningOrInMaintenance = [aSNOPModel isNotRunningOrIsInMaintenance];
+    BOOL notRunningOrInMaintenance = isNotRunningOrIsInMaintenance();
     BOOL locked						= [gSecurity isLocked:ORXL3Lock];
     BOOL lockedOrNotRunningMaintenance = [gSecurity runInProgressButNotType:eMaintenanceRunType orIsLocked:ORXL3Lock];
     
@@ -706,20 +697,10 @@ static NSDictionary* xl3Ops;
 
 - (void) updateHVButtons
 {
- 
-    //Get SNOP Model
-    NSArray*  objs = [[(ORAppDelegate*)[NSApp delegate] document] collectObjectsOfClass:NSClassFromString(@"SNOPModel")];
-    SNOPModel* aSNOPModel = nil;
-    if ([objs count]) {
-        aSNOPModel = [objs objectAtIndex:0];
-    } else {
-        NSLogColor([NSColor redColor], @"xl3LockChanged: Couldn't find SNOP model. Please add it to the experiment and restart the run.\n");
-    }
 
     BOOL lockedOrNotRunningMaintenance = [gSecurity runInProgressButNotType:eMaintenanceRunType orIsLocked:ORXL3Lock];
-    BOOL notRunningOrInMaintenance = true; //default if no snopmodel found
-    if (aSNOPModel) notRunningOrInMaintenance = [aSNOPModel isNotRunningOrIsInMaintenance];
-    
+    BOOL notRunningOrInMaintenance = isNotRunningOrIsInMaintenance();
+
     if ([hvPowerSupplyMatrix selectedColumn] == 0) { //A
         bool unlock = ![model hvANeedsUserIntervention] && [model hvEverUpdated] && [model hvSwitchEverUpdated] && ![model hvASwitch] && [model hvAFromDB] && !lockedOrNotRunningMaintenance;
         [hvOnButton setEnabled:unlock];

--- a/Source/Objects/Custom Hardware/SNO+/XL3/XL3_LinkController.m
+++ b/Source/Objects/Custom Hardware/SNO+/XL3/XL3_LinkController.m
@@ -471,8 +471,8 @@ static NSDictionary* xl3Ops;
 
     //HV
     [self hvStatusChanged:nil];
+    [self hvTriggerStatusChanged:nil];
     [hvTriggersButton setEnabled:!lockedOrNotRunningMaintenance];
-    [loadNominalSettingsButton setEnabled:!lockedOrNotRunningMaintenance];
 
     //Connection
     [toggleConnectButton setEnabled: !lockedOrNotRunningMaintenance];
@@ -859,10 +859,12 @@ static NSDictionary* xl3Ops;
 
 - (void) hvTriggerStatusChanged:(NSNotification*)aNote
 {
+    BOOL lockedOrNotRunningMaintenance = [gSecurity runInProgressButNotType:eMaintenanceRunType orIsLocked:ORXL3Lock];
+
     if ([model isTriggerON]) {
         [hvATriggerStatusField setStringValue:@"ON"];
         [hvBTriggerStatusField setStringValue:@"ON"];
-        [loadNominalSettingsButton setEnabled:YES];
+        [loadNominalSettingsButton setEnabled:!lockedOrNotRunningMaintenance];
         [hvTriggersButton setState:NSOnState];
     } else {
         [hvATriggerStatusField setStringValue:@"OFF"];

--- a/Source/Objects/Custom Hardware/SNO+/XL3/XL3_LinkController.m
+++ b/Source/Objects/Custom Hardware/SNO+/XL3/XL3_LinkController.m
@@ -480,7 +480,9 @@ static NSDictionary* xl3Ops;
 
     //HV
     [self hvStatusChanged:nil];
-    
+    [hvTriggersButton setEnabled:!lockedOrNotRunningMaintenance];
+    [loadNominalSettingsButton setEnabled:!lockedOrNotRunningMaintenance];
+
     //Connection
     [toggleConnectButton setEnabled: !lockedOrNotRunningMaintenance];
     [errorTimeOutPU setEnabled: !lockedOrNotRunningMaintenance];


### PR DESCRIPTION
- [x] Keep window unlocked when we switch through XL3s, FECs and DBs
- [x] Lock MTC when toggling radio buttons in non-maintenance
- [x] No polling in Physics
- [x] Ask to stop polling when starting a non-maintenance run
- [x] Add subrun number to run control display
- [x] Lock field in CAEN
- [x] Show trigger status in HV Master
- [x] Add OWLs HV state in HV master
- [x] Add tooltips for standard runs
- [x] Lock Triggers ON/OFF when in physics