### PR TITLE
don't send a queue_run_start command for rollover runs

### DIFF
--- a/Source/Experiments/SNOP/SNOPModel.m
+++ b/Source/Experiments/SNOP/SNOPModel.m
@@ -557,16 +557,9 @@ resync;
 
     switch (start) {
     case ROLLOVER_START:
-        @try {
-            /* Tell the MTC server to queue the run start. This will suspend
-             * the MTC readout and fire a SOFT_GT. When the run starts, we will
-             * resume the MTC readout */
-            [mtc_server okCommand:"queue_run_start"];
-        } @catch (NSException *e) {
-            NSLogColor([NSColor redColor], @"error sending queue_run_start "
-                       "command to mtc_server: %@\n", [e reason]);
-            goto err;
-        }
+        /* We don't queue the run start here for rollover runs. Since we don't
+         * send a queue_run_start command to the mtc server, the first gtid and
+         * the valid gtid fields in the run header will be the same. */
         break;
     case CONTINUOUS_START:
         @try {


### PR DESCRIPTION
This commit updates the runInitialization method in the SNO+ model so that it
doesn't send the mtc server a queue_run_start command. This will cause the mtc
server to set the first and valid gtid fields in the run header to be the same,
which is how analysis will know that it was a rollover run.

I haven't tested this out yet, and it will also require the mtc server to be updated before a new release is made.