### PR TITLE
SNO+: update SNO+ model and run model to load elapsed time since run start

### DIFF
--- a/Source/Experiments/SNOP/SNOPModel.m
+++ b/Source/Experiments/SNOP/SNOPModel.m
@@ -1002,6 +1002,8 @@ err:
         [runControl setRunningState:eRunInProgress];
         if (pqRun->valid[kRun_runStartTime]) {
             [runControl setStartTime:pqRun->runStartTime];
+            [runControl setElapsedRunTime:-[pqRun->runStartTime timeIntervalSinceNow]];
+            [runControl startTimer];
         }
         state = RUNNING;
     }

--- a/Source/Objects/Control/RunControl/ORRunModel.h
+++ b/Source/Objects/Control/RunControl/ORRunModel.h
@@ -204,6 +204,7 @@
 - (void) runAbortFromScript;
 
 - (void) startRun;
+- (void) startTimer;
 - (void) startNoScriptRun;
 - (void) restartRun;
 - (void) stopRun;

--- a/Source/Objects/Control/RunControl/ORRunModel.m
+++ b/Source/Objects/Control/RunControl/ORRunModel.m
@@ -1296,6 +1296,13 @@ static NSString *ORRunModelRunControlConnection = @"Run Control Connector";
     }
 }
 
+- (void) startTimer
+{
+    [timer invalidate];
+    [timer release];
+    timer = [[NSTimer scheduledTimerWithTimeInterval:1.0 target:self selector:@selector(incrementTime:)userInfo:nil repeats:YES] retain];
+}
+
 - (void) startRunStage3:(NSNumber*)doInitBool
 {
 	if(startScript){
@@ -1324,15 +1331,11 @@ static NSString *ORRunModelRunControlConnection = @"Run Control Connector";
 		[readoutThread start];
 		 
         [self setStartTime:[NSDate date]];
-		[self setSubRunStartTime:[NSDate date]];
-		[self setElapsedRunTime:0];
+	[self setSubRunStartTime:[NSDate date]];
+	[self setElapsedRunTime:0];
         [self setElapsedSubRunTime:0];
-        
-        [timer invalidate];
-        [timer release];
-        timer = [[NSTimer scheduledTimerWithTimeInterval:1.0 target:self selector:@selector(incrementTime:)userInfo:nil repeats:YES] retain];
-        
-        
+
+        [self startTimer];
         
         [[ORGlobal sharedGlobal] checkRunMode];
         


### PR DESCRIPTION
This commit updates the SNO+ model so that it loads the elapsed time since the
run started from the detector state database to the run model on boot up. This
required a small change to the run control to start the run timer so that the
elapsed time is incremented properly.

With this update, the run handover process should not require a new run to be started. I am not going to merge this until getting approval from Mark Howe since I had to edit the run control object but I will keep it in the new release.