### PR TITLE
Check relays

### DIFF
--- a/Source/Experiments/SNOP/SNOPController.m
+++ b/Source/Experiments/SNOP/SNOPController.m
@@ -36,7 +36,7 @@
 #import "SNOCaenModel.h"
 #import "RunTypeWordBits.hh"
 #import "ECARun.h"
-#import "NhitMonitor.h"
+#import "NHitMonitor.h"
 
 NSString* ORSNOPRequestHVStatus = @"ORSNOPRequestHVStatus";
 NSString* ORRunWaitFinished = @"ORRunWaitFinished";

--- a/Source/Objects/Custom Hardware/SNO+/XL3/DB.h
+++ b/Source/Objects/Custom Hardware/SNO+/XL3/DB.h
@@ -61,9 +61,12 @@ typedef struct {
 
 typedef struct
 {
-	MB mb[16]; //!< all 16 fec database values
-    uint16_t pmticID[16]; //!< All 16 PMTIC IDs. Not in MB for compatibility
-	uint32_t ctcDelay; //!< ctc based trigger delay
+  MB mb[16]; //!< all 16 fec database values
+  uint16_t pmticID[16]; //!< All 16 PMTIC IDs. Not stored in MB for compatibility
+  uint32_t ctcDelay; //!< ctc based trigger delay
+  uint32_t relays_known; //!< stores if the relays have been set successfully
+  uint32_t hv_relay1; //!< stores the (lower) relays
+  uint32_t hv_relay2; //!< stores the (upper) relays
 } Crate; //!< all database values for the crate
 
 Crate crate; //!< Current configuration

--- a/Source/Objects/Custom Hardware/SNO+/XL3/ORXL3Model.h
+++ b/Source/Objects/Custom Hardware/SNO+/XL3/ORXL3Model.h
@@ -441,6 +441,7 @@ enum {
 
 - (void) setHVRelays:(unsigned long long)relayMask error:(unsigned long*)aError;
 - (void) setHVRelays:(unsigned long long)relayMask;
+- (void) readHVRelays:(unsigned long long*) relayMask isKnown:(BOOL*)isKnown;
 - (void) closeHVRelays;
 - (void) openHVRelays;
 

--- a/Source/Objects/Custom Hardware/SNO+/XL3/ORXL3Model.h
+++ b/Source/Objects/Custom Hardware/SNO+/XL3/ORXL3Model.h
@@ -441,7 +441,7 @@ enum {
 
 - (void) setHVRelays:(unsigned long long)relayMask error:(unsigned long*)aError;
 - (void) setHVRelays:(unsigned long long)relayMask;
-- (void) readHVRelays:(unsigned long long*) relayMask isKnown:(BOOL*)isKnown;
+- (void) readHVRelays:(uint64_t*) relayMask isKnown:(BOOL*)isKnown;
 - (void) closeHVRelays;
 - (void) openHVRelays;
 

--- a/Source/Objects/Custom Hardware/SNO+/XL3/ORXL3Model.h
+++ b/Source/Objects/Custom Hardware/SNO+/XL3/ORXL3Model.h
@@ -449,6 +449,8 @@ enum {
 - (void) readHVSwitchOnForA:(BOOL*)aIsOn forB:(BOOL*)bIsOn;
 - (void) readHVSwitchOn;
 
+- (uint32_t) checkRelays:(uint64_t)relays;
+- (BOOL) isHVAdvisable:(unsigned char) sup;
 
 + (bool) requestHVParams:(ORXL3Model *)model;
 - (void) safeHvInit;

--- a/Source/Objects/Custom Hardware/SNO+/XL3/ORXL3Model.m
+++ b/Source/Objects/Custom Hardware/SNO+/XL3/ORXL3Model.m
@@ -4322,6 +4322,8 @@ err:
                 // Finally make sure the XL3s are reading out
                 if([xl3 xl3Mode] == NORMAL_MODE) {
                     goodModes++;
+                } else {
+                    NSLogColor([NSColor redColor],@"%@ NOT in normal mode\n",[[xl3 xl3Link] crateName]);
                 }
             }
         }

--- a/Source/Objects/Custom Hardware/SNO+/XL3/ORXL3Model.m
+++ b/Source/Objects/Custom Hardware/SNO+/XL3/ORXL3Model.m
@@ -4308,7 +4308,7 @@ err:
                             goodRelays++;
                         }
                         else {
-                            NSLogColor([NSColor redColor], @"%@ HV relays for slot 15 are closed but FEC is missing!\n");
+                            NSLogColor([NSColor redColor], @"%@ HV relays for slot 15 are closed but FEC is missing!\n",[[self xl3Link] crateName]);
                         }
 
                     } else {
@@ -4316,7 +4316,7 @@ err:
                     }
                 }
                 @catch (NSException *exception) {
-                    NSLogColor([NSColor redColor],@"%@ error in readHVRelays\n",[[xl3 xl3Link] crateName]);
+                    NSLogColor([NSColor redColor],@"%@ error in readHVRelays. Error: %@ Reason: %@\n",[[xl3 xl3Link] crateName],[exception name], [exception reason]);
                 }
 
                 // Finally make sure the XL3s are reading out
@@ -4337,7 +4337,7 @@ err:
             if (!interlockIsGood) NSLogColor([NSColor redColor],@"%@ HV interlock BAD\n",[[self xl3Link] crateName]);
         }
         @catch (NSException *exception) {
-            NSLogColor([NSColor redColor],@"%@ error in readHVInterlock\n",[[self xl3Link] crateName]);
+            NSLogColor([NSColor redColor],@"%@ error in readHVInterlock. Error: %@ Reason %@\n",[[self xl3Link] crateName],[exception name], [exception reason]);
         }
 
         @try {
@@ -4347,7 +4347,7 @@ err:
             }
         }
         @catch (NSException *exception) {
-            NSLogColor([NSColor redColor],@"%@ error in readHVRelays\n",[[self xl3Link] crateName]);
+            NSLogColor([NSColor redColor],@"%@ error in readHVRelays. Error: %@ Reason: %@\n",[[self xl3Link] crateName],[exception name], [exception reason]);
         }
 
         // Make sure the relays are open for all slots that are missing

--- a/Source/Objects/Custom Hardware/SNO+/XL3/ORXL3Model.m
+++ b/Source/Objects/Custom Hardware/SNO+/XL3/ORXL3Model.m
@@ -4247,7 +4247,7 @@ err:
     uint32_t slots = [self getSlotsPresent];
     for (int i=0;i<16;i++) {
         if((slots & 1<<16) == 0) {
-            if(((0xF << 1*4) & relays) != 0)
+            if(((0xF << i*4) & relays) != 0)
                 bad_slots += 1<<i;
         }
     }
@@ -4303,7 +4303,6 @@ err:
                     } else {
                         NSLogColor([NSColor redColor],@"%@ HV Relays unknown\n",[[xl3 xl3Link] crateName]);
                     }
-
                 }
                 @catch (NSException *exception) {
                     NSLogColor([NSColor redColor],@"%@ error in readHVRelays\n",[[xl3 xl3Link] crateName]);
@@ -4332,7 +4331,9 @@ err:
 
         @try {
             [self readHVRelays:&relays isKnown:&relaysKnown];
-            if (!relaysKnown) NSLogColor([NSColor redColor],@"%@ HV relays unknown\n",[[self xl3Link] crateName]);
+            if (!relaysKnown){
+                NSLogColor([NSColor redColor],@"%@ HV relays unknown\n",[[self xl3Link] crateName]);
+            }
         }
         @catch (NSException *exception) {
             NSLogColor([NSColor redColor],@"%@ error in readHVRelays\n",[[self xl3Link] crateName]);
@@ -4341,7 +4342,7 @@ err:
         // Make sure the relays are open for all slots that are missing
         if(relaysKnown) {
             uint32_t badRelays = [self checkRelays:relays];
-            relaysGood = badRelays == 0;
+            relaysGood = (badRelays == 0);
             if(!relaysGood) {
                 NSLogColor([NSColor redColor], @"%@ has missing slots with closed relays!\n", [[self xl3Link] crateName]);
             }

--- a/Source/Objects/Custom Hardware/SNO+/XL3/ORXL3Model.m
+++ b/Source/Objects/Custom Hardware/SNO+/XL3/ORXL3Model.m
@@ -4254,8 +4254,12 @@ err:
     uint32_t bad_slots = 0;
     uint32_t slots = [self getSlotsPresent];
     for (int i=0;i<16;i++) {
-        if((slots & 1<<16) == 0) {
-            if(((0xF << i*4) & relays) != 0)
+        // If slot is missing
+        if((slots & 1<<i) == 0) {
+            // And if the 4 relays for that slot aren't all 0 (open)
+            uint64_t mask = (uint64_t)0xF << i*4;
+            if((mask & relays) != 0)
+                //Then set a bit in bad_slots
                 bad_slots += 1<<i;
         }
     }
@@ -4360,6 +4364,9 @@ err:
 
         // Check that the XL3 Mode is not INIT
         modeGood = [self xl3Mode] == NORMAL_MODE;
+        if(!modeGood){
+            NSLogColor([NSColor redColor], @"%@ is not in NORMAL mode!\n", [[self xl3Link] crateName]);
+        }
     }
 
     return interlockIsGood && relaysKnown && modeGood && relaysGood;

--- a/Source/Objects/Custom Hardware/SNO+/XL3/ORXL3Model.m
+++ b/Source/Objects/Custom Hardware/SNO+/XL3/ORXL3Model.m
@@ -4134,9 +4134,17 @@ err:
         mask2 = swapLong(data->mask2);
         known = swapLong(data->relays_known);
     }
-
     *_relayMask = mask1 + ((uint64_t)mask2 << 32);
     *isKnown = (known != 0);
+
+    if(!known) {
+        [self setRelayStatus:@"status: UNKNOWN"];
+    }
+    else {
+        [self setRelayMask:*_relayMask];
+        [self setRelayStatus:@"status: SET"];
+
+    }
 }
 
 - (void) closeHVRelays
@@ -4253,12 +4261,14 @@ err:
     }
     return bad_slots;
 }
+
 - (BOOL) isHVAdvisable:(unsigned char) sup {
     BOOL interlockIsGood = false;
     BOOL relaysKnown = false;
     BOOL relaysGood = true; // Start true b/c if relaysKnown doesn't pass this won't be checked.
     BOOL modeGood = false;
     uint64_t relays;
+
     if ([self crateNumber] == 16 && sup != 0) { //16B
         //Checks interlocks for any crates with connected OWL tubes
         //Assumes that all relevant crates are represented in the open experiment

--- a/Source/Objects/Custom Hardware/SNO+/XL3/ORXL3Model.m
+++ b/Source/Objects/Custom Hardware/SNO+/XL3/ORXL3Model.m
@@ -4114,6 +4114,31 @@ err:
     }
 }
 
+- (void) readHVRelays:(uint64_t*) _relayMask isKnown:(BOOL*)isKnown {
+    char payload[XL3_PAYLOAD_SIZE];
+    uint32_t mask1, mask2, known;
+
+    memset(payload, 0, XL3_PAYLOAD_SIZE);
+    GetHVRelaysResults* data = (GetHVRelaysResults*) payload;
+
+    @try {
+        [[self xl3Link] sendCommand:GET_HV_RELAYS_ID withPayload:payload expectResponse:YES];
+    }
+    @catch (NSException *exception) {
+        NSLogColor([NSColor redColor],@"%@ error sending GetHVRelays command.\n",[[self xl3Link] crateName]);
+        @throw exception;
+    }
+
+    if ([xl3Link needToSwap]) {
+        mask1 = swapLong(data->mask1);
+        mask2 = swapLong(data->mask2);
+        known = swapLong(data->relays_known);
+    }
+
+    *_relayMask = mask1 + ((uint64_t)mask2 << 32);
+    *isKnown = (known != 0);
+}
+
 - (void) closeHVRelays
 {
     unsigned long error;

--- a/Source/Objects/Custom Hardware/SNO+/XL3/PacketTypes.h
+++ b/Source/Objects/Custom Hardware/SNO+/XL3/PacketTypes.h
@@ -62,6 +62,7 @@
 #define MULTI_SET_CRATE_TRIGGERS_ID   (0x36)
 // HV Tasks
 #define SET_HV_RELAYS_ID          (0x40) //!< turns on/off hv relays
+#define GET_HV_RELAYS_ID          (0x41) //!< returns the stored relay values
 #define HV_READBACK_ID			      (0x42) //!< reads voltage and current	
 #define READ_PMT_CURRENT_ID	      (0x43) //!< reads pmt current from FEC hv csr	
 #define SETUP_CHARGE_INJ_ID		    (0x44) //!< setup charge injection in FEC hv csr
@@ -348,6 +349,12 @@ typedef struct{
 typedef struct{
   uint32_t errorFlags;
 } SetHVRelaysResults;
+
+typedef struct{
+  uint32_t mask1;
+  uint32_t mask2;
+  uint32_t relays_known;
+} GetHVRelaysResults;
 
 typedef struct{
   float voltageA;

--- a/Source/Objects/Custom Hardware/SNO+/XL3/XL3_Link.xib
+++ b/Source/Objects/Custom Hardware/SNO+/XL3/XL3_Link.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="7706" systemVersion="14B25" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="6254" systemVersion="14B25" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
     <dependencies>
         <deployment version="1050" identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="7706"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="6254"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="XL3_LinkController">
@@ -2142,14 +2142,14 @@
                                                         </connections>
                                                     </button>
                                                     <button verticalHuggingPriority="750" id="4068">
-                                                        <rect key="frame" x="170" y="2" width="109" height="28"/>
+                                                        <rect key="frame" x="154" y="2" width="142" height="28"/>
                                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                                        <buttonCell key="cell" type="push" title="Check Interlock" bezelStyle="rounded" alignment="center" controlSize="small" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="4069">
+                                                        <buttonCell key="cell" type="push" title="Check Interlock/Relays" bezelStyle="rounded" alignment="center" controlSize="small" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="4069">
                                                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                                             <font key="font" metaFont="smallSystem"/>
                                                         </buttonCell>
                                                         <connections>
-                                                            <action selector="hvCheckInterlockAction:" target="-2" id="4334"/>
+                                                            <action selector="hvCheckInterlockRelaysAction:" target="-2" id="HxJ-qz-hGn"/>
                                                         </connections>
                                                     </button>
                                                     <textField verticalHuggingPriority="750" id="4063">

--- a/Source/Objects/Custom Hardware/SNO+/XL3/XL3_LinkController.h
+++ b/Source/Objects/Custom Hardware/SNO+/XL3/XL3_LinkController.h
@@ -303,7 +303,7 @@
 - (IBAction)hvRelayMaskMatrixAction:(id)sender;
 - (IBAction)hvRelaySetAction:(id)sender;
 - (IBAction)hvRelayOpenAllAction:(id)sender;
-- (IBAction)hvCheckInterlockAction:(id)sender;
+- (IBAction)hvCheckInterlockRelaysAction:(id)sender;
 - (IBAction)hvTurnOnAction:(id)sender;
 - (IBAction)hvTurnOffAction:(id)sender;
 - (IBAction)hvAcceptReadback:(id)sender;

--- a/Source/Objects/Custom Hardware/SNO+/XL3/XL3_LinkController.m
+++ b/Source/Objects/Custom Hardware/SNO+/XL3/XL3_LinkController.m
@@ -1459,11 +1459,15 @@ static NSDictionary* xl3Ops;
 
     [self endEditing];
     [model readHVInterlock];
-    [model readHVRelays:&relays isKnown:&known];
-    if(known) {
-        NSLog(@"Relay mask = %llu\n", (unsigned long long) relays);
-    } else {
-        NSLog(@"Relays are unknown!\n");
+    @try {
+        [model readHVRelays:&relays isKnown:&known];
+        if(known) {
+            NSLog(@"Relay mask = %llu\n", (unsigned long long) relays);
+        } else {
+            NSLog(@"Relays are unknown!\n");
+        }
+    }@catch (NSException *exception) {
+        NSLogColor([NSColor redColor],@"%@ error in readHVRelays. Error: %@ Reason: %@\n",[[model xl3Link] crateName], [exception name], [exception reason]);
     }
 }
 

--- a/Source/Objects/Custom Hardware/SNO+/XL3/XL3_LinkController.m
+++ b/Source/Objects/Custom Hardware/SNO+/XL3/XL3_LinkController.m
@@ -1452,11 +1452,19 @@ static NSDictionary* xl3Ops;
     [model openHVRelays];
 }
 
-- (IBAction)hvCheckInterlockAction:(id)sender
+- (IBAction)hvCheckInterlockRelaysAction:(id)sender
 {
+    uint64_t relays;
+    BOOL known;
+
     [self endEditing];
     [model readHVInterlock];
-
+    [model readHVRelays:&relays isKnown:&known];
+    if(known) {
+        NSLog(@"Relay mask = %llu\n", (unsigned long long) relays);
+    } else {
+        NSLog(@"Relays are unknown!\n");
+    }
 }
 
 - (IBAction)hvTurnOnAction:(id)sender


### PR DESCRIPTION
This adds two things. Firstly the check interlock button is now check interlock & relays*. Second, when turning HV on the the following things are checked. Interlock, XL3 mode (init/normal), HV relays are known, and HV relays are open for any missing fecs. If any of those fail the HV won't turn on.

Additionally this will require ML403 code that's as recent or better than [this](https://github.com/pennneutrinos/fullml403/commit/9c7d20967b355fa97ff07267ac96887516e12b09) commit.
So we should probably consider versioning and documenting that dependency somewhere and stuff like that.

@BenLand100 would you mind taking a look at this and making sure it won't disrupt any of the existing HV code.

*Not actually, my macbook is several version of xcode too advanced so I haven't made any .xib changes. I'll have to change the xl3 gui using one of the site computer when test it or something.