### PR TITLE
SNO+: Remove intensity correlation from trigger rate check for TELLIE

### DIFF
--- a/Source/Objects/Custom Hardware/SNO+/ELLIE/ELLIEModel.m
+++ b/Source/Objects/Custom Hardware/SNO+/ELLIE/ELLIEModel.m
@@ -461,7 +461,7 @@ NSString* ORTELLIERunFinished = @"ORTELLIERunFinished";
      */
     
     /*
-     Currently the predicted nPhotons does not correlate with reality so this check is defunkt.
+     Currently the predicted nPhotons does not correlate with reality so this check is defunct.
      it might be worth adding it back eventually once our understanding has improved. For now
      make do with a simple rate check (below).
     float safe_gradient = -1;

--- a/Source/Objects/Custom Hardware/SNO+/ELLIE/ELLIEModel.m
+++ b/Source/Objects/Custom Hardware/SNO+/ELLIE/ELLIEModel.m
@@ -459,6 +459,11 @@ NSString* ORTELLIERunFinished = @"ORTELLIERunFinished";
      to avoid pushing too much current through individual channels / trigger sums. Use a
      loglog curve to define what counts as detector safe.
      */
+    
+    /*
+     Currently the predicted nPhotons does not correlate with reality so this check is defunkt.
+     it might be worth adding it back eventually once our understanding has improved. For now
+     make do with a simple rate check (below).
     float safe_gradient = -1;
     float safe_intercept = 1.05e6;
     float max_photons = safe_intercept*pow(frequency, safe_gradient);
@@ -467,6 +472,10 @@ NSString* ORTELLIERunFinished = @"ORTELLIERunFinished";
     } else {
         return YES;
     }
+     */
+    if(frequency > 1.01e3)
+        return NO;
+    return YES;
 }
 
 -(NSString*)calcTellieFibreForNode:(NSUInteger)node{


### PR DESCRIPTION
Recent testing of the PCA set points has shown that TELLIE's calibrated photon output doesn't correlate with the nHits observed by the detector. This PR replaces an intensity vs rate check (which uses those 'bad' calibrations!) with a simple rate cut at 1kHz. 