### PR TITLE
SNO+: initialize nhit monitor before loading settings

### DIFF
--- a/Source/Experiments/SNOP/SNOPModel.m
+++ b/Source/Experiments/SNOP/SNOPModel.m
@@ -287,9 +287,11 @@ tellieRunFiles = _tellieRunFiles;
     /* Initialize ECARun object: this doesn't start the run */
     anECARun = [[ECARun alloc] init];
 
+    nhitMonitor = [[NHitMonitor alloc] init];
+
     [[self undoManager] disableUndoRegistration];
-	[self initOrcaDBConnectionHistory];
-	[self initDebugDBConnectionHistory];
+    [self initOrcaDBConnectionHistory];
+    [self initDebugDBConnectionHistory];
 
     [self setViewType:[decoder decodeIntForKey:@"viewType"]];
 
@@ -371,8 +373,6 @@ tellieRunFiles = _tellieRunFiles;
 
     /* initialize our connection to the XL3 server */
     xl3_server = [[RedisClient alloc] initWithHostName:xl3Host withPort:xl3Port];
-
-    nhitMonitor = [[NHitMonitor alloc] init];
 
     return self;
 }

--- a/Source/Experiments/SNOP/SNOPModel.m
+++ b/Source/Experiments/SNOP/SNOPModel.m
@@ -140,7 +140,6 @@ tellieRunFiles = _tellieRunFiles;
     [self initOrcaDBConnectionHistory];
     [self initDebugDBConnectionHistory];
 
-    nhitMonitor = [[NHitMonitor alloc] init];
     [[self undoManager] enableUndoRegistration];
 
     return self;

--- a/Source/Experiments/SNOP/SNOPModel.m
+++ b/Source/Experiments/SNOP/SNOPModel.m
@@ -354,14 +354,19 @@ tellieRunFiles = _tellieRunFiles;
     [self setNhitMonitorPulserRate:[decoder decodeIntForKey:@"nhitMonitorPulserRate"]];
     [self setNhitMonitorNumPulses:[decoder decodeIntForKey:@"nhitMonitorNumPulses"]];
     [self setNhitMonitorMaxNhit:[decoder decodeIntForKey:@"nhitMonitorMaxNhit"]];
-    [self setNhitMonitorAutoRun:[decoder decodeBoolForKey:@"nhitMonitorAutoRun"]];
     [self setNhitMonitorAutoPulserRate:[decoder decodeIntForKey:@"nhitMonitorAutoPulserRate"]];
     [self setNhitMonitorAutoNumPulses:[decoder decodeIntForKey:@"nhitMonitorAutoNumPulses"]];
     [self setNhitMonitorAutoMaxNhit:[decoder decodeIntForKey:@"nhitMonitorAutoMaxNhit"]];
     [self setNhitMonitorRunType:[decoder decodeIntForKey:@"nhitMonitorRunType"]];
     [self setNhitMonitorCrateMask:[decoder decodeIntForKey:@"nhitMonitorCrateMask"]];
+    /* Don't automatically run the nhit monitor until we load all the settings.
+     * Initially the time interval and auto run variables will be uninitialized
+     * in this method and if we set the time interval here and
+     * nhitMonitorAutoRun is set to YES, it will start the automatic timer
+     * before the settings are loaded. */
+    nhitMonitorAutoRun = NO;
     [self setNhitMonitorTimeInterval:[decoder decodeDoubleForKey:@"nhitMonitorTimeInterval"]];
-    [self setNhitMonitorMaxNhit:[decoder decodeIntForKey:@"nhitMonitorMaxNhit"]];
+    [self setNhitMonitorAutoRun:[decoder decodeBoolForKey:@"nhitMonitorAutoRun"]];
     [[self undoManager] enableUndoRegistration];
 
     //Set extra security


### PR DESCRIPTION
This pull request fixes a few bugs in the initialization of the nhit monitor settings.

- delete initialization of the nhit monitor in init() since initWithCoder() is immediately called afterwards even when the SNO+ controller is first added to the experiment
- initialize the nhit monitor object before loading settings in initWithCoder()
- don't automatically run the nhit monitor until all settings are loaded

This is an attempt to fix a bug that was seen on May 14, 2017 where it appeared that there were two copies of the nhit monitor running (i.e. two nstimer objects had somehow been started). None of these fixes obviously fixes the issue but since some of them may have started a timer with uninitialized values it's possible that it might fix the issue.