### PR TITLE
ping crates at run starts

### DIFF
--- a/Source/Experiments/SNOP/NHitMonitor.h
+++ b/Source/Experiments/SNOP/NHitMonitor.h
@@ -50,6 +50,7 @@ struct NhitRecord {
 - (void) dealloc;
 - (void) registerNotificationObservers;
 - (void) runAboutToStop: (NSNotification*) aNote;
+- (void) orcaAboutToQuit: (NSNotification*) aNote;
 - (void) _waitForThreadToFinish;
 - (BOOL) isRunning;
 - (void) stop;

--- a/Source/Experiments/SNOP/NHitMonitor.h
+++ b/Source/Experiments/SNOP/NHitMonitor.h
@@ -58,7 +58,8 @@ struct NhitRecord {
 - (void) disconnect;
 - (void) nhitMonitorCallback: (ORPQResult *) result;
 - (void) run: (NSDictionary *) args;
-- (void) _run: (int) crate pulserRate: (int) pulserRate numPulses: (int) numPulses maxNhit: (int) maxNhit slots: (NSMutableArray *) slots channels:(NSMutableArray *) channels;
+- (void) _run: (NSDictionary *) args;
+- (void) __run: (int) crate pulserRate: (int) pulserRate numPulses: (int) numPulses maxNhit: (int) maxNhit slots: (NSMutableArray *) slots channels:(NSMutableArray *) channels;
 @end
 
 extern NSString* ORNhitMonitorUpdateNotification;

--- a/Source/Experiments/SNOP/NHitMonitor.m
+++ b/Source/Experiments/SNOP/NHitMonitor.m
@@ -191,6 +191,11 @@ static int get_nhit_trigger_count(char *err, RedisClient *mtc, int sock, char *b
                      selector : @selector(runAboutToStop:)
                          name : ORRunAboutToStopNotification
                        object : nil];
+
+    [notifyCenter addObserver : self
+                     selector : @selector(orcaAboutToQuit:)
+                         name : OROrcaAboutToQuitNotification
+                       object : nil];
 }
 
 - (void) runAboutToStop: (NSNotification*) aNote
@@ -210,6 +215,17 @@ static int get_nhit_trigger_count(char *err, RedisClient *mtc, int sock, char *b
     [NSThread detachNewThreadSelector:@selector(_waitForThreadToFinish)
                              toTarget:self
                            withObject:nil];
+}
+
+- (void) orcaAboutToQuit: (NSNotification*) aNote
+{
+    /* Stop the nhit monitor if it's running and delay the termination. */
+    if (![self isRunning]) return;
+
+    [self stop];
+
+    /* Tell Orca to wait five seconds before quitting. */
+    [(ORAppDelegate *)[NSApp delegate] delayTermination];
 }
 
 - (void) _waitForThreadToFinish

--- a/Source/Experiments/SNOP/NHitMonitor.m
+++ b/Source/Experiments/SNOP/NHitMonitor.m
@@ -195,7 +195,7 @@ static int get_nhit_trigger_count(char *err, RedisClient *mtc, int sock, char *b
 
     [notifyCenter addObserver : self
                      selector : @selector(orcaAboutToQuit:)
-                         name : OROrcaAboutToQuitNotification
+                         name : OROrcaAboutToQuitNotice
                        object : nil];
 }
 

--- a/Source/Experiments/SNOP/NHitMonitor.m
+++ b/Source/Experiments/SNOP/NHitMonitor.m
@@ -381,6 +381,7 @@ err:
         } else {
             NSLogColor([NSColor redColor],
                        @"nhit monitor: unable to acquire eca lock!\n");
+            [[NSNotificationCenter defaultCenter] postNotificationOnMainThreadWithName:ORNhitMonitorNotification object:self userInfo:@{@"finished":@1}];
         }
     }
 }

--- a/Source/Experiments/SNOP/NHitMonitor.m
+++ b/Source/Experiments/SNOP/NHitMonitor.m
@@ -18,6 +18,7 @@
 #import "RedisClient.h"
 #import "ORMTC_Constants.h"
 #import "TUBiiModel.h"
+#import "AppDelegate.h"
 
 #define SWAP_INT32(a,b) swap_int32((uint32_t *)(a),(b))
 

--- a/Source/Experiments/SNOP/NHitMonitor.m
+++ b/Source/Experiments/SNOP/NHitMonitor.m
@@ -18,7 +18,7 @@
 #import "RedisClient.h"
 #import "ORMTC_Constants.h"
 #import "TUBiiModel.h"
-#import "AppDelegate.h"
+#import "ORAppDelegate.h"
 
 #define SWAP_INT32(a,b) swap_int32((uint32_t *)(a),(b))
 

--- a/Source/Experiments/SNOP/NHitMonitor.m
+++ b/Source/Experiments/SNOP/NHitMonitor.m
@@ -370,7 +370,7 @@ err:
         snop = [snops objectAtIndex:0];
 
         /* Try to acquire the lock for 10 seconds. If we can't get it then we
-         * just skip the ping crates. */
+         * just skip running the nhit monitor. */
         if ([[snop ecaLock] lockBeforeDate:[NSDate dateWithTimeIntervalSinceNow:10.0]]) {
             @try {
                 [self _run:args];

--- a/Source/Experiments/SNOP/NHitMonitor.m
+++ b/Source/Experiments/SNOP/NHitMonitor.m
@@ -356,6 +356,37 @@ err:
 
 - (void) run: (NSDictionary *) args
 {
+    SNOPModel *snop;
+
+    @autoreleasepool {
+        NSArray* snops = [[(ORAppDelegate*)[NSApp delegate] document]
+             collectObjectsOfClass:NSClassFromString(@"SNOPModel")];
+
+        if ([snops count] == 0) {
+            NSLogColor([NSColor redColor], @"nhit monitor: unable to find SNO+ model object.\n");
+            return;
+        }
+
+        snop = [snops objectAtIndex:0];
+
+        /* Try to acquire the lock for 10 seconds. If we can't get it then we
+         * just skip the ping crates. */
+        if ([[snop ecaLock] lockBeforeDate:[NSDate dateWithTimeIntervalSinceNow:10.0]]) {
+            @try {
+                [self _run:args];
+            } @finally {
+                /* Make sure to unlock the lock when we're done. */
+                [[snop ecaLock] unlock];
+            }
+        } else {
+            NSLogColor([NSColor redColor],
+                       @"nhit monitor: unable to acquire eca lock!\n");
+        }
+    }
+}
+
+- (void) _run: (NSDictionary *) args
+{
     /* Run the nhit monitor. This method should only be called by the start method. */
     SNOPModel *snop;
     uint32_t pedestals_enabled, pulser_enabled, pedestal_mask, coarse_delay;
@@ -367,192 +398,190 @@ err:
     ORFec32Model *fec;
     int slot, channel;
 
-    @autoreleasepool {
-        int crate = [[args objectForKey:@"crate"] intValue];
-        int pulserRate = [[args objectForKey:@"pulserRate"] intValue];
-        int numPulses = [[args objectForKey:@"numPulses"] intValue];
-        int maxNhit = [[args objectForKey:@"maxNhit"] intValue];
+    int crate = [[args objectForKey:@"crate"] intValue];
+    int pulserRate = [[args objectForKey:@"pulserRate"] intValue];
+    int numPulses = [[args objectForKey:@"numPulses"] intValue];
+    int maxNhit = [[args objectForKey:@"maxNhit"] intValue];
 
-        NSArray* snops = [[(ORAppDelegate*)[NSApp delegate] document]
-             collectObjectsOfClass:NSClassFromString(@"SNOPModel")];
+    NSArray* snops = [[(ORAppDelegate*)[NSApp delegate] document]
+         collectObjectsOfClass:NSClassFromString(@"SNOPModel")];
 
-        if ([snops count] == 0) {
-            NSLogColor([NSColor redColor], @"nhit monitor: unable to find SNO+ model object.\n");
-            goto err;
+    if ([snops count] == 0) {
+        NSLogColor([NSColor redColor], @"nhit monitor: unable to find SNO+ model object.\n");
+        goto err;
+    }
+
+    snop = [snops objectAtIndex:0];
+
+    /* Since we are running in a separate thread, it's easiest to just open
+     * up a new connection to the mtc server instead of having to dispatch
+     * all commands to the main thread. */
+    mtc = [[RedisClient alloc] initWithHostName:[snop mtcHost] withPort:[snop mtcPort]];
+    /* Autorelease the MTC object. It will get freed when the function
+     * finishes since we are in an @autoreleasepool block. */
+    [mtc autorelease];
+
+    /* Find the correct XL3. */
+    xl3 = nil;
+
+    NSArray* xl3s = [[(ORAppDelegate*)[NSApp delegate] document]
+         collectObjectsOfClass:NSClassFromString(@"ORXL3Model")];
+
+    for (i = 0; i < [xl3s count]; i++) {
+        if ([[xl3s objectAtIndex:i] crateNumber] == crate) {
+            xl3 = [xl3s objectAtIndex:i];
+            break;
         }
+    }
 
-        snop = [snops objectAtIndex:0];
+    if (!xl3) {
+        NSLogColor([NSColor redColor], @"nhit monitor: unable to find XL3 %i\n", crate);
+        goto err;
+    }
 
-        /* Since we are running in a separate thread, it's easiest to just open
-         * up a new connection to the mtc server instead of having to dispatch
-         * all commands to the main thread. */
-        mtc = [[RedisClient alloc] initWithHostName:[snop mtcHost] withPort:[snop mtcPort]];
-        /* Autorelease the MTC object. It will get freed when the function
-         * finishes since we are in an @autoreleasepool block. */
-        [mtc autorelease];
+    if (![xl3 isTriggerON]) {
+        NSLogColor([NSColor redColor], @"nhit monitor: crate %i triggers are off!\n", crate);
+        goto err;
+    }
 
-        /* Find the correct XL3. */
-        xl3 = nil;
+    if (maxNhit > MAX_NHIT) {
+        NSLogColor([NSColor redColor], @"nhit monitor: max nhit must be less than %i\n", MAX_NHIT);
+        goto err;
+    }
 
-        NSArray* xl3s = [[(ORAppDelegate*)[NSApp delegate] document]
-             collectObjectsOfClass:NSClassFromString(@"ORXL3Model")];
+    /* Disable all pedestals. */
+    for (slot = 0; slot < 16; slot++) {
+        fec = [[OROrderedObjManager for:[xl3 guardian]] objectInSlot:16-slot];
 
-        for (i = 0; i < [xl3s count]; i++) {
-            if ([[xl3s objectAtIndex:i] crateNumber] == crate) {
-                xl3 = [xl3s objectAtIndex:i];
-                break;
-            }
-        }
+        if (!fec) continue;
 
-        if (!xl3) {
-            NSLogColor([NSColor redColor], @"nhit monitor: unable to find XL3 %i\n", crate);
-            goto err;
-        }
+        dispatch_sync(dispatch_get_main_queue(), ^{
+            [fec setPedEnabledMask:0];
+        });
+    }
 
-        if (![xl3 isTriggerON]) {
-            NSLogColor([NSColor redColor], @"nhit monitor: crate %i triggers are off!\n", crate);
-            goto err;
-        }
-
-        if (maxNhit > MAX_NHIT) {
-            NSLogColor([NSColor redColor], @"nhit monitor: max nhit must be less than %i\n", MAX_NHIT);
-            goto err;
-        }
-
-        /* Disable all pedestals. */
+    /* create a list of channels for which to enable pedestals. We only add
+     * channels if both the N100 and N20 triggers are enabled. */
+    NSMutableArray *slots = [NSMutableArray array];
+    NSMutableArray *channels = [NSMutableArray array];
+    /* Loop over channels 17 and 18 first, since they are the most likely
+     * to have pickup. Then, we loop over the channels in order starting
+     * from 0, except we skip the channels at the edge of each daughter
+     * board since those tend to cause pickup on the next set of channels. */
+    int channel_order[32] = {17,18,0,1,2,3,4,5,8,9,10,11,12,13,14,19,20,21,22,25,26,27,28,29,30,31,6,7,15,16,23,24};
+    for (i = 0; i < 32; i++) {
+        channel = channel_order[i];
         for (slot = 0; slot < 16; slot++) {
             fec = [[OROrderedObjManager for:[xl3 guardian]] objectInSlot:16-slot];
 
             if (!fec) continue;
 
-            dispatch_sync(dispatch_get_main_queue(), ^{
-                [fec setPedEnabledMask:0];
-            });
-        }
-
-        /* create a list of channels for which to enable pedestals. We only add
-         * channels if both the N100 and N20 triggers are enabled. */
-        NSMutableArray *slots = [NSMutableArray array];
-        NSMutableArray *channels = [NSMutableArray array];
-        /* Loop over channels 17 and 18 first, since they are the most likely
-         * to have pickup. Then, we loop over the channels in order starting
-         * from 0, except we skip the channels at the edge of each daughter
-         * board since those tend to cause pickup on the next set of channels. */
-        int channel_order[32] = {17,18,0,1,2,3,4,5,8,9,10,11,12,13,14,19,20,21,22,25,26,27,28,29,30,31,6,7,15,16,23,24};
-        for (i = 0; i < 32; i++) {
-            channel = channel_order[i];
-            for (slot = 0; slot < 16; slot++) {
-                fec = [[OROrderedObjManager for:[xl3 guardian]] objectInSlot:16-slot];
-
-                if (!fec) continue;
-
-                if ([fec trigger100nsEnabled: channel] && \
-                    [fec trigger20nsEnabled: channel]) {
-                    [slots addObject:[NSNumber numberWithInt:slot]];
-                    [channels addObject:[NSNumber numberWithInt:channel]];
-                }
+            if ([fec trigger100nsEnabled: channel] && \
+                [fec trigger20nsEnabled: channel]) {
+                [slots addObject:[NSNumber numberWithInt:slot]];
+                [channels addObject:[NSNumber numberWithInt:channel]];
             }
         }
+    }
 
-        if (maxNhit > [channels count]) {
-            NSLogColor([NSColor redColor], @"nhit monitor: crate %i only has %i channels with triggers enabled, but max nhit is %i\n", crate, [channels count], maxNhit);
-            goto err;
-        }
+    if (maxNhit > [channels count]) {
+        NSLogColor([NSColor redColor], @"nhit monitor: crate %i only has %i channels with triggers enabled, but max nhit is %i\n", crate, [channels count], maxNhit);
+        goto err;
+    }
 
-        /* Connect to the data stream server. */
-        if ([self connect]) {
-            NSLogColor([NSColor redColor], @"nhit monitor: failed to connect to the data stream server\n");
-            goto err;
-        }
+    /* Connect to the data stream server. */
+    if ([self connect]) {
+        NSLogColor([NSColor redColor], @"nhit monitor: failed to connect to the data stream server\n");
+        goto err;
+    }
 
-        @try {
-            /* Save the current MTC settings so we can set them back when the
-             * nhit monitor is done. */
-            control_register = [mtc intCommand:"mtcd_read 0x0"];
-            pedestals_enabled = control_register & 0x1;
-            pulser_enabled = control_register & 0x2;
-            pedestal_mask = [mtc intCommand:"get_ped_crate_mask"];
-            pulser_rate = [mtc intCommand:"get_pulser_freq"];
-            coarse_delay = [mtc intCommand:"get_coarse_delay"];
-            fine_delay = [mtc intCommand:"get_fine_delay"];
-            pedestal_width = [mtc intCommand:"get_pedestal_width"];
-            gt_mask = [mtc intCommand:"get_gt_mask"];
-        } @catch (NSException *e) {
-            NSLogColor([NSColor redColor], @"nhit monitor failed to get mtc "
-                       "hardware state. error: %@ reason: %@\n",
-                       [e name], [e reason]);
-            [self disconnect];
-            goto err;
-        }
+    @try {
+        /* Save the current MTC settings so we can set them back when the
+         * nhit monitor is done. */
+        control_register = [mtc intCommand:"mtcd_read 0x0"];
+        pedestals_enabled = control_register & 0x1;
+        pulser_enabled = control_register & 0x2;
+        pedestal_mask = [mtc intCommand:"get_ped_crate_mask"];
+        pulser_rate = [mtc intCommand:"get_pulser_freq"];
+        coarse_delay = [mtc intCommand:"get_coarse_delay"];
+        fine_delay = [mtc intCommand:"get_fine_delay"];
+        pedestal_width = [mtc intCommand:"get_pedestal_width"];
+        gt_mask = [mtc intCommand:"get_gt_mask"];
+    } @catch (NSException *e) {
+        NSLogColor([NSColor redColor], @"nhit monitor failed to get mtc "
+                   "hardware state. error: %@ reason: %@\n",
+                   [e name], [e reason]);
+        [self disconnect];
+        goto err;
+    }
 
-        if ((gt_mask & MTC_PULSE_GT_MASK) == 0) {
-            NSLogColor([NSColor redColor], @"nhit monitor: PULSE_GT is not masked in!\n");
-            [self disconnect];
-            goto err;
-        }
+    if ((gt_mask & MTC_PULSE_GT_MASK) == 0) {
+        NSLogColor([NSColor redColor], @"nhit monitor: PULSE_GT is not masked in!\n");
+        [self disconnect];
+        goto err;
+    }
 
-        @try {
-            /* Initialize the MTC settings for the nhit monitor. */
-            [mtc okCommand:"disable_pulser"];
+    @try {
+        /* Initialize the MTC settings for the nhit monitor. */
+        [mtc okCommand:"disable_pulser"];
+        [mtc okCommand:"enable_pedestals"];
+        [mtc okCommand:"set_ped_crate_mask %i", (1 << crate)];
+        [mtc okCommand:"set_pulser_freq %i", pulserRate];
+        [mtc okCommand:"set_coarse_delay %i", COARSE_DELAY];
+        [mtc okCommand:"set_fine_delay %i", FINE_DELAY];
+        [mtc okCommand:"set_pedestal_width %i", PEDESTAL_WIDTH];
+
+        /* turn off all pedestals */
+        [xl3 setPedestalMask:[xl3 getSlotsPresent] pattern:0];
+
+        /* We call another method here because we need to wrap everything
+         * in a try-catch block so that if anything fails we make sure to
+         * reset the MTC settings. */
+        [self __run:crate pulserRate:pulserRate numPulses:numPulses maxNhit:maxNhit slots:slots channels:channels];
+    } @catch (NSException *e) {
+        NSLogColor([NSColor redColor], @"nhit monitor failed. error: %@ "
+                   "reason: %@\n", [e name], [e reason]);
+    } @finally {
+        /* Make sure to reset all the hardware settings. */
+        if (pedestals_enabled) {
             [mtc okCommand:"enable_pedestals"];
-            [mtc okCommand:"set_ped_crate_mask %i", (1 << crate)];
-            [mtc okCommand:"set_pulser_freq %i", pulserRate];
-            [mtc okCommand:"set_coarse_delay %i", COARSE_DELAY];
-            [mtc okCommand:"set_fine_delay %i", FINE_DELAY];
-            [mtc okCommand:"set_pedestal_width %i", PEDESTAL_WIDTH];
-
-            /* turn off all pedestals */
-            [xl3 setPedestalMask:[xl3 getSlotsPresent] pattern:0];
-
-            /* We call another method here because we need to wrap everything
-             * in a try-catch block so that if anything fails we make sure to
-             * reset the MTC settings. */
-            [self _run:crate pulserRate:pulserRate numPulses:numPulses maxNhit:maxNhit slots:slots channels:channels];
-        } @catch (NSException *e) {
-            NSLogColor([NSColor redColor], @"nhit monitor failed. error: %@ "
-                       "reason: %@\n", [e name], [e reason]);
-        } @finally {
-            /* Make sure to reset all the hardware settings. */
-            if (pedestals_enabled) {
-                [mtc okCommand:"enable_pedestals"];
-            } else {
-                [mtc okCommand:"disable_pedestals"];
-            }
-
-            if (pulser_enabled) {
-                [mtc okCommand:"enable_pulser"];
-            } else {
-                [mtc okCommand:"disable_pulser"];
-            }
-
-            [mtc okCommand:"set_ped_crate_mask %i", pedestal_mask];
-            [mtc okCommand:"set_pulser_freq %i", pulser_rate];
-            [mtc okCommand:"set_coarse_delay %i", coarse_delay];
-            [mtc okCommand:"set_fine_delay %i", fine_delay];
-            [mtc okCommand:"set_pedestal_width %i", pedestal_width];
-
-            /* turn off all pedestals */
-            [xl3 setPedestalMask:[xl3 getSlotsPresent] pattern:0];
-
-            /* Disconnect from the data server. */
-            [self disconnect];
+        } else {
+            [mtc okCommand:"disable_pedestals"];
         }
 
-        NSLog(@"nhit monitor done\n");
+        if (pulser_enabled) {
+            [mtc okCommand:"enable_pulser"];
+        } else {
+            [mtc okCommand:"disable_pulser"];
+        }
+
+        [mtc okCommand:"set_ped_crate_mask %i", pedestal_mask];
+        [mtc okCommand:"set_pulser_freq %i", pulser_rate];
+        [mtc okCommand:"set_coarse_delay %i", coarse_delay];
+        [mtc okCommand:"set_fine_delay %i", fine_delay];
+        [mtc okCommand:"set_pedestal_width %i", pedestal_width];
+
+        /* turn off all pedestals */
+        [xl3 setPedestalMask:[xl3 getSlotsPresent] pattern:0];
+
+        /* Disconnect from the data server. */
+        [self disconnect];
+    }
+
+    NSLog(@"nhit monitor done\n");
 
 err:
-        /* Post a notification so that the SNOPController can enable the run
-         * button. Note: ideally the SNOPController would just check to see if
-         * the nhit monitor was running and then enable/disable the buttons
-         * depending on if it's running. However, there is no easy way to post
-         * the notification *after* this thread exits, and so when the
-         * notification is posted the nhit monitor will still be running. To
-         * get around this we add a userInfo dictionary to the notification. */
-        [[NSNotificationCenter defaultCenter] postNotificationOnMainThreadWithName:ORNhitMonitorNotification object:self userInfo:@{@"finished":@1}];
-    }
+    /* Post a notification so that the SNOPController can enable the run
+     * button. Note: ideally the SNOPController would just check to see if
+     * the nhit monitor was running and then enable/disable the buttons
+     * depending on if it's running. However, there is no easy way to post
+     * the notification *after* this thread exits, and so when the
+     * notification is posted the nhit monitor will still be running. To
+     * get around this we add a userInfo dictionary to the notification. */
+    [[NSNotificationCenter defaultCenter] postNotificationOnMainThreadWithName:ORNhitMonitorNotification object:self userInfo:@{@"finished":@1}];
 }
 
-- (void) _run: (int) crate pulserRate: (int) pulserRate numPulses: (int) numPulses maxNhit: (int) maxNhit slots: (NSMutableArray *) slots channels:(NSMutableArray *) channels
+- (void) __run: (int) crate pulserRate: (int) pulserRate numPulses: (int) numPulses maxNhit: (int) maxNhit slots: (NSMutableArray *) slots channels:(NSMutableArray *) channels
 {
     /* Run the nhit monitor. This method should only be called in a separate
      * thread. The start method should be called to actually start the nhit

--- a/Source/Experiments/SNOP/SNOPModel.h
+++ b/Source/Experiments/SNOP/SNOPModel.h
@@ -142,6 +142,8 @@ BOOL isNotRunningOrIsInMaintenance();
     uint32_t nhitMonitorCrateMask;
     NSTimeInterval nhitMonitorTimeInterval;
 
+    NSLock *ecaLock;
+
     RedisClient *mtc_server;
     RedisClient *xl3_server;
 
@@ -223,6 +225,7 @@ BOOL isNotRunningOrIsInMaintenance();
 - (void) couchDBResult:(id)aResult tag:(NSString*)aTag op:(id)anOp;
 
 - (void) pingCratesAtRunStart;
+- (NSLock *) ecaLock;
 - (void) pingCrates;
 - (void) runNhitMonitorAutomatically;
 - (void) runNhitMonitor;

--- a/Source/Experiments/SNOP/SNOPModel.h
+++ b/Source/Experiments/SNOP/SNOPModel.h
@@ -222,6 +222,7 @@ BOOL isNotRunningOrIsInMaintenance();
 - (void) taskFinished:(NSTask*)aTask;
 - (void) couchDBResult:(id)aResult tag:(NSString*)aTag op:(id)anOp;
 
+- (void) pingCratesAtRunStart;
 - (void) pingCrates;
 - (void) runNhitMonitorAutomatically;
 - (void) runNhitMonitor;

--- a/Source/Experiments/SNOP/SNOPModel.m
+++ b/Source/Experiments/SNOP/SNOPModel.m
@@ -1330,6 +1330,15 @@ static NSComparisonResult compareXL3s(ORXL3Model *xl3_1, ORXL3Model *xl3_2, void
         }
     }
 
+    /* Send an EPED record with the stepNumber set to 0xffffffff to let the
+     * nearline job know that we are done. */
+    [self shipEPEDStructWithCoarseDelay: [mtc coarseDelay]
+                              fineDelay: [mtc fineDelay]
+                         chargePulseAmp: 0
+                          pedestalWidth: [mtc pedestalWidth]
+                                calType: 50
+                             stepNumber: 0xffffffff];
+
     /* Set the pedestal mask for each crate back. */
     for (i = 0; i < [xl3s count]; i++) {
         xl3 = [xl3s objectAtIndex:i];

--- a/Source/Experiments/SNOP/SNOPModel.m
+++ b/Source/Experiments/SNOP/SNOPModel.m
@@ -1274,7 +1274,7 @@ static NSComparisonResult compareXL3s(ORXL3Model *xl3_1, ORXL3Model *xl3_2, void
                                           fineDelay: [mtc fineDelay]
                                      chargePulseAmp: 0
                                       pedestalWidth: [mtc pedestalWidth]
-                                            calType: 5
+                                            calType: 50
                                          stepNumber: ((i << 4) | j)];
 
                 @try {

--- a/Source/Experiments/SNOP/SNOPModel.m
+++ b/Source/Experiments/SNOP/SNOPModel.m
@@ -1320,9 +1320,9 @@ static NSComparisonResult compareXL3s(ORXL3Model *xl3_1, ORXL3Model *xl3_2, void
                            @"failed to fire pedestal. error: %@ reason: %@\n",
                            [e name], [e reason]);
             }
-        }
 
-        NSLog(@"PING crate %02d\n", i);
+            NSLog(@"PING crate %02d, slot %02d\n", i, j);
+        }
     }
 
     /* Set the pedestal mask for each crate back. */

--- a/Source/Experiments/SNOP/SNOPModel.m
+++ b/Source/Experiments/SNOP/SNOPModel.m
@@ -1374,8 +1374,6 @@ static NSComparisonResult compareXL3s(ORXL3Model *xl3_1, ORXL3Model *xl3_2, void
                            @"pingCratesAtRunStart: failed to fire pedestal. error: %@ reason: %@\n",
                            [e name], [e reason]);
             }
-
-            NSLog(@"PING crate %02d, slot %02d\n", i, j);
         }
     }
 

--- a/Source/Experiments/SNOP/SNOPModel.m
+++ b/Source/Experiments/SNOP/SNOPModel.m
@@ -48,6 +48,7 @@
 #import "ORPQModel.h"
 #import "ORPQResult.h"
 #import "RunTypeWordBits.hh"
+#import "TUBiiModel.hh"
 
 #define RUNNING 0
 #define STARTING 1
@@ -1201,32 +1202,45 @@ static NSComparisonResult compareXL3s(ORXL3Model *xl3_1, ORXL3Model *xl3_2, void
      * events to determine if any slots are not firing triggers correctly.
      * This function should only be called in a separate thread. */
     int i, j, k;
-    uint32_t crate_pedestal_mask, coarse_delay, fine_delay, pedestal_width;
+    uint32_t crate_pedestal_mask, coarse_delay, fine_delay, pedestal_width, gt_mask;
     float pulser_rate;
     uint32_t channelMasks[16];
+    uint32_t sync_trigger_mask, async_trigger_mask, tubii_dac;
 
     NSArray* xl3s = [[(ORAppDelegate*)[NSApp delegate] document]
          collectObjectsOfClass:NSClassFromString(@"ORXL3Model")];
     NSArray* mtcs = [[(ORAppDelegate*)[NSApp delegate] document]
          collectObjectsOfClass:NSClassFromString(@"ORMTCModel")];
+    NSArray* tubiis = [[(ORAppDelegate*)[NSApp delegate] document]
+         collectObjectsOfClass:NSClassFromString(@"TUBiiModel")];
 
     xl3s = [xl3s sortedArrayUsingFunction:compareXL3s context:nil];
 
     ORMTCModel* mtc;
     ORXL3Model* xl3;
+    TUBiiModel* tubii;
 
     if ([mtcs count] == 0) {
         NSLogColor([NSColor redColor],
-                   @"pingCrates: couldn't find MTC object.\n");
+                   @"pingCratesAtRunStart: couldn't find MTC object.\n");
         return;
     }
 
     mtc = [mtcs objectAtIndex:0];
 
+    if ([tubiis count] == 0) {
+        NSLogColor([NSColor redColor],
+                   @"pingCratesAtRunStart: couldn't find TUBii object.\n");
+        return;
+    }
+
+    tubii = [tubiis objectAtIndex:0];
+
     crate_pedestal_mask = [mtc pedCrateMask];
     coarse_delay = [mtc coarseDelay];
     fine_delay = [mtc fineDelay];
     pedestal_width = [mtc pedestalWidth];
+    gt_mask = [mtc gtMask];
 
     pulser_rate = [mtc pgtRate];
 
@@ -1259,6 +1273,41 @@ static NSComparisonResult compareXL3s(ORXL3Model *xl3_1, ORXL3Model *xl3_2, void
     } @catch (NSException *e) {
         NSLogColor([NSColor redColor],
                    @"error setting the MTCD pedestal width. error: "
+                    "%@ reason: %@\n", [e name], [e reason]);
+        return;
+    }
+
+    if (gt_mask & MTC_EXT_2_MASK) {
+        NSLogColor([NSColor redColor], @"pingCratesAtRunStart: EXT2 is masked in, so can't run ping crates.\n");
+        return;
+    }
+
+    /* Set the EXT2 trigger signal high so that it gets latched in every event
+     * while we ping the crates. This is to mark these events so that if we
+     * find out that changing the pedestal mask while running causes noise or
+     * other problems we can throw these events out. */
+    @try {
+        sync_trigger_mask = [tubii syncTrigMask];
+        async_trigger_mask = [tubii asyncTrigMask];
+        tubii_dac = [tubii MTCAMimic1_ThresholdInBits];
+    } @catch (NSException *e) {
+        NSLogColor([NSColor redColor],
+                   @"error getting TUBii trigger masks or dac value. error: "
+                    "%@ reason: %@\n", [e name], [e reason]);
+        return;
+    }
+
+    if (sync_mask != 0 || async_mask != 0) {
+        NSLogColor([NSColor redColor],
+                   @"pingCratesAtRunStart: tubii already has triggers enabled.\n");
+    }
+
+    @try {
+        [tubii setTriggerMask:0x10000 setAsyncMask:0];
+        [tubii setMTCAMimic1_ThresholdInBits:0];
+    } @catch (NSException *e) {
+        NSLogColor([NSColor redColor],
+                   @"error setting TUBii trigger masks or dac value. error: "
                     "%@ reason: %@\n", [e name], [e reason]);
         return;
     }
@@ -1346,6 +1395,16 @@ static NSComparisonResult compareXL3s(ORXL3Model *xl3_1, ORXL3Model *xl3_2, void
         if ([[xl3 xl3Link] isConnected]) {
             [xl3 setPedestals];
         }
+    }
+
+    /* Reset tubii's trigger masks and DAC value. */
+    @try {
+        [tubii setTriggerMask:0 setAsyncMask:0];
+        [tubii setMTCAMimic1_ThresholdInBits:tubii_dac];
+    } @catch (NSException *e) {
+        NSLogColor([NSColor redColor],
+                   @"error setting TUBii trigger masks or dac value. error: "
+                    "%@ reason: %@\n", [e name], [e reason]);
     }
 
     /* Reset the crate pedestal all crates in the MTCD pedestal mask. */

--- a/Source/Experiments/SNOP/SNOPModel.m
+++ b/Source/Experiments/SNOP/SNOPModel.m
@@ -1250,7 +1250,7 @@ static NSComparisonResult compareXL3s(ORXL3Model *xl3_1, ORXL3Model *xl3_2, void
         [mtc loadCoarseDelayToHardware];
     } @catch (NSException *e) {
         NSLogColor([NSColor redColor],
-                   @"error setting the MTCD coarse delay. error: "
+                   @"pingCratesAtRunStart: error setting the MTCD coarse delay. error: "
                     "%@ reason: %@\n", [e name], [e reason]);
         return;
     }
@@ -1261,7 +1261,7 @@ static NSComparisonResult compareXL3s(ORXL3Model *xl3_1, ORXL3Model *xl3_2, void
         [mtc loadFineDelayToHardware];
     } @catch (NSException *e) {
         NSLogColor([NSColor redColor],
-                   @"error setting the MTCD fine delay. error: "
+                   @"pingCratesAtRunStart: error setting the MTCD fine delay. error: "
                     "%@ reason: %@\n", [e name], [e reason]);
         return;
     }
@@ -1272,7 +1272,7 @@ static NSComparisonResult compareXL3s(ORXL3Model *xl3_1, ORXL3Model *xl3_2, void
         [mtc loadPedWidthToHardware];
     } @catch (NSException *e) {
         NSLogColor([NSColor redColor],
-                   @"error setting the MTCD pedestal width. error: "
+                   @"pingCratesAtRunStart: error setting the MTCD pedestal width. error: "
                     "%@ reason: %@\n", [e name], [e reason]);
         return;
     }
@@ -1292,7 +1292,7 @@ static NSComparisonResult compareXL3s(ORXL3Model *xl3_1, ORXL3Model *xl3_2, void
         tubii_dac = [tubii MTCAMimic1_ThresholdInBits];
     } @catch (NSException *e) {
         NSLogColor([NSColor redColor],
-                   @"error getting TUBii trigger masks or dac value. error: "
+                   @"pingCratesAtRunStart: error getting TUBii trigger masks or dac value. error: "
                     "%@ reason: %@\n", [e name], [e reason]);
         return;
     }
@@ -1307,7 +1307,7 @@ static NSComparisonResult compareXL3s(ORXL3Model *xl3_1, ORXL3Model *xl3_2, void
         [tubii setMTCAMimic1_ThresholdInBits:0];
     } @catch (NSException *e) {
         NSLogColor([NSColor redColor],
-                   @"error setting TUBii trigger masks or dac value. error: "
+                   @"pingCratesAtRunStart: error setting TUBii trigger masks or dac value. error: "
                     "%@ reason: %@\n", [e name], [e reason]);
         return;
     }
@@ -1324,7 +1324,7 @@ static NSComparisonResult compareXL3s(ORXL3Model *xl3_1, ORXL3Model *xl3_2, void
             [mtc loadPedestalCrateMaskToHardware];
         } @catch (NSException *e) {
             NSLogColor([NSColor redColor],
-                       @"error setting the MTCD crate pedestal mask. error: "
+                       @"pingCratesAtRunStart: error setting the MTCD crate pedestal mask. error: "
                         "%@ reason: %@\n", [e name], [e reason]);
             continue;
         }
@@ -1348,7 +1348,7 @@ static NSComparisonResult compareXL3s(ORXL3Model *xl3_1, ORXL3Model *xl3_2, void
 
             if ([xl3 multiSetPedestalMask:[xl3 getSlotsPresent]
                      patterns:channelMasks]) {
-                NSLogColor([NSColor redColor], @"failed to set pedestal mask "
+                NSLogColor([NSColor redColor], @"pingCratesAtRunStart: failed to set pedestal mask "
                             "for crate %02d slot %02d\n", i, j);
                 continue;
             }
@@ -1371,7 +1371,7 @@ static NSComparisonResult compareXL3s(ORXL3Model *xl3_1, ORXL3Model *xl3_2, void
                 [mtc firePedestals:1 withRate:1];
             } @catch (NSException *e) {
                 NSLogColor([NSColor redColor],
-                           @"failed to fire pedestal. error: %@ reason: %@\n",
+                           @"pingCratesAtRunStart: failed to fire pedestal. error: %@ reason: %@\n",
                            [e name], [e reason]);
             }
 
@@ -1403,7 +1403,7 @@ static NSComparisonResult compareXL3s(ORXL3Model *xl3_1, ORXL3Model *xl3_2, void
         [tubii setMTCAMimic1_ThresholdInBits:tubii_dac];
     } @catch (NSException *e) {
         NSLogColor([NSColor redColor],
-                   @"error setting TUBii trigger masks or dac value. error: "
+                   @"pingCratesAtRunStart: error setting TUBii trigger masks or dac value. error: "
                     "%@ reason: %@\n", [e name], [e reason]);
     }
 
@@ -1413,7 +1413,7 @@ static NSComparisonResult compareXL3s(ORXL3Model *xl3_1, ORXL3Model *xl3_2, void
         [mtc loadPedestalCrateMaskToHardware];
     } @catch (NSException *e) {
         NSLogColor([NSColor redColor],
-                   @"error setting the MTCD crate pedestal mask. error: "
+                   @"pingCratesAtRunStart: error setting the MTCD crate pedestal mask. error: "
                     "%@ reason: %@\n", [e name], [e reason]);
     }
 
@@ -1423,7 +1423,7 @@ static NSComparisonResult compareXL3s(ORXL3Model *xl3_1, ORXL3Model *xl3_2, void
         [mtc loadCoarseDelayToHardware];
     } @catch (NSException *e) {
         NSLogColor([NSColor redColor],
-                   @"error setting the MTCD coarse delay. error: "
+                   @"pingCratesAtRunStart: error setting the MTCD coarse delay. error: "
                     "%@ reason: %@\n", [e name], [e reason]);
     }
 
@@ -1433,7 +1433,7 @@ static NSComparisonResult compareXL3s(ORXL3Model *xl3_1, ORXL3Model *xl3_2, void
         [mtc loadFineDelayToHardware];
     } @catch (NSException *e) {
         NSLogColor([NSColor redColor],
-                   @"error setting the MTCD fine delay. error: "
+                   @"pingCratesAtRunStart: error setting the MTCD fine delay. error: "
                     "%@ reason: %@\n", [e name], [e reason]);
     }
 
@@ -1443,7 +1443,7 @@ static NSComparisonResult compareXL3s(ORXL3Model *xl3_1, ORXL3Model *xl3_2, void
         [mtc loadPedWidthToHardware];
     } @catch (NSException *e) {
         NSLogColor([NSColor redColor],
-                   @"error setting the MTCD pedestal width. error: "
+                   @"pingCratesAtRunStart: error setting the MTCD pedestal width. error: "
                     "%@ reason: %@\n", [e name], [e reason]);
     }
 
@@ -1454,7 +1454,7 @@ static NSComparisonResult compareXL3s(ORXL3Model *xl3_1, ORXL3Model *xl3_2, void
         [mtc loadPulserRateToHardware];
     } @catch (NSException *e) {
         NSLogColor([NSColor redColor],
-                   @"error setting the pulser rate. error: "
+                   @"pingCratesAtRunStart: error setting the pulser rate. error: "
                     "%@ reason: %@\n", [e name], [e reason]);
     }
 }
@@ -1496,7 +1496,7 @@ static NSComparisonResult compareXL3s(ORXL3Model *xl3_1, ORXL3Model *xl3_2, void
         [mtc loadPedestalCrateMaskToHardware];
     } @catch (NSException *e) {
         NSLogColor([NSColor redColor],
-                   @"error setting the MTCD crate pedestal mask. error: "
+                   @"pingCrates: error setting the MTCD crate pedestal mask. error: "
                     "%@ reason: %@\n", [e name], [e reason]);
         return;
     }
@@ -1508,7 +1508,7 @@ static NSComparisonResult compareXL3s(ORXL3Model *xl3_1, ORXL3Model *xl3_2, void
         if ([[xl3 xl3Link] isConnected]) {
             if ([xl3 setPedestalMask:[xl3 getSlotsPresent] pattern:0]) {
                 NSLogColor([NSColor redColor],
-                           @"failed to set pedestal mask for crate %02d\n", i);
+                           @"pingCrates: failed to set pedestal mask for crate %02d\n", i);
                 continue;
             }
         }
@@ -1523,7 +1523,7 @@ static NSComparisonResult compareXL3s(ORXL3Model *xl3_1, ORXL3Model *xl3_2, void
             if ([xl3 setPedestalMask:[xl3 getSlotsPresent]
                  pattern:0xffffffff]) {
                 NSLogColor([NSColor redColor],
-                           @"failed to set pedestal mask for crate %02d\n", i);
+                           @"pingCrates: failed to set pedestal mask for crate %02d\n", i);
                 continue;
             }
 
@@ -1531,14 +1531,14 @@ static NSComparisonResult compareXL3s(ORXL3Model *xl3_1, ORXL3Model *xl3_2, void
                 [mtc firePedestals:1 withRate:1];
             } @catch (NSException *e) {
                 NSLogColor([NSColor redColor],
-                           @"failed to fire pedestal. error: %@ reason: %@\n",
+                           @"pingCrates: failed to fire pedestal. error: %@ reason: %@\n",
                            [e name], [e reason]);
             }
 
             /* Set pedestal mask back to 0. */
             if ([xl3 setPedestalMask:[xl3 getSlotsPresent] pattern:0]) {
                 NSLogColor([NSColor redColor],
-                           @"failed to set pedestal mask for crate %02d\n", i);
+                           @"pingCrates: failed to set pedestal mask for crate %02d\n", i);
                 continue;
             }
 
@@ -1561,7 +1561,7 @@ static NSComparisonResult compareXL3s(ORXL3Model *xl3_1, ORXL3Model *xl3_2, void
         [mtc loadPedestalCrateMaskToHardware];
     } @catch (NSException *e) {
         NSLogColor([NSColor redColor],
-                   @"error setting the MTCD crate pedestal mask. error: "
+                   @"pingCrates: error setting the MTCD crate pedestal mask. error: "
                     "%@ reason: %@\n", [e name], [e reason]);
     }
 
@@ -1572,7 +1572,7 @@ static NSComparisonResult compareXL3s(ORXL3Model *xl3_1, ORXL3Model *xl3_2, void
         [mtc loadPulserRateToHardware];
     } @catch (NSException *e) {
         NSLogColor([NSColor redColor],
-                   @"error setting the pulser rate. error: "
+                   @"pingCrates: error setting the pulser rate. error: "
                     "%@ reason: %@\n", [e name], [e reason]);
     }
 }

--- a/Source/Experiments/SNOP/SNOPModel.m
+++ b/Source/Experiments/SNOP/SNOPModel.m
@@ -48,7 +48,7 @@
 #import "ORPQModel.h"
 #import "ORPQResult.h"
 #import "RunTypeWordBits.hh"
-#import "TUBiiModel.hh"
+#import "TUBiiModel.h"
 
 #define RUNNING 0
 #define STARTING 1
@@ -1297,13 +1297,13 @@ static NSComparisonResult compareXL3s(ORXL3Model *xl3_1, ORXL3Model *xl3_2, void
         return;
     }
 
-    if (sync_mask != 0 || async_mask != 0) {
+    if (sync_trigger_mask != 0 || async_trigger_mask != 0) {
         NSLogColor([NSColor redColor],
                    @"pingCratesAtRunStart: tubii already has triggers enabled.\n");
     }
 
     @try {
-        [tubii setTriggerMask:0x10000 setAsyncMask:0];
+        [tubii setTrigMask:0x10000 setAsyncMask:0];
         [tubii setMTCAMimic1_ThresholdInBits:0];
     } @catch (NSException *e) {
         NSLogColor([NSColor redColor],
@@ -1399,7 +1399,7 @@ static NSComparisonResult compareXL3s(ORXL3Model *xl3_1, ORXL3Model *xl3_2, void
 
     /* Reset tubii's trigger masks and DAC value. */
     @try {
-        [tubii setTriggerMask:0 setAsyncMask:0];
+        [tubii setTrigMask:0 setAsyncMask:0];
         [tubii setMTCAMimic1_ThresholdInBits:tubii_dac];
     } @catch (NSException *e) {
         NSLogColor([NSColor redColor],

--- a/Source/Experiments/SNOP/SNOPModel.m
+++ b/Source/Experiments/SNOP/SNOPModel.m
@@ -1177,175 +1177,177 @@ static NSComparisonResult compareXL3s(ORXL3Model *xl3_1, ORXL3Model *xl3_2, void
     uint32_t crate_pedestal_mask, coarse_delay, fine_delay, pedestal_width;
     float pulser_rate;
 
-    NSArray* xl3s = [[(ORAppDelegate*)[NSApp delegate] document]
-         collectObjectsOfClass:NSClassFromString(@"ORXL3Model")];
-    NSArray* mtcs = [[(ORAppDelegate*)[NSApp delegate] document]
-         collectObjectsOfClass:NSClassFromString(@"ORMTCModel")];
+    @autoreleasepool {
+        NSArray* xl3s = [[(ORAppDelegate*)[NSApp delegate] document]
+             collectObjectsOfClass:NSClassFromString(@"ORXL3Model")];
+        NSArray* mtcs = [[(ORAppDelegate*)[NSApp delegate] document]
+             collectObjectsOfClass:NSClassFromString(@"ORMTCModel")];
 
-    xl3s = [xl3s sortedArrayUsingFunction:compareXL3s context:nil];
+        xl3s = [xl3s sortedArrayUsingFunction:compareXL3s context:nil];
 
-    ORMTCModel* mtc;
-    ORXL3Model* xl3;
+        ORMTCModel* mtc;
+        ORXL3Model* xl3;
 
-    if ([mtcs count] == 0) {
-        NSLogColor([NSColor redColor], @"pingCrates: couldn't find MTC object.\n");
-        return;
-    }
+        if ([mtcs count] == 0) {
+            NSLogColor([NSColor redColor], @"pingCrates: couldn't find MTC object.\n");
+            return;
+        }
 
-    mtc = [mtcs objectAtIndex:0];
+        mtc = [mtcs objectAtIndex:0];
 
-    crate_pedestal_mask = [mtc pedCrateMask];
-    coarse_delay = [mtc coarseDelay];
-    fine_delay = [mtc fineDelay];
-    pedestal_width = [mtc pedestalWidth];
+        crate_pedestal_mask = [mtc pedCrateMask];
+        coarse_delay = [mtc coarseDelay];
+        fine_delay = [mtc fineDelay];
+        pedestal_width = [mtc pedestalWidth];
 
-    pulser_rate = [mtc pgtRate];
+        pulser_rate = [mtc pgtRate];
 
-    /* Set the coarse delay. */
-    [mtc setCoarseDelay:250];
-    @try {
-        [mtc loadCoarseDelayToHardware];
-    } @catch (NSException *e) {
-        NSLogColor([NSColor redColor],
-                   @"error setting the MTCD coarse delay. error: "
-                    "%@ reason: %@\n", [e name], [e reason]);
-        return;
-    }
+        /* Set the coarse delay. */
+        [mtc setCoarseDelay:250];
+        @try {
+            [mtc loadCoarseDelayToHardware];
+        } @catch (NSException *e) {
+            NSLogColor([NSColor redColor],
+                       @"error setting the MTCD coarse delay. error: "
+                        "%@ reason: %@\n", [e name], [e reason]);
+            return;
+        }
 
-    /* Set the fine delay. */
-    [mtc setFineDelay:0];
-    @try {
-        [mtc loadFineDelayToHardware];
-    } @catch (NSException *e) {
-        NSLogColor([NSColor redColor],
-                   @"error setting the MTCD fine delay. error: "
-                    "%@ reason: %@\n", [e name], [e reason]);
-        return;
-    }
+        /* Set the fine delay. */
+        [mtc setFineDelay:0];
+        @try {
+            [mtc loadFineDelayToHardware];
+        } @catch (NSException *e) {
+            NSLogColor([NSColor redColor],
+                       @"error setting the MTCD fine delay. error: "
+                        "%@ reason: %@\n", [e name], [e reason]);
+            return;
+        }
 
-    /* Reset the pedestal width. */
-    [mtc setPedestalWidth:50];
-    @try {
-        [mtc loadPedWidthToHardware];
-    } @catch (NSException *e) {
-        NSLogColor([NSColor redColor],
-                   @"error setting the MTCD pedestal width. error: "
-                    "%@ reason: %@\n", [e name], [e reason]);
-        return;
-    }
+        /* Reset the pedestal width. */
+        [mtc setPedestalWidth:50];
+        @try {
+            [mtc loadPedWidthToHardware];
+        } @catch (NSException *e) {
+            NSLogColor([NSColor redColor],
+                       @"error setting the MTCD pedestal width. error: "
+                        "%@ reason: %@\n", [e name], [e reason]);
+            return;
+        }
 
-    /* Enable all pedestals for each crate, and then fire a single pedestal
-     * pulse. */
-    for (i = 0; i < [xl3s count]; i++) {
-        xl3 = [xl3s objectAtIndex:i];
+        /* Enable all pedestals for each crate, and then fire a single pedestal
+         * pulse. */
+        for (i = 0; i < [xl3s count]; i++) {
+            xl3 = [xl3s objectAtIndex:i];
 
-        /* Enable all crates in the MTCD pedestal mask. */
-        [mtc setPedCrateMask:1 << [xl3 crateNumber]];
+            /* Enable all crates in the MTCD pedestal mask. */
+            [mtc setPedCrateMask:1 << [xl3 crateNumber]];
 
+            @try {
+                [mtc loadPedestalCrateMaskToHardware];
+            } @catch (NSException *e) {
+                NSLogColor([NSColor redColor],
+                           @"error setting the MTCD crate pedestal mask. error: "
+                            "%@ reason: %@\n", [e name], [e reason]);
+                continue;
+            }
+
+            if (![[xl3 xl3Link] isConnected]) continue;
+
+            for (j = 0; j < 16; j++) {
+                if (!([xl3 getSlotsPresent] & (1 << j))) continue;
+
+                if ([xl3 setPedestalMask:(1 << j) pattern:0xffffffff]) {
+                    NSLogColor([NSColor redColor],
+                               @"failed to set pedestal mask for crate %02d slot %02d\n", i, j);
+                    continue;
+                }
+
+                /* The crate and slot are encoded in the step number or
+                 * half_crate_id field. For example, to unpack the crate and
+                 * slot:
+                 *
+                 *     crate = (eped_record.half_crate_id >> 4) & 0xff;
+                 *     slot = eped_record.half_crate_id & 0xf;
+                 */
+                [self shipEPEDStructWithCoarseDelay: [mtc coarseDelay]
+                                          fineDelay: [mtc fineDelay]
+                                     chargePulseAmp: 0
+                                      pedestalWidth: [mtc pedestalWidth]
+                                            calType: 5
+                                         stepNumber: ((i << 4) | j)];
+
+                @try {
+                    [mtc firePedestals:1 withRate:1];
+                } @catch (NSException *e) {
+                    NSLogColor([NSColor redColor],
+                               @"failed to fire pedestal. error: %@ reason: %@\n",
+                               [e name], [e reason]);
+                }
+            }
+
+            NSLog(@"PING crate %02d\n", i);
+        }
+
+        /* Set the pedestal mask for each crate back. */
+        for (i = 0; i < [xl3s count]; i++) {
+            xl3 = [xl3s objectAtIndex:i];
+
+            if ([[xl3 xl3Link] isConnected]) {
+                [xl3 setPedestals];
+            }
+        }
+
+        /* Reset the crate pedestal all crates in the MTCD pedestal mask. */
+        [mtc setPedCrateMask:crate_pedestal_mask];
         @try {
             [mtc loadPedestalCrateMaskToHardware];
         } @catch (NSException *e) {
             NSLogColor([NSColor redColor],
                        @"error setting the MTCD crate pedestal mask. error: "
                         "%@ reason: %@\n", [e name], [e reason]);
-            continue;
         }
 
-        if (![[xl3 xl3Link] isConnected]) continue;
-
-        for (j = 0; j < 16; j++) {
-            if (!([xl3 getSlotsPresent] & (1 << j))) continue;
-
-            if ([xl3 setPedestalMask:(1 << j) pattern:0xffffffff]) {
-                NSLogColor([NSColor redColor],
-                           @"failed to set pedestal mask for crate %02d slot %02d\n", i, j);
-                continue;
-            }
-
-            /* The crate and slot are encoded in the step number or
-             * half_crate_id field. For example, to unpack the crate and
-             * slot:
-             *
-             *     crate = (eped_record.half_crate_id >> 4) & 0xff;
-             *     slot = eped_record.half_crate_id & 0xf;
-             */
-            [self shipEPEDStructWithCoarseDelay: [mtc coarseDelay]
-                                      fineDelay: [mtc fineDelay]
-                                 chargePulseAmp: 0
-                                  pedestalWidth: [mtc pedestalWidth]
-                                        calType: 5
-                                     stepNumber: ((i << 4) | j)];
-
-            @try {
-                [mtc firePedestals:1 withRate:1];
-            } @catch (NSException *e) {
-                NSLogColor([NSColor redColor],
-                           @"failed to fire pedestal. error: %@ reason: %@\n",
-                           [e name], [e reason]);
-            }
+        /* Reset the coarse delay. */
+        [mtc setCoarseDelay:coarse_delay];
+        @try {
+            [mtc loadCoarseDelayToHardware];
+        } @catch (NSException *e) {
+            NSLogColor([NSColor redColor],
+                       @"error setting the MTCD coarse delay. error: "
+                        "%@ reason: %@\n", [e name], [e reason]);
         }
 
-        NSLog(@"PING crate %02d\n", i);
-    }
-
-    /* Set the pedestal mask for each crate back. */
-    for (i = 0; i < [xl3s count]; i++) {
-        xl3 = [xl3s objectAtIndex:i];
-
-        if ([[xl3 xl3Link] isConnected]) {
-            [xl3 setPedestals];
+        /* Reset the fine delay. */
+        [mtc setFineDelay:fine_delay];
+        @try {
+            [mtc loadFineDelayToHardware];
+        } @catch (NSException *e) {
+            NSLogColor([NSColor redColor],
+                       @"error setting the MTCD fine delay. error: "
+                        "%@ reason: %@\n", [e name], [e reason]);
         }
-    }
 
-    /* Reset the crate pedestal all crates in the MTCD pedestal mask. */
-    [mtc setPedCrateMask:crate_pedestal_mask];
-    @try {
-        [mtc loadPedestalCrateMaskToHardware];
-    } @catch (NSException *e) {
-        NSLogColor([NSColor redColor],
-                   @"error setting the MTCD crate pedestal mask. error: "
-                    "%@ reason: %@\n", [e name], [e reason]);
-    }
+        /* Reset the pedestal width. */
+        [mtc setPedestalWidth:pedestal_width];
+        @try {
+            [mtc loadPedWidthToHardware];
+        } @catch (NSException *e) {
+            NSLogColor([NSColor redColor],
+                       @"error setting the MTCD pedestal width. error: "
+                        "%@ reason: %@\n", [e name], [e reason]);
+        }
 
-    /* Reset the coarse delay. */
-    [mtc setCoarseDelay:coarse_delay];
-    @try {
-        [mtc loadCoarseDelayToHardware];
-    } @catch (NSException *e) {
-        NSLogColor([NSColor redColor],
-                   @"error setting the MTCD coarse delay. error: "
-                    "%@ reason: %@\n", [e name], [e reason]);
-    }
-
-    /* Reset the fine delay. */
-    [mtc setFineDelay:fine_delay];
-    @try {
-        [mtc loadFineDelayToHardware];
-    } @catch (NSException *e) {
-        NSLogColor([NSColor redColor],
-                   @"error setting the MTCD fine delay. error: "
-                    "%@ reason: %@\n", [e name], [e reason]);
-    }
-
-    /* Reset the pedestal width. */
-    [mtc setPedestalWidth:pedestal_width];
-    @try {
-        [mtc loadPedWidthToHardware];
-    } @catch (NSException *e) {
-        NSLogColor([NSColor redColor],
-                   @"error setting the MTCD pedestal width. error: "
-                    "%@ reason: %@\n", [e name], [e reason]);
-    }
-
-    /* Reset the pulser rate since the firePedestals function sets the pulser
-     * rate to 0. */
-    @try {
-        [mtc setPgtRate:pulser_rate];
-        [mtc loadPulserRateToHardware];
-    } @catch (NSException *e) {
-        NSLogColor([NSColor redColor],
-                   @"error setting the pulser rate. error: "
-                    "%@ reason: %@\n", [e name], [e reason]);
+        /* Reset the pulser rate since the firePedestals function sets the pulser
+         * rate to 0. */
+        @try {
+            [mtc setPgtRate:pulser_rate];
+            [mtc loadPulserRateToHardware];
+        } @catch (NSException *e) {
+            NSLogColor([NSColor redColor],
+                       @"error setting the pulser rate. error: "
+                        "%@ reason: %@\n", [e name], [e reason]);
+        }
     }
 }
 

--- a/Source/Experiments/SNOP/SNOPModel.m
+++ b/Source/Experiments/SNOP/SNOPModel.m
@@ -1216,7 +1216,8 @@ static NSComparisonResult compareXL3s(ORXL3Model *xl3_1, ORXL3Model *xl3_2, void
     ORXL3Model* xl3;
 
     if ([mtcs count] == 0) {
-        NSLogColor([NSColor redColor], @"pingCrates: couldn't find MTC object.\n");
+        NSLogColor([NSColor redColor],
+                   @"pingCrates: couldn't find MTC object.\n");
         return;
     }
 
@@ -1296,9 +1297,10 @@ static NSComparisonResult compareXL3s(ORXL3Model *xl3_1, ORXL3Model *xl3_2, void
                 }
             }
 
-            if ([xl3 multiSetPedestalMask:[xl3 getSlotsPresent] patterns:channelMasks]) {
-                NSLogColor([NSColor redColor],
-                           @"failed to set pedestal mask for crate %02d slot %02d\n", i, j);
+            if ([xl3 multiSetPedestalMask:[xl3 getSlotsPresent]
+                     patterns:channelMasks]) {
+                NSLogColor([NSColor redColor], @"failed to set pedestal mask "
+                            "for crate %02d slot %02d\n", i, j);
                 continue;
             }
 

--- a/Source/Experiments/SNOP/SNOPModel.m
+++ b/Source/Experiments/SNOP/SNOPModel.m
@@ -2305,8 +2305,6 @@ static NSComparisonResult compareXL3s(ORXL3Model *xl3_1, ORXL3Model *xl3_2, void
 
 - (void)hvMasterTriggersOFF
 {
-    [[[(ORAppDelegate*)[NSApp delegate] document] collectObjectsOfClass:NSClassFromString(@"ORXL3Model")] makeObjectsPerformSelector:@selector(setIsPollingXl3:) withObject:NO];
-
     [[[(ORAppDelegate*)[NSApp delegate] document] collectObjectsOfClass:NSClassFromString(@"ORXL3Model")] makeObjectsPerformSelector:@selector(hvTriggersOFF)];
 }
 

--- a/Source/Experiments/SNOP/SNOPModel.m
+++ b/Source/Experiments/SNOP/SNOPModel.m
@@ -288,6 +288,8 @@ tellieRunFiles = _tellieRunFiles;
 
     nhitMonitor = [[NHitMonitor alloc] init];
 
+    ecaLock = [[NSLock alloc] init];
+
     [[self undoManager] disableUndoRegistration];
     [self initOrcaDBConnectionHistory];
     [self initDebugDBConnectionHistory];
@@ -427,6 +429,7 @@ tellieRunFiles = _tellieRunFiles;
     [logHost release];
     [anECARun release];
     [nhitMonitor release];
+    [ecaLock release];
     [_smellieRunFiles release];
     [_tellieRunFiles release];
     [_tellieRunNameLabel release];
@@ -1293,7 +1296,7 @@ static NSComparisonResult compareXL3s(ORXL3Model *xl3_1, ORXL3Model *xl3_2, void
                 }
             }
 
-            if ([xl3 multiSetPedestalMask:0xffff patterns:channelMasks]) {
+            if ([xl3 multiSetPedestalMask:[xl3 getSlotsPresent] patterns:channelMasks]) {
                 NSLogColor([NSColor redColor],
                            @"failed to set pedestal mask for crate %02d slot %02d\n", i, j);
                 continue;

--- a/Source/Experiments/SNOP/SNOPModel.m
+++ b/Source/Experiments/SNOP/SNOPModel.m
@@ -1226,7 +1226,7 @@ static NSComparisonResult compareXL3s(ORXL3Model *xl3_1, ORXL3Model *xl3_2, void
     /* Reset the pedestal width. */
     [mtc setPedestalWidth:50];
     @try {
-        [mtc loadPedestalWidthToHardware];
+        [mtc loadPedWidthToHardware];
     } @catch (NSException *e) {
         NSLogColor([NSColor redColor],
                    @"error setting the MTCD pedestal width. error: "
@@ -1330,7 +1330,7 @@ static NSComparisonResult compareXL3s(ORXL3Model *xl3_1, ORXL3Model *xl3_2, void
     /* Reset the pedestal width. */
     [mtc setPedestalWidth:pedestal_width];
     @try {
-        [mtc loadPedestalWidthToHardware];
+        [mtc loadPedWidthToHardware];
     } @catch (NSException *e) {
         NSLogColor([NSColor redColor],
                    @"error setting the MTCD pedestal width. error: "

--- a/Source/Experiments/SNOP/SNOPModel.m
+++ b/Source/Experiments/SNOP/SNOPModel.m
@@ -1273,7 +1273,7 @@ static NSComparisonResult compareXL3s(ORXL3Model *xl3_1, ORXL3Model *xl3_2, void
                                       fineDelay: [mtc fineDelay]
                                  chargePulseAmp: 0
                                   pedestalWidth: [mtc pedestalWidth]
-                                        calType: 0
+                                        calType: 5
                                      stepNumber: ((i << 4) | j)];
 
             @try {

--- a/Source/Experiments/SNOP/SNOPModel.m
+++ b/Source/Experiments/SNOP/SNOPModel.m
@@ -1160,14 +1160,38 @@ static NSComparisonResult compareXL3s(ORXL3Model *xl3_1, ORXL3Model *xl3_2, void
     }
 }
 
+- (NSLock *) ecaLock
+{
+    return ecaLock;
+}
+
 - (void) pingCratesAtRunStart
 {
     [NSThread detachNewThreadSelector:@selector(_pingCratesAtRunStart)
                              toTarget:self
                            withObject:nil];
 }
-    
+
 - (void) _pingCratesAtRunStart
+{
+    @autoreleasepool {
+        /* Try to acquire the lock for 10 seconds. If we can't get it then we
+         * just skip the ping crates. */
+        if ([ecaLock lockBeforeDate:[NSDate dateWithTimeIntervalSinceNow:10.0]]) {
+            @try {
+                [self __pingCratesAtRunStart];
+            } @finally {
+                /* Make sure to unlock the lock when we're done. */
+                [ecaLock unlock];
+            }
+        } else {
+            NSLogColor([NSColor redColor],
+                       @"pingCratesAtRunStart: unable to acquire eca lock!\n");
+        }
+    }
+}
+
+- (void) __pingCratesAtRunStart
 {
     /* Fire pedestals on each slot in the detector. This function is called at
      * the start of physics runs. A nearline job will eventually look at these
@@ -1177,177 +1201,175 @@ static NSComparisonResult compareXL3s(ORXL3Model *xl3_1, ORXL3Model *xl3_2, void
     uint32_t crate_pedestal_mask, coarse_delay, fine_delay, pedestal_width;
     float pulser_rate;
 
-    @autoreleasepool {
-        NSArray* xl3s = [[(ORAppDelegate*)[NSApp delegate] document]
-             collectObjectsOfClass:NSClassFromString(@"ORXL3Model")];
-        NSArray* mtcs = [[(ORAppDelegate*)[NSApp delegate] document]
-             collectObjectsOfClass:NSClassFromString(@"ORMTCModel")];
+    NSArray* xl3s = [[(ORAppDelegate*)[NSApp delegate] document]
+         collectObjectsOfClass:NSClassFromString(@"ORXL3Model")];
+    NSArray* mtcs = [[(ORAppDelegate*)[NSApp delegate] document]
+         collectObjectsOfClass:NSClassFromString(@"ORMTCModel")];
 
-        xl3s = [xl3s sortedArrayUsingFunction:compareXL3s context:nil];
+    xl3s = [xl3s sortedArrayUsingFunction:compareXL3s context:nil];
 
-        ORMTCModel* mtc;
-        ORXL3Model* xl3;
+    ORMTCModel* mtc;
+    ORXL3Model* xl3;
 
-        if ([mtcs count] == 0) {
-            NSLogColor([NSColor redColor], @"pingCrates: couldn't find MTC object.\n");
-            return;
-        }
+    if ([mtcs count] == 0) {
+        NSLogColor([NSColor redColor], @"pingCrates: couldn't find MTC object.\n");
+        return;
+    }
 
-        mtc = [mtcs objectAtIndex:0];
+    mtc = [mtcs objectAtIndex:0];
 
-        crate_pedestal_mask = [mtc pedCrateMask];
-        coarse_delay = [mtc coarseDelay];
-        fine_delay = [mtc fineDelay];
-        pedestal_width = [mtc pedestalWidth];
+    crate_pedestal_mask = [mtc pedCrateMask];
+    coarse_delay = [mtc coarseDelay];
+    fine_delay = [mtc fineDelay];
+    pedestal_width = [mtc pedestalWidth];
 
-        pulser_rate = [mtc pgtRate];
+    pulser_rate = [mtc pgtRate];
 
-        /* Set the coarse delay. */
-        [mtc setCoarseDelay:250];
-        @try {
-            [mtc loadCoarseDelayToHardware];
-        } @catch (NSException *e) {
-            NSLogColor([NSColor redColor],
-                       @"error setting the MTCD coarse delay. error: "
-                        "%@ reason: %@\n", [e name], [e reason]);
-            return;
-        }
+    /* Set the coarse delay. */
+    [mtc setCoarseDelay:250];
+    @try {
+        [mtc loadCoarseDelayToHardware];
+    } @catch (NSException *e) {
+        NSLogColor([NSColor redColor],
+                   @"error setting the MTCD coarse delay. error: "
+                    "%@ reason: %@\n", [e name], [e reason]);
+        return;
+    }
 
-        /* Set the fine delay. */
-        [mtc setFineDelay:0];
-        @try {
-            [mtc loadFineDelayToHardware];
-        } @catch (NSException *e) {
-            NSLogColor([NSColor redColor],
-                       @"error setting the MTCD fine delay. error: "
-                        "%@ reason: %@\n", [e name], [e reason]);
-            return;
-        }
+    /* Set the fine delay. */
+    [mtc setFineDelay:0];
+    @try {
+        [mtc loadFineDelayToHardware];
+    } @catch (NSException *e) {
+        NSLogColor([NSColor redColor],
+                   @"error setting the MTCD fine delay. error: "
+                    "%@ reason: %@\n", [e name], [e reason]);
+        return;
+    }
 
-        /* Reset the pedestal width. */
-        [mtc setPedestalWidth:50];
-        @try {
-            [mtc loadPedWidthToHardware];
-        } @catch (NSException *e) {
-            NSLogColor([NSColor redColor],
-                       @"error setting the MTCD pedestal width. error: "
-                        "%@ reason: %@\n", [e name], [e reason]);
-            return;
-        }
+    /* Reset the pedestal width. */
+    [mtc setPedestalWidth:50];
+    @try {
+        [mtc loadPedWidthToHardware];
+    } @catch (NSException *e) {
+        NSLogColor([NSColor redColor],
+                   @"error setting the MTCD pedestal width. error: "
+                    "%@ reason: %@\n", [e name], [e reason]);
+        return;
+    }
 
-        /* Enable all pedestals for each crate, and then fire a single pedestal
-         * pulse. */
-        for (i = 0; i < [xl3s count]; i++) {
-            xl3 = [xl3s objectAtIndex:i];
+    /* Enable all pedestals for each crate, and then fire a single pedestal
+     * pulse. */
+    for (i = 0; i < [xl3s count]; i++) {
+        xl3 = [xl3s objectAtIndex:i];
 
-            /* Enable all crates in the MTCD pedestal mask. */
-            [mtc setPedCrateMask:1 << [xl3 crateNumber]];
+        /* Enable all crates in the MTCD pedestal mask. */
+        [mtc setPedCrateMask:1 << [xl3 crateNumber]];
 
-            @try {
-                [mtc loadPedestalCrateMaskToHardware];
-            } @catch (NSException *e) {
-                NSLogColor([NSColor redColor],
-                           @"error setting the MTCD crate pedestal mask. error: "
-                            "%@ reason: %@\n", [e name], [e reason]);
-                continue;
-            }
-
-            if (![[xl3 xl3Link] isConnected]) continue;
-
-            for (j = 0; j < 16; j++) {
-                if (!([xl3 getSlotsPresent] & (1 << j))) continue;
-
-                if ([xl3 setPedestalMask:(1 << j) pattern:0xffffffff]) {
-                    NSLogColor([NSColor redColor],
-                               @"failed to set pedestal mask for crate %02d slot %02d\n", i, j);
-                    continue;
-                }
-
-                /* The crate and slot are encoded in the step number or
-                 * half_crate_id field. For example, to unpack the crate and
-                 * slot:
-                 *
-                 *     crate = (eped_record.half_crate_id >> 4) & 0xff;
-                 *     slot = eped_record.half_crate_id & 0xf;
-                 */
-                [self shipEPEDStructWithCoarseDelay: [mtc coarseDelay]
-                                          fineDelay: [mtc fineDelay]
-                                     chargePulseAmp: 0
-                                      pedestalWidth: [mtc pedestalWidth]
-                                            calType: 50
-                                         stepNumber: ((i << 4) | j)];
-
-                @try {
-                    [mtc firePedestals:1 withRate:1];
-                } @catch (NSException *e) {
-                    NSLogColor([NSColor redColor],
-                               @"failed to fire pedestal. error: %@ reason: %@\n",
-                               [e name], [e reason]);
-                }
-            }
-
-            NSLog(@"PING crate %02d\n", i);
-        }
-
-        /* Set the pedestal mask for each crate back. */
-        for (i = 0; i < [xl3s count]; i++) {
-            xl3 = [xl3s objectAtIndex:i];
-
-            if ([[xl3 xl3Link] isConnected]) {
-                [xl3 setPedestals];
-            }
-        }
-
-        /* Reset the crate pedestal all crates in the MTCD pedestal mask. */
-        [mtc setPedCrateMask:crate_pedestal_mask];
         @try {
             [mtc loadPedestalCrateMaskToHardware];
         } @catch (NSException *e) {
             NSLogColor([NSColor redColor],
                        @"error setting the MTCD crate pedestal mask. error: "
                         "%@ reason: %@\n", [e name], [e reason]);
+            continue;
         }
 
-        /* Reset the coarse delay. */
-        [mtc setCoarseDelay:coarse_delay];
-        @try {
-            [mtc loadCoarseDelayToHardware];
-        } @catch (NSException *e) {
-            NSLogColor([NSColor redColor],
-                       @"error setting the MTCD coarse delay. error: "
-                        "%@ reason: %@\n", [e name], [e reason]);
+        if (![[xl3 xl3Link] isConnected]) continue;
+
+        for (j = 0; j < 16; j++) {
+            if (!([xl3 getSlotsPresent] & (1 << j))) continue;
+
+            if ([xl3 setPedestalMask:(1 << j) pattern:0xffffffff]) {
+                NSLogColor([NSColor redColor],
+                           @"failed to set pedestal mask for crate %02d slot %02d\n", i, j);
+                continue;
+            }
+
+            /* The crate and slot are encoded in the step number or
+             * half_crate_id field. For example, to unpack the crate and
+             * slot:
+             *
+             *     crate = (eped_record.half_crate_id >> 4) & 0xff;
+             *     slot = eped_record.half_crate_id & 0xf;
+             */
+            [self shipEPEDStructWithCoarseDelay: [mtc coarseDelay]
+                                      fineDelay: [mtc fineDelay]
+                                 chargePulseAmp: 0
+                                  pedestalWidth: [mtc pedestalWidth]
+                                        calType: 50
+                                     stepNumber: ((i << 4) | j)];
+
+            @try {
+                [mtc firePedestals:1 withRate:1];
+            } @catch (NSException *e) {
+                NSLogColor([NSColor redColor],
+                           @"failed to fire pedestal. error: %@ reason: %@\n",
+                           [e name], [e reason]);
+            }
         }
 
-        /* Reset the fine delay. */
-        [mtc setFineDelay:fine_delay];
-        @try {
-            [mtc loadFineDelayToHardware];
-        } @catch (NSException *e) {
-            NSLogColor([NSColor redColor],
-                       @"error setting the MTCD fine delay. error: "
-                        "%@ reason: %@\n", [e name], [e reason]);
-        }
+        NSLog(@"PING crate %02d\n", i);
+    }
 
-        /* Reset the pedestal width. */
-        [mtc setPedestalWidth:pedestal_width];
-        @try {
-            [mtc loadPedWidthToHardware];
-        } @catch (NSException *e) {
-            NSLogColor([NSColor redColor],
-                       @"error setting the MTCD pedestal width. error: "
-                        "%@ reason: %@\n", [e name], [e reason]);
-        }
+    /* Set the pedestal mask for each crate back. */
+    for (i = 0; i < [xl3s count]; i++) {
+        xl3 = [xl3s objectAtIndex:i];
 
-        /* Reset the pulser rate since the firePedestals function sets the pulser
-         * rate to 0. */
-        @try {
-            [mtc setPgtRate:pulser_rate];
-            [mtc loadPulserRateToHardware];
-        } @catch (NSException *e) {
-            NSLogColor([NSColor redColor],
-                       @"error setting the pulser rate. error: "
-                        "%@ reason: %@\n", [e name], [e reason]);
+        if ([[xl3 xl3Link] isConnected]) {
+            [xl3 setPedestals];
         }
+    }
+
+    /* Reset the crate pedestal all crates in the MTCD pedestal mask. */
+    [mtc setPedCrateMask:crate_pedestal_mask];
+    @try {
+        [mtc loadPedestalCrateMaskToHardware];
+    } @catch (NSException *e) {
+        NSLogColor([NSColor redColor],
+                   @"error setting the MTCD crate pedestal mask. error: "
+                    "%@ reason: %@\n", [e name], [e reason]);
+    }
+
+    /* Reset the coarse delay. */
+    [mtc setCoarseDelay:coarse_delay];
+    @try {
+        [mtc loadCoarseDelayToHardware];
+    } @catch (NSException *e) {
+        NSLogColor([NSColor redColor],
+                   @"error setting the MTCD coarse delay. error: "
+                    "%@ reason: %@\n", [e name], [e reason]);
+    }
+
+    /* Reset the fine delay. */
+    [mtc setFineDelay:fine_delay];
+    @try {
+        [mtc loadFineDelayToHardware];
+    } @catch (NSException *e) {
+        NSLogColor([NSColor redColor],
+                   @"error setting the MTCD fine delay. error: "
+                    "%@ reason: %@\n", [e name], [e reason]);
+    }
+
+    /* Reset the pedestal width. */
+    [mtc setPedestalWidth:pedestal_width];
+    @try {
+        [mtc loadPedWidthToHardware];
+    } @catch (NSException *e) {
+        NSLogColor([NSColor redColor],
+                   @"error setting the MTCD pedestal width. error: "
+                    "%@ reason: %@\n", [e name], [e reason]);
+    }
+
+    /* Reset the pulser rate since the firePedestals function sets the pulser
+     * rate to 0. */
+    @try {
+        [mtc setPgtRate:pulser_rate];
+        [mtc loadPulserRateToHardware];
+    } @catch (NSException *e) {
+        NSLogColor([NSColor redColor],
+                   @"error setting the pulser rate. error: "
+                    "%@ reason: %@\n", [e name], [e reason]);
     }
 }
 

--- a/Source/Objects/Custom Hardware/SNO+/MTC/ORMTCModel.m
+++ b/Source/Objects/Custom Hardware/SNO+/MTC/ORMTCModel.m
@@ -220,6 +220,10 @@ tubRegister;
 
         [self loadCoarseDelayToHardware];
         [self loadFineDelayToHardware];
+        /* Temporary hack to make sure we don't run with a lockout width of
+         * 5100 after a power cycle. Eventually, the lockout width should be in
+         * the standard run definition. */
+        [self setLockoutWidth:420];
         [self loadLockOutWidthToHardware];
         [self loadPedWidthToHardware];
         [self loadPulserRateToHardware];

--- a/Source/Objects/Custom Hardware/SNO+/MTC/ORMTCModel.m
+++ b/Source/Objects/Custom Hardware/SNO+/MTC/ORMTCModel.m
@@ -673,8 +673,12 @@ tubRegister;
 
 - (void) setGtMask:(uint32_t)_mask
 {
-    gtMask = _mask;
-    [[NSNotificationCenter defaultCenter] postNotificationName:ORMTCGTMaskChanged object:self];
+    @synchronized(self) {
+        if (gtMask != _mask) {
+            gtMask = _mask;
+            [[NSNotificationCenter defaultCenter] postNotificationOnMainThreadWithName:ORMTCGTMaskChanged object:self];
+        }
+    }
 }
 
 - (uint32_t) gtMask
@@ -684,8 +688,12 @@ tubRegister;
 
 - (void) setPgtRate:(float)rate
 {
-    pgtRate = rate;
-    [[NSNotificationCenter defaultCenter] postNotificationName:ORMTCPulserRateChanged object:self];
+    @synchronized(self) {
+        if (pgtRate != rate) {
+            pgtRate = rate;
+            [[NSNotificationCenter defaultCenter] postNotificationOnMainThreadWithName:ORMTCPulserRateChanged object:self];
+        }
+    }
 }
 
 - (float) pgtRate
@@ -700,9 +708,11 @@ tubRegister;
 
 - (void) setCoarseDelay:(int) delay
 {
-    if (coarseDelay != delay) {
-        coarseDelay = delay;
-        [[NSNotificationCenter defaultCenter] postNotificationName:ORMTCSettingsChanged object:self];
+    @synchronized(self) {
+        if (coarseDelay != delay) {
+            coarseDelay = delay;
+            [[NSNotificationCenter defaultCenter] postNotificationOnMainThreadWithName:ORMTCSettingsChanged object:self];
+        }
     }
 }
 
@@ -713,16 +723,22 @@ tubRegister;
 
 - (void) setFineDelay:(int)delay
 {
-    if (fineDelay != delay) {
-        fineDelay = delay;
-        [[NSNotificationCenter defaultCenter] postNotificationName:ORMTCSettingsChanged object:self];
+    @synchronized(self) {
+        if (fineDelay != delay) {
+            fineDelay = delay;
+            [[NSNotificationCenter defaultCenter] postNotificationOnMainThreadWithName:ORMTCSettingsChanged object:self];
+        }
     }
 }
 
 - (void) setPrescaleValue:(uint16_t)newVal
 {
-    prescaleValue = newVal;
-    [[NSNotificationCenter defaultCenter] postNotificationName:ORMTCSettingsChanged object:self];
+    @synchronized(self) {
+        if (prescaleValue != newVal) {
+            prescaleValue = newVal;
+            [[NSNotificationCenter defaultCenter] postNotificationOnMainThreadWithName:ORMTCSettingsChanged object:self];
+        }
+    }
 }
 
 - (uint16_t) prescaleValue
@@ -844,9 +860,11 @@ tubRegister;
 
 - (void) setLockoutWidth:(uint16_t)width
 {
-    if (lockoutWidth != width) {
-        lockoutWidth = width;
-        [[NSNotificationCenter defaultCenter] postNotificationName:ORMTCSettingsChanged object:self];
+    @synchronized(self) {
+        if (lockoutWidth != width) {
+            lockoutWidth = width;
+            [[NSNotificationCenter defaultCenter] postNotificationOnMainThreadWithName:ORMTCSettingsChanged object:self];
+        }
     }
 }
 
@@ -857,9 +875,11 @@ tubRegister;
 
 - (void) setPedestalWidth:(uint16_t) width
 {
-    if (pedestalWidth != width) {
-        pedestalWidth = width;
-        [[NSNotificationCenter defaultCenter] postNotificationName:ORMTCSettingsChanged object:self];
+    @synchronized(self) {
+        if (pedestalWidth != width) {
+            pedestalWidth = width;
+            [[NSNotificationCenter defaultCenter] postNotificationOnMainThreadWithName:ORMTCSettingsChanged object:self];
+        }
     }
 }
 
@@ -870,9 +890,11 @@ tubRegister;
 
 - (void) setGTCrateMask:(uint32_t)mask
 {
-    if (GTCrateMask != mask) {
-        GTCrateMask = mask;
-        [[NSNotificationCenter defaultCenter] postNotificationName:ORMTCSettingsChanged object:self];
+    @synchronized(self) {
+        if (GTCrateMask != mask) {
+            GTCrateMask = mask;
+            [[NSNotificationCenter defaultCenter] postNotificationOnMainThreadWithName:ORMTCSettingsChanged object:self];
+        }
     }
 }
 
@@ -883,9 +905,11 @@ tubRegister;
 
 - (void) setPedCrateMask:(uint32_t)mask
 {
-    if (pedCrateMask != mask) {
-        pedCrateMask = mask;
-        [[NSNotificationCenter defaultCenter] postNotificationName:ORMTCSettingsChanged object:self];
+    @synchronized(self) {
+        if (pedCrateMask != mask) {
+            pedCrateMask = mask;
+            [[NSNotificationCenter defaultCenter] postNotificationOnMainThreadWithName:ORMTCSettingsChanged object:self];
+        }
     }
 }
 

--- a/Source/Objects/Custom Hardware/SNO+/RedisClient/RedisClient.h
+++ b/Source/Objects/Custom Hardware/SNO+/RedisClient/RedisClient.h
@@ -29,5 +29,5 @@
 - (redisReply*) vcommand: (const char*) fmt args:(va_list) args;
 - (redisReply*) command: (const char *) fmt, ...;
 - (void) okCommand: (const char *) fmt, ...;
-- (int) intCommand: (const char *) fmt, ...;
+- (long long) intCommand: (const char *) fmt, ...;
 @end

--- a/Source/Objects/Custom Hardware/SNO+/RedisClient/RedisClient.m
+++ b/Source/Objects/Custom Hardware/SNO+/RedisClient/RedisClient.m
@@ -176,7 +176,7 @@
     freeReplyObject(r);
 }
 
-- (int) intCommand: (const char *) fmt, ... 
+- (long long) intCommand: (const char *) fmt, ... 
 {
     va_list ap;
     va_start(ap,fmt);
@@ -190,7 +190,7 @@
         [excep raise];
     }
 
-    int responseVal = r->integer;
+    long long responseVal = r->integer;
     freeReplyObject(r);
     return responseVal;
 }

--- a/Source/Objects/Custom Hardware/SNO+/XL3/ORXL3Model.h
+++ b/Source/Objects/Custom Hardware/SNO+/XL3/ORXL3Model.h
@@ -407,6 +407,7 @@ enum {
 - (void) compositeXl3RW;
 - (void) compositeQuit;
 - (int) setPedestals;
+- (int) multiSetPedestalMask: (uint32_t) slotMask patterns: (uint32_t[16]) patterns;
 - (int) setPedestalMask: (uint32_t) slotMask pattern: (uint32_t) pattern;
 - (void) compositeSetPedestal;
 - (void) setPedestalInParallel;

--- a/Source/Objects/Custom Hardware/SNO+/XL3/ORXL3Model.m
+++ b/Source/Objects/Custom Hardware/SNO+/XL3/ORXL3Model.m
@@ -2982,7 +2982,7 @@ err:
     args->slotMask = htonl(slotMask);
 
     for (i = 0; i < 16; i++) {
-        args->pattern[i] = htonl(patterns[i]);
+        args->channelMasks[i] = htonl(patterns[i]);
     }
 
     @try {

--- a/Source/Objects/Custom Hardware/SNO+/XL3/ORXL3Model.m
+++ b/Source/Objects/Custom Hardware/SNO+/XL3/ORXL3Model.m
@@ -2971,12 +2971,12 @@ err:
     /* Similar to setPedestalMask except any slots not in the slot mask will
      * not have their pedestal mask changed. */
     char payload[XL3_PAYLOAD_SIZE];
-    MultiSetCratePedestalsArgs *args;
-    MultiSetCratePedestalsResults *results;
+    MultiSetCratePedsArgs *args;
+    MultiSetCratePedsResults *results;
 
     memset(&payload, 0, XL3_PAYLOAD_SIZE);
 
-    args = (MultiSetCratePedestalsArgs *) payload;
+    args = (MultiSetCratePedsArgs *) payload;
 
     args->slotMask = htonl(slotMask);
 
@@ -2985,13 +2985,13 @@ err:
     }
 
     @try {
-        [[self xl3Link] sendCommand:MULTI_SET_CRATE_PEDESTALS_ID withPayload:payload
+        [[self xl3Link] sendCommand:MULTI_SET_CRATE_PEDS_ID withPayload:payload
                         expectResponse:YES];
     } @catch (NSException *e) {
         return -1;
     }
 
-    results = (MultiSetCratePedestalsResults *) payload;
+    results = (MultiSetCratePedsResults *) payload;
 
     if (ntohl(results->errorMask)) {
         return -1;

--- a/Source/Objects/Custom Hardware/SNO+/XL3/ORXL3Model.m
+++ b/Source/Objects/Custom Hardware/SNO+/XL3/ORXL3Model.m
@@ -2970,6 +2970,7 @@ err:
 {
     /* Similar to setPedestalMask except any slots not in the slot mask will
      * not have their pedestal mask changed. */
+    int i;
     char payload[XL3_PAYLOAD_SIZE];
     MultiSetCratePedsArgs *args;
     MultiSetCratePedsResults *results;


### PR DESCRIPTION
This commit updates the SNO+ model to ping each slot in the detector once at
the start of physics run. These events will be useful to diagnose any problems
with the triggers on a run by run basis.

@tannerbk is working on a nearline job that will analyze these events to look for issues and alert the operator if there is a problem.

This hasn't been tested yet at the teststand.

One issue that needs to be figured out is how to mark these events in the data stream. Currently, I use a standard EPED record to and use the half crate id field to mark which crate and slot are being pedestalled. I think the embedded pedestals also will use this record to mark which channels are being pedestalled, so we probably need to come up with a unique flag to identify these records. In addition, we'll need to figure out some way to synchronize the embedded pedestals so that they don't start until after this finishes running.