### PR TITLE
add method to enable the extended readout mapping on the CAEN board

### DIFF
--- a/Source/Objects/Custom Hardware/SNO+/CAEN/SNOCaenModel.h
+++ b/Source/Objects/Custom Hardware/SNO+/CAEN/SNOCaenModel.h
@@ -216,6 +216,7 @@ enum {
 - (void)			writePostTriggerSetting;
 - (void)			writeChannelEnabledMask;
 - (void)            writeNumberBLTEvents:(BOOL)enable;
+- (void)            writeEnableExtendedReadoutBuffer:(BOOL)enable;
 - (void)            writeEnableBerr:(BOOL)enable;
 - (void)			writeOverUnderThresholds;
 

--- a/Source/Objects/Custom Hardware/SNO+/CAEN/SNOCaenModel.m
+++ b/Source/Objects/Custom Hardware/SNO+/CAEN/SNOCaenModel.m
@@ -1134,7 +1134,7 @@ NSString* SNOCaenModelContinuousModeChanged              = @"SNOCaenModelContinu
     unsigned long aValue;
     [self read:kVMEControl returnValue:&aValue];
 
-	if (enable) {
+    if (enable) {
         aValue |= 0x100;
     } else {
         aValue &= 0xffffffeff;

--- a/Source/Objects/Custom Hardware/SNO+/CAEN/SNOCaenModel.m
+++ b/Source/Objects/Custom Hardware/SNO+/CAEN/SNOCaenModel.m
@@ -214,6 +214,7 @@ NSString* SNOCaenModelContinuousModeChanged              = @"SNOCaenModelContinu
         [self initBoard];
         [self writeNumberBLTEvents:0];
         [self writeEnableBerr:0];
+        [self writeEnableExtendedReadoutBuffer:1];
         [self writeAcquisitionControl:YES];
     } @catch (NSException *e) {
         NSLogColor([NSColor redColor], @"error loading CAEN hardware: %@\n",
@@ -1122,6 +1123,24 @@ NSString* SNOCaenModelContinuousModeChanged              = @"SNOCaenModelContinu
     unsigned long aValue = (enable) ? 1 : 0;
 
     [self write:kBLTEventNum sendValue:aValue];
+}
+
+- (void) writeEnableExtendedReadoutBuffer:(BOOL)enable
+{
+    /* Enable/disable the extended readout buffer. The normal readout buffer is
+     * mapped to 4kB of address space, however there is an undocumented bit in
+     * the vme control register which, if enabled, extends this space to ~16MB.
+     * */
+    unsigned long aValue;
+    [self read:kVMEControl returnValue:&aValue];
+
+	if (enable) {
+        aValue |= 0x100;
+    } else {
+        aValue &= 0xffffffeff;
+    }
+
+    [self write:kVMEControl sendValue:aValue];
 }
 
 - (void) writeEnableBerr:(BOOL)enable


### PR DESCRIPTION
This commit enables the undocumented extended readout mapping for the CAEN board which speeds up the readout.

This shouldn't be merged until the new mtc server is installed.

I haven't tested it on the teststand yet.