### PR TITLE
Phil/abort run stop

### DIFF
--- a/Source/Experiments/SNOP/SNOPController.h
+++ b/Source/Experiments/SNOP/SNOPController.h
@@ -205,6 +205,7 @@
 - (void) triggerStatusChanged:(NSNotification*)aNote;
 - (void) dbOrcaDBIPChanged:(NSNotification*)aNote;
 - (void) dbDebugDBIPChanged:(NSNotification*)aNote;
+- (void) stillWaitingForBuffers:(NSNotification *) aNote;
 
 - (IBAction) testMTCServer:(id)sender;
 - (IBAction) testXL3Server:(id)sender;

--- a/Source/Experiments/SNOP/SNOPController.h
+++ b/Source/Experiments/SNOP/SNOPController.h
@@ -175,6 +175,7 @@
     uint32_t hvMask;
 
     RunStatusIcon* doggy_icon;
+    NSAlert*       waitingForBuffersAlert;
 
     // Detector State
     IBOutlet WebView* detectorState;
@@ -206,6 +207,10 @@
 - (void) dbOrcaDBIPChanged:(NSNotification*)aNote;
 - (void) dbDebugDBIPChanged:(NSNotification*)aNote;
 - (void) stillWaitingForBuffers:(NSNotification *) aNote;
+- (void) notWaitingForBuffers:(NSNotification *) aNote;
+
+- (void) openWaitingAlert;
+- (void) closeWaitingAlert;
 
 - (IBAction) testMTCServer:(id)sender;
 - (IBAction) testXL3Server:(id)sender;

--- a/Source/Experiments/SNOP/SNOPController.h
+++ b/Source/Experiments/SNOP/SNOPController.h
@@ -209,9 +209,6 @@
 - (void) stillWaitingForBuffers:(NSNotification *) aNote;
 - (void) notWaitingForBuffers:(NSNotification *) aNote;
 
-- (void) openWaitingAlert;
-- (void) closeWaitingAlert;
-
 - (IBAction) testMTCServer:(id)sender;
 - (IBAction) testXL3Server:(id)sender;
 - (IBAction) testDataServer:(id)sender;

--- a/Source/Experiments/SNOP/SNOPController.h
+++ b/Source/Experiments/SNOP/SNOPController.h
@@ -206,8 +206,8 @@
 - (void) triggerStatusChanged:(NSNotification*)aNote;
 - (void) dbOrcaDBIPChanged:(NSNotification*)aNote;
 - (void) dbDebugDBIPChanged:(NSNotification*)aNote;
-- (void) stillWaitingForBuffers:(NSNotification *) aNote;
-- (void) notWaitingForBuffers:(NSNotification *) aNote;
+- (void) stillWaitingForBuffers:(NSNotification *)aNote;
+- (void) notWaitingForBuffers:(NSNotification *)aNote;
 
 - (IBAction) testMTCServer:(id)sender;
 - (IBAction) testXL3Server:(id)sender;

--- a/Source/Experiments/SNOP/SNOPController.m
+++ b/Source/Experiments/SNOP/SNOPController.m
@@ -835,6 +835,10 @@ err:
 
 - (void) stillWaitingForBuffers:(NSNotification*)aNote
 {
+    /* Throw up a window-modal dialog to give the user an option
+     * to avoid waiting for the hardware buffers to clear at the end
+     * of a run (only for OS X 10.10 or later).  Must be called
+     * only from the main thread. */
 #if defined(MAC_OS_X_VERSION_10_10) && MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_10 // 10.10-specific
     NSString* s = [NSString stringWithFormat:@"Waiting for buffers to empty..."];
     waitingForBuffersAlert = [[[NSAlert alloc] init] autorelease];
@@ -852,6 +856,8 @@ err:
 
 - (void) notWaitingForBuffers:(NSNotification*)aNote
 {
+    /* Close our "Waiting for buffers" dialog if it was open.
+     * Must be called only from the main thread. */
     waitingForBuffersAlert = nil;
 }
 

--- a/Source/Experiments/SNOP/SNOPController.m
+++ b/Source/Experiments/SNOP/SNOPController.m
@@ -858,7 +858,10 @@ err:
 {
     /* Close our "Waiting for buffers" dialog if it was open.
      * Must be called only from the main thread. */
-    waitingForBuffersAlert = nil;
+    if (waitingForBuffersAlert) {
+        [[self window] endSheet:[[self window] attachedSheet] returnCode:NSAlertSecondButtonReturn];
+        waitingForBuffersAlert = nil;
+    }
 }
 
 - (void) hvStatusChanged:(NSNotification*)aNote

--- a/Source/Experiments/SNOP/SNOPController.m
+++ b/Source/Experiments/SNOP/SNOPController.m
@@ -833,7 +833,7 @@ err:
     [debugDBIPAddressPU setStringValue:[model debugDBIPAddress]];
 }
 
-- (void) openWaitingAlert
+- (void) stillWaitingForBuffers:(NSNotification*)aNote
 {
 #if defined(MAC_OS_X_VERSION_10_10) && MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_10 // 10.10-specific
     NSString* s = [NSString stringWithFormat:@"Waiting for buffers to empty..."];
@@ -850,19 +850,9 @@ err:
 #endif
 }
 
-- (void) closeWaitingAlert
-{
-    waitingForBuffersAlert = nil;
-}
-
-- (void) stillWaitingForBuffers:(NSNotification*)aNote
-{
-    [self performSelectorOnMainThread:@selector(openWaitingAlert) withObject:nil waitUntilDone:NO];
-}
-
 - (void) notWaitingForBuffers:(NSNotification*)aNote
 {
-    [self performSelectorOnMainThread:@selector(closeWaitingAlert) withObject:nil waitUntilDone:NO];
+    waitingForBuffersAlert = nil;
 }
 
 - (void) hvStatusChanged:(NSNotification*)aNote

--- a/Source/Experiments/SNOP/SNOPController.m
+++ b/Source/Experiments/SNOP/SNOPController.m
@@ -462,12 +462,12 @@ snopGreenColor;
 
     [notifyCenter addObserver : self
                      selector : @selector(stillWaitingForBuffers:)
-                         name : ORStillWaitingForBuffersNotification
+                         name : ORSNOPStillWaitingForBuffersNotification
                         object: nil];
 
     [notifyCenter addObserver : self
                      selector : @selector(notWaitingForBuffers:)
-                         name : ORNotWaitingForBuffersNotification
+                         name : ORSNOPNotWaitingForBuffersNotification
                         object: nil];
 }
 

--- a/Source/Experiments/SNOP/SNOPController.m
+++ b/Source/Experiments/SNOP/SNOPController.m
@@ -843,7 +843,7 @@ err:
     NSString* s = [NSString stringWithFormat:@"Waiting for buffers to empty..."];
     waitingForBuffersAlert = [[[NSAlert alloc] init] autorelease];
     [waitingForBuffersAlert setMessageText:s];
-    [waitingForBuffersAlert addButtonWithTitle:@"Force stop and LOSE DATA!"];
+    [waitingForBuffersAlert addButtonWithTitle:@"Force Stop and LOSE DATA!"];
     [waitingForBuffersAlert setAlertStyle:NSInformationalAlertStyle];
     [waitingForBuffersAlert beginSheetModalForWindow:[self window] completionHandler:^(NSModalResponse result){
         if (result == NSAlertFirstButtonReturn) {

--- a/Source/Experiments/SNOP/SNOPModel.h
+++ b/Source/Experiments/SNOP/SNOPModel.h
@@ -148,7 +148,7 @@ BOOL isNotRunningOrIsInMaintenance();
     int state;
     int start;
     bool resync;
-    bool waitingFlag;   // flag indicates we are waiting for our buffers to empty
+    bool waitingForBuffers;     // flag indicates we are waiting for our buffers to empty
 
     @private
         //Run type word
@@ -260,6 +260,7 @@ BOOL isNotRunningOrIsInMaintenance();
 - (void) updateRHDRSruct;
 - (void) shipRHDRRecord;
 - (void) stillWaitingForBuffers;
+- (void) abortWaitingForBuffers;
 
 #pragma mark ¥¥¥Accessors
 - (NHitMonitor *) nhitMonitor;

--- a/Source/Experiments/SNOP/SNOPModel.h
+++ b/Source/Experiments/SNOP/SNOPModel.h
@@ -372,5 +372,5 @@ extern NSString* ORSNOPModelSRCollectionChangedNotification;
 extern NSString* ORSNOPModelSRChangedNotification;
 extern NSString* ORSNOPModelSRVersionChangedNotification;
 extern NSString* ORSNOPModelNhitMonitorChangedNotification;
-extern NSString* ORStillWaitingForBuffersNotification;
-extern NSString* ORNotWaitingForBuffersNotification;
+extern NSString* ORSNOPStillWaitingForBuffersNotification;
+extern NSString* ORSNOPNotWaitingForBuffersNotification;

--- a/Source/Experiments/SNOP/SNOPModel.h
+++ b/Source/Experiments/SNOP/SNOPModel.h
@@ -148,6 +148,7 @@ BOOL isNotRunningOrIsInMaintenance();
     int state;
     int start;
     bool resync;
+    bool waitingFlag;   // flag indicates we are waiting for our buffers to empty
 
     @private
         //Run type word
@@ -258,6 +259,7 @@ BOOL isNotRunningOrIsInMaintenance();
 - (void) shipEPEDRecord;
 - (void) updateRHDRSruct;
 - (void) shipRHDRRecord;
+- (void) stillWaitingForBuffers;
 
 #pragma mark ¥¥¥Accessors
 - (NHitMonitor *) nhitMonitor;
@@ -369,3 +371,5 @@ extern NSString* ORSNOPModelSRCollectionChangedNotification;
 extern NSString* ORSNOPModelSRChangedNotification;
 extern NSString* ORSNOPModelSRVersionChangedNotification;
 extern NSString* ORSNOPModelNhitMonitorChangedNotification;
+extern NSString* ORStillWaitingForBuffersNotification;
+extern NSString* ORNotWaitingForBuffersNotification;

--- a/Source/Experiments/SNOP/SNOPModel.m
+++ b/Source/Experiments/SNOP/SNOPModel.m
@@ -550,8 +550,8 @@ tellieRunFiles = _tellieRunFiles;
     ORMTCModel *mtc;
     SNOCaenModel *caen;
     ORXL3Model *xl3;
-
     int i;
+
     objs = [[(ORAppDelegate*)[NSApp delegate] document]
          collectObjectsOfClass:NSClassFromString(@"ORMTCModel")];
 

--- a/Source/Experiments/SNOP/SNOPModel.m
+++ b/Source/Experiments/SNOP/SNOPModel.m
@@ -908,8 +908,8 @@ err:
         [NSThread detachNewThreadSelector:@selector(_waitForBuffers)
                                  toTarget:self
                                withObject:nil];
-        // post a modal dialog after 1 sec if the buffers haven't cleared yet
-        [self performSelector:@selector(stillWaitingForBuffers) withObject:nil afterDelay:1];
+        // post a modal dialog after 3 secs if the buffers haven't cleared yet
+        [self performSelector:@selector(stillWaitingForBuffers) withObject:nil afterDelay:3];
         break;
     default:
         break;

--- a/Source/Experiments/SNOP/SNOPModel.m
+++ b/Source/Experiments/SNOP/SNOPModel.m
@@ -923,6 +923,8 @@ err:
 
 - (void) stillWaitingForBuffers
 {
+    /* We're stopping a run but our buffers are taking a while to clear, so
+     * send a notification to allow our controller to throw up a "force stop" dialog */
     if (waitingForBuffers) {
         [[NSNotificationCenter defaultCenter] postNotificationOnMainThreadWithName:ORStillWaitingForBuffersNotification object:self];
     }
@@ -930,6 +932,7 @@ err:
 
 - (void) abortWaitingForBuffers
 {
+    /* Give up on waiting for our buffers to clear at the end of a run */
     waitingForBuffers = false;
 }
 

--- a/Source/Experiments/SNOP/SNOPModel.m
+++ b/Source/Experiments/SNOP/SNOPModel.m
@@ -68,8 +68,8 @@ NSString* ORSNOPModelSRCollectionChangedNotification = @"ORSNOPModelSRCollection
 NSString* ORSNOPModelSRChangedNotification = @"ORSNOPModelSRChangedNotification";
 NSString* ORSNOPModelSRVersionChangedNotification = @"ORSNOPModelSRVersionChangedNotification";
 NSString* ORSNOPModelNhitMonitorChangedNotification = @"ORSNOPModelNhitMonitorChangedNotification";
-NSString* ORStillWaitingForBuffersNotification = @"ORStillWaitingForBuffersNotification";
-NSString* ORNotWaitingForBuffersNotification = @"ORNotWaitingForBuffersNotification";
+NSString* ORSNOPStillWaitingForBuffersNotification = @"ORSNOPStillWaitingForBuffersNotification";
+NSString* ORSNOPNotWaitingForBuffersNotification = @"ORSNOPNotWaitingForBuffersNotification";
 
 BOOL isNotRunningOrIsInMaintenance()
 {
@@ -928,7 +928,7 @@ err:
     /* We're stopping a run but our buffers are taking a while to clear, so
      * send a notification to allow our controller to throw up a "force stop" dialog */
     if (waitingForBuffers) {
-        [[NSNotificationCenter defaultCenter] postNotificationOnMainThreadWithName:ORStillWaitingForBuffersNotification object:self];
+        [[NSNotificationCenter defaultCenter] postNotificationOnMainThreadWithName:ORSNOPStillWaitingForBuffersNotification object:self];
     }
 }
 
@@ -960,7 +960,7 @@ err:
         [mtc release];
         [xl3 release];
         waitingForBuffers = false;
-        [[NSNotificationCenter defaultCenter] postNotificationOnMainThreadWithName:ORNotWaitingForBuffersNotification object:self];
+        [[NSNotificationCenter defaultCenter] postNotificationOnMainThreadWithName:ORSNOPNotWaitingForBuffersNotification object:self];
 
         /* Go ahead and end the run. */
         dispatch_sync(dispatch_get_main_queue(), ^{

--- a/Source/Experiments/SNOP/SNOPModel.m
+++ b/Source/Experiments/SNOP/SNOPModel.m
@@ -924,7 +924,7 @@ err:
 - (void) stillWaitingForBuffers
 {
     if (waitingForBuffers) {
-        [[NSNotificationCenter defaultCenter] postNotificationName:ORStillWaitingForBuffersNotification object:self];
+        [[NSNotificationCenter defaultCenter] postNotificationOnMainThreadWithName:ORStillWaitingForBuffersNotification object:self];
     }
 }
 
@@ -955,7 +955,7 @@ err:
         [mtc release];
         [xl3 release];
         waitingForBuffers = false;
-        [[NSNotificationCenter defaultCenter] postNotificationName:ORNotWaitingForBuffersNotification object:self];
+        [[NSNotificationCenter defaultCenter] postNotificationOnMainThreadWithName:ORNotWaitingForBuffersNotification object:self];
 
         /* Go ahead and end the run. */
         dispatch_sync(dispatch_get_main_queue(), ^{

--- a/Source/Experiments/SNOP/SNOPModel.m
+++ b/Source/Experiments/SNOP/SNOPModel.m
@@ -550,6 +550,7 @@ tellieRunFiles = _tellieRunFiles;
     ORMTCModel *mtc;
     SNOCaenModel *caen;
     ORXL3Model *xl3;
+
     int i;
     objs = [[(ORAppDelegate*)[NSApp delegate] document]
          collectObjectsOfClass:NSClassFromString(@"ORMTCModel")];
@@ -762,6 +763,7 @@ err:
 {
     NSArray* objs;
     ORMTCModel *mtc;
+
     objs = [[(ORAppDelegate*)[NSApp delegate] document]
          collectObjectsOfClass:NSClassFromString(@"ORMTCModel")];
 


### PR DESCRIPTION
Add ability to force a run to stop while waiting for the data buffers to empty.  Dialog currently appears after 3 seconds of waiting -- we may want to change this.