### PR TITLE
SNO+: Update how fibre field is passed in TELLIE expert tab

### DIFF
--- a/Source/Objects/Custom Hardware/SNO+/ELLIE/ELLIEController.m
+++ b/Source/Objects/Custom Hardware/SNO+/ELLIE/ELLIEController.m
@@ -528,8 +528,9 @@ NSString* ORTELLIERunStart = @"ORTELLIERunStarted";
         [tellieNoPulsesTf setBackgroundColor:[NSColor whiteColor]];
         // Make settings dict to pass to fire method
         float pulseSeparation = 1000.*(1./[telliePulseFreqTf floatValue]); // TELLIE accepts pulse rate in ms
+        NSString* fibre = [model calcTellieFibreForChannel:[tellieChannelTf integerValue]];
         NSMutableDictionary* settingsDict = [NSMutableDictionary dictionaryWithCapacity:100];
-        [settingsDict setValue:[tellieExpertFibreSelectPb titleOfSelectedItem] forKey:@"fibre"];
+        [settingsDict setValue:fibre forKey:@"fibre"];
         [settingsDict setValue:[NSNumber numberWithInteger:[tellieChannelTf integerValue]]  forKey:@"channel"];
         [settingsDict setValue:[tellieExpertOperationModePb titleOfSelectedItem] forKey:@"run_mode"];
         //[settingsDict setValue:[NSNumber numberWithInteger:[telliePhotonsTf integerValue]] forKey:@"photons"];

--- a/Source/Objects/Custom Hardware/SNO+/ELLIE/ELLIEModel.h
+++ b/Source/Objects/Custom Hardware/SNO+/ELLIE/ELLIEModel.h
@@ -128,6 +128,7 @@
 -(NSNumber*) calcTellieChannelPulseSettings:(NSUInteger)channel withNPhotons:(NSUInteger)photons withFireFrequency:(NSUInteger)frequency inSlave:(BOOL)mode;
 -(NSNumber*) calcTellieChannelForFibre:(NSString*)fibre;
 -(NSString*) calcTellieFibreForNode:(NSUInteger)node;
+-(NSString*) calcTellieFibreForChannel:(NSUInteger)channel;
 -(NSNumber*)calcPhotonsForIPW:(NSUInteger)ipw forChannel:(NSUInteger)channel inSlave:(BOOL)inSlave;
 -(NSString*)selectPriorityFibre:(NSArray*)fibres forNode:(NSUInteger)node;
 -(void) startTellieRunThread:(NSDictionary*)fireCommands;

--- a/Source/Objects/Custom Hardware/SNO+/ELLIE/ELLIEModel.m
+++ b/Source/Objects/Custom Hardware/SNO+/ELLIE/ELLIEModel.m
@@ -557,6 +557,20 @@ NSString* ORTELLIERunFinished = @"ORTELLIERunFinished";
     return channel;
 }
 
+-(NSString*) calcTellieFibreForChannel:(NSUInteger)channel
+{
+    /*
+     Use patch pannel map loaded from the telliedb to map a given fibre to the correct tellie channel.
+     */
+    if([self tellieFibreMapping] == nil){
+        NSLogColor([NSColor redColor], @"[TELLIE]: fibre map has not been loaded from couchdb - you need to call loadTellieStaticsFromDB\n");
+        return nil;
+    }
+    NSUInteger channelIndex = [[[self tellieFibreMapping] objectForKey:@"channels"] indexOfObject:channel];
+    NSString* fibre = [[[self tellieFibreMapping] objectForKey:@"fibres"] objectAtIndex:channelIndex];
+    return fibre;
+}
+
 -(NSString*)selectPriorityFibre:(NSArray*)fibres forNode:(NSUInteger)node{
     /*
      Select appropriate fibre based on naming convensions for the node at


### PR DESCRIPTION
In the TELLIE expert tab the fibre name was being read from the GUI's drop down menu. This caused a bug: If a user manually changes the TELLIE channel to be fired (rather than using the usual fibre / node selection), the fibre field is automatically cleared. In this case the fibre field would be left blank and no fibre information is propagated to the couchdb during running. This PR fixes this bug. 