### PR TITLE
Nominal settings check hv

### DIFF
--- a/Source/Objects/Custom Hardware/SNO+/XL3/ORXL3Model.m
+++ b/Source/Objects/Custom Hardware/SNO+/XL3/ORXL3Model.m
@@ -1784,7 +1784,7 @@ void SwapLongBlock(void* p, int32_t n)
          "current_nominal_settings.crate   = current_channel_status.crate   AND "
          "current_nominal_settings.slot    = current_channel_status.slot    AND "
          "current_nominal_settings.channel = current_channel_status.channel AND "
-         "current_nominal_status.crate = %i",
+         "current_nominal_settings.crate = %i",
          [self crateNumber]];
 
     [db dbQuery:query object:self selector:@selector(nominalSettingsCallback:) timeout:10.0];

--- a/Source/Objects/Custom Hardware/SNO+/XL3/ORXL3Model.m
+++ b/Source/Objects/Custom Hardware/SNO+/XL3/ORXL3Model.m
@@ -1785,7 +1785,7 @@ void SwapLongBlock(void* p, int32_t n)
          "current_nominal_settings.slot    = current_channel_status.slot    AND "
          "current_nominal_settings.channel = current_channel_status.channel AND "
          "current_nominal_status.crate = %i",
-         [self crateNumber]]
+         [self crateNumber]];
 
     [db dbQuery:query object:self selector:@selector(nominalSettingsCallback:) timeout:10.0];
 }


### PR DESCRIPTION
This pull request adds a check to make sure that any channels with HV on have their sequencer enabled to avoid blind flashers.

Tested on the teststand on June 16, 2017.