### PR TITLE
zero all pedestal masks before physics runs

### DIFF
--- a/Source/Experiments/SNOP/SNOPModel.m
+++ b/Source/Experiments/SNOP/SNOPModel.m
@@ -600,6 +600,24 @@ tellieRunFiles = _tellieRunFiles;
             NSLogColor([NSColor redColor], @"error initializing MTC.\n");
             goto err;
         }
+
+        /* Load the XL3 hardware. */
+        objs = [[(ORAppDelegate*)[NSApp delegate] document]
+             collectObjectsOfClass:NSClassFromString(@"ORXL3Model")];
+
+        for (i = 0; i < [objs count]; i++) {
+            xl3 = [objs objectAtIndex:i];
+
+            if ([gOrcaGlobals runType] & kPhysicsRun) {
+                /* If we're in a physics run, we zero the pedestal masks before
+                 * the run starts. This is because it was noticed that the
+                 * number of channels in the pedestal mask seems to affect the
+                 * noise on the trigger signals. See
+                 * http://snopl.us/shift/view/9e1ff17e58704756a99f947ec2509f39?index_start=15. */
+                [xl3 zeroPedestalMasksAtRunStart];
+            }
+        }
+
         break;
     default:
         /* Turn off triggers */
@@ -639,10 +657,20 @@ tellieRunFiles = _tellieRunFiles;
             xl3 = [objs objectAtIndex:i];
 
             if ([xl3 initAtRunStart]) {
-                NSLogColor([NSColor redColor], @"error initializing XL3.\n");
+                NSLogColor([NSColor redColor], @"error initializing XL3 %i.\n", [xl3 crateNumber]);
                 goto err;
             }
+
+            if ([gOrcaGlobals runType] & kPhysicsRun) {
+                /* If we're in a physics run, we zero the pedestal masks before
+                 * the run starts. This is because it was noticed that the
+                 * number of channels in the pedestal mask seems to affect the
+                 * noise on the trigger signals. See
+                 * http://snopl.us/shift/view/9e1ff17e58704756a99f947ec2509f39?index_start=15. */
+                [xl3 zeroPedestalMasksAtRunStart];
+            }
         }
+
         break;
     }
 

--- a/Source/Objects/Custom Hardware/SNO+/Fec32/ORFec32Model.m
+++ b/Source/Objects/Custom Hardware/SNO+/Fec32/ORFec32Model.m
@@ -281,7 +281,6 @@ static int              sChannelsNotChangedCount = 0;
 - (void) setPedEnabledMask:(unsigned long) aMask
 {
     [[[self undoManager] prepareWithInvocationTarget:self] setPedEnabledMask:pedEnabledMask];
-    //NSLog(@"FEC (%d,%d), mask 0x%08x\n", [self crateNumber], [self stationNumber], aMask);
     pedEnabledMask = aMask;
     [self postNotificationName:ORFecPedEnabledMaskChanged];
 }

--- a/Source/Objects/Custom Hardware/SNO+/XL3/ORXL3Model.h
+++ b/Source/Objects/Custom Hardware/SNO+/XL3/ORXL3Model.h
@@ -290,6 +290,7 @@ enum {
 - (void) documentClosed;
 - (void) detectorStateChanged:(NSNotification*)aNote;
 - (int) initAtRunStart;
+- (void) zeroPedestalMasksAtRunStart;
 
 #pragma mark •••Accessors
 - (BOOL) isTriggerON;

--- a/Source/Objects/Custom Hardware/SNO+/XL3/ORXL3Model.m
+++ b/Source/Objects/Custom Hardware/SNO+/XL3/ORXL3Model.m
@@ -370,7 +370,7 @@ isLoaded = isLoaded;
      *
      * See this shift report for more details:
      * http://snopl.us/shift/view/9e1ff17e58704756a99f947ec2509f39. */
-    int slot, i, hv;
+    int slot;
     ORFec32Model *fec;
 
     /* First, set the pedestal mask in the GUI to zero. */


### PR DESCRIPTION
This pull request sets the pedestal mask for all FECs to zero before a physics run. The reason for this is that it was noticed that the number of channels in the pedestal mask seems to affect the noise on the trigger signal. See this shift report for more details: http://snopl.us/shift/view/9e1ff17e58704756a99f947ec2509f39?index_start=15.