### PR TITLE
set calType to zero when ping crates at run start finishes

### DIFF
--- a/Source/Experiments/SNOP/SNOPModel.m
+++ b/Source/Experiments/SNOP/SNOPModel.m
@@ -1405,13 +1405,13 @@ static NSComparisonResult compareXL3s(ORXL3Model *xl3_1, ORXL3Model *xl3_2, void
         }
     }
 
-    /* Send an EPED record with the stepNumber set to 0xffffffff to let the
-     * nearline job know that we are done. */
+    /* Send an EPED record with calType set to zero to let the nearline job
+     * know that we are done. */
     [self shipEPEDStructWithCoarseDelay: [mtc coarseDelay]
                               fineDelay: [mtc fineDelay]
                          chargePulseAmp: 0
                           pedestalWidth: [mtc pedestalWidth]
-                                calType: 50
+                                calType: 0
                              stepNumber: 0xffffffff];
 
     /* Set the pedestal mask for each crate back. */


### PR DESCRIPTION
This pull request updates the ping crates at run start method to set the calType to zero when it finishes. The reason is that RAT associates all events after an EPED record with that EPED record, and so this makes it easier for nearline jobs to just look at the ping crates events.