### PR TITLE
fix a few warnings pointed out by the XCode analyzer tool

### DIFF
--- a/Source/Objects/Custom Hardware/SNO+/Fec32/ORFec32Model.m
+++ b/Source/Objects/Custom Hardware/SNO+/Fec32/ORFec32Model.m
@@ -910,17 +910,15 @@ static int              sChannelsNotChangedCount = 0;
 {
 	return ((kHVRefMax-kHVRefMin)/255.0)*hVRef+kHVRefMin;
 }
-//readVoltages
-//read the voltage and temp adcs for a crate and card
-//assumes that bus access has already been granted.
--(void) readVoltages
-{	
-    bool statusChanged = false;
 
-    statusChanged = [self readVoltagesUsingXL3];
+- (void) readVoltages
+{
+    /* Read the voltage and temp adcs for a crate and card. Assumes that bus
+     * access has already been granted. */
+    [self readVoltagesUsingXL3];
 }
 
--(void) parseVoltages:(VMonResults*)result;
+- (void) parseVoltages:(VMonResults*)result;
 {
     [self parseVoltagesUsingXL3:result];
 }

--- a/Source/Objects/Custom Hardware/SNO+/XL3/ORXL3Model.m
+++ b/Source/Objects/Custom Hardware/SNO+/XL3/ORXL3Model.m
@@ -1878,7 +1878,6 @@ void SwapLongBlock(void* p, int32_t n)
     int slot, dbNum, channel;
     char payload[XL3_PAYLOAD_SIZE];
     ORFec32Model *fec;
-    ORFecDaughterCardModel *db;
 
     memset(&payload, 0, sizeof(payload));
 
@@ -1901,8 +1900,6 @@ void SwapLongBlock(void* p, int32_t n)
         if ([self isTriggerON]) {
             for (dbNum = 0; dbNum < 4; dbNum++) {
                 if (![fec dcPresent:dbNum]) continue;
-
-                db = [fec dc:dbNum];
 
                 for (channel = 0; channel < 8; channel++) {
                     if ([fec trigger100nsEnabled: (dbNum*8 + channel)]) {


### PR DESCRIPTION
I ran the XCode analyzer tool in XCode 6.2 and it pointed out a couple of unused variables.
