### PR TITLE
check caen settings before starting standard run

### DIFF
--- a/Source/Experiments/SNOP/SNOPController.m
+++ b/Source/Experiments/SNOP/SNOPController.m
@@ -723,7 +723,6 @@ snopGreenColor;
 - (IBAction) startRunAction:(id)sender
 {
     /* Action when the user clicks on the Start or Restart Button. */
-    SNOCaenModel* caen;
     unsigned long dbruntypeword = 0;
 
     /* If we are not going to maintenance we shouldn't be polling */
@@ -736,26 +735,6 @@ snopGreenColor;
 
     // Get the run type word of the next run
     dbruntypeword = [[runSettings valueForKey:@"run_type_word"] unsignedLongValue];
-
-    if ([runControl runningState] == eRunInProgress) {
-        NSArray *objs = [[(ORAppDelegate*)[NSApp delegate] document] collectObjectsOfClass:NSClassFromString(@"SNOCaenModel")];
-        if ([objs count]) {
-            caen = [objs objectAtIndex:0];
-
-            /* Check to see if the CAEN settings need to be reloaded. */
-            @try {
-                if ([caen checkFromSerialization:runSettings]) {
-                    /* Need to resync. */
-                    NSLog(@"CAEN settings are different in this standard run. Resyncing...\n");
-                    [model setResync:YES];
-                }
-            } @catch (NSException *e) {
-                NSLogColor([NSColor redColor], @"unable to validate CAEN settings because of exception. name: %@ reason: %@. Assuming settings haven't changed...\n", [e name], [e reason]);
-            }
-        } else {
-            NSLogColor([NSColor redColor], @"couldn't find CAEN model. Assuming settings haven't changed.\n");
-        }
-    }
 
     if (!((dbruntypeword & kMaintenanceRun) || (dbruntypeword & kDiagnosticRun))) {
         // Make sure we are not polling

--- a/Source/Experiments/SNOP/SNOPController.m
+++ b/Source/Experiments/SNOP/SNOPController.m
@@ -744,13 +744,11 @@ snopGreenColor;
 
             /* Check to see if the CAEN settings need to be reloaded. */
             @try {
-                NSLog(@"checking caen settings\n");
                 if ([caen checkFromSerialization:runSettings]) {
                     /* Need to resync. */
                     NSLog(@"CAEN settings are different in this standard run. Resyncing...\n");
                     [model setResync:YES];
                 }
-                NSLog(@"caen settings don't need to be changed\n");
             } @catch (NSException *e) {
                 NSLogColor([NSColor redColor], @"unable to validate CAEN settings because of exception. name: %@ reason: %@. Assuming settings haven't changed...\n", [e name], [e reason]);
             }

--- a/Source/Experiments/SNOP/SNOPController.m
+++ b/Source/Experiments/SNOP/SNOPController.m
@@ -42,7 +42,6 @@
 NSString* ORSNOPRequestHVStatus = @"ORSNOPRequestHVStatus";
 NSString* ORRunWaitFinished = @"ORRunWaitFinished";
 
-
 #define UNITS_UNDECIDED 0
 #define UNITS_RAW       1
 #define UNITS_CONVERTED 2
@@ -723,34 +722,60 @@ snopGreenColor;
 
 - (IBAction) startRunAction:(id)sender
 {
+    /* Action when the user clicks on the Start or Restart Button. */
+    SNOCaenModel* caen;
+    unsigned long dbruntypeword = 0;
 
     /* If we are not going to maintenance we shouldn't be polling */
-    unsigned long dbruntypeword = 0;
     NSMutableDictionary* runSettings = [[[model standardRunCollection] objectForKey:[model standardRunType]] objectForKey:[model standardRunVersion]];
-    if(runSettings != nil){
-        //Get the run type word of the next run
-        dbruntypeword = [[runSettings valueForKey:@"run_type_word"] unsignedLongValue];
+
+    if (runSettings == nil) {
+        NSLogColor([NSColor redColor], @"Standard run %@(%@) does NOT exists in DB. \n", [model standardRunType], [model standardRunVersion]);
+        return;
     }
 
-    if( !((dbruntypeword & kMaintenanceRun) || (dbruntypeword & kDiagnosticRun)) ){
-        //Make sure we are not polling
-        NSArray* xl3s = [[(ORAppDelegate*)[NSApp delegate] document] collectObjectsOfClass:NSClassFromString(@"ORXL3Model")];
-        for(ORXL3Model *anXL3 in xl3s){
-            if([anXL3 isPollingXl3]) {
+    // Get the run type word of the next run
+    dbruntypeword = [[runSettings valueForKey:@"run_type_word"] unsignedLongValue];
+
+    if ([runControl runningState] == eRunInProgress) {
+        NSArray *objs = [[(ORAppDelegate*)[NSApp delegate] document] collectObjectsOfClass:NSClassFromString(@"SNOCaenModel")];
+        if ([objs count]) {
+            caen = [objs objectAtIndex:0];
+
+            /* Check to see if the CAEN settings need to be reloaded. */
+            @try {
+                NSLog(@"checking caen settings\n");
+                if ([caen checkFromSerialization:runSettings]) {
+                    /* Need to resync. */
+                    NSLog(@"CAEN settings are different in this standard run. Resyncing...\n");
+                    [model setResync:YES];
+                }
+                NSLog(@"caen settings don't need to be changed\n");
+            } @catch (NSException *e) {
+                NSLogColor([NSColor redColor], @"unable to validate CAEN settings because of exception. name: %@ reason: %@. Assuming settings haven't changed...\n", [e name], [e reason]);
+            }
+        } else {
+            NSLogColor([NSColor redColor], @"couldn't find CAEN model. Assuming settings haven't changed.\n");
+        }
+    }
+
+    if (!((dbruntypeword & kMaintenanceRun) || (dbruntypeword & kDiagnosticRun))) {
+        // Make sure we are not polling
+        NSArray *xl3s = [[(ORAppDelegate*)[NSApp delegate] document] collectObjectsOfClass:NSClassFromString(@"ORXL3Model")];
+        for (ORXL3Model *anXL3 in xl3s) {
+            if ([anXL3 isPollingXl3]) {
                 NSLog(@"Stopping XL3 polling on crate %d\n",[anXL3 crateNumber]);
                 [anXL3 setIsPollingXl3:false];
             }
         }
     }
 
-    //Start the standard run and stop run initialization if failed
-    if(![model startStandardRun:[model standardRunType] withVersion:[model standardRunVersion]]) return;
-
+    // Start the standard run
+    [model startStandardRun:[model standardRunType] withVersion:[model standardRunVersion]];
 }
 
-- (IBAction)resyncRunAction:(id)sender
+- (IBAction) resyncRunAction:(id)sender
 {
-
     /* A resync run does a hard stop and start without the user having to hit
      * stop run and then start run. Doing this resets the GTID, which resyncs
      * crate 9 after it goes out of sync :). */
@@ -758,7 +783,6 @@ snopGreenColor;
     [model setResync:YES];
 
     [self startRunAction:nil];
-
 }
 
 - (IBAction) stopRunAction:(id)sender

--- a/Source/Experiments/SNOP/SNOPModel.m
+++ b/Source/Experiments/SNOP/SNOPModel.m
@@ -906,11 +906,11 @@ err:
      * will fire a SOFT_GT and turn triggers off. Then we need to wait
      * until the MTC/CAEN/XL3s have read out all the data. */
 
-    //Stop the ECA thread
-    /* This will send a cancel signal to the ECAThread which will exit
-     at the end of the current ECA step. This makes the run wait until
-     the ECAThread is stopped */
-    if([anECARun isExecuting] && ![anECARun isFinishing]){
+    // Stop the ECA thread
+    /* This will send a cancel signal to the ECAThread which will exit at the
+     * end of the current ECA step. This makes the run wait until the ECAThread
+     * is stopped */
+    if ([anECARun isExecuting] && ![anECARun isFinishing]) {
         [anECARun stop];
     }
 

--- a/Source/Objects/Custom Hardware/SNO+/CAEN/SNOCaenModel.h
+++ b/Source/Objects/Custom Hardware/SNO+/CAEN/SNOCaenModel.h
@@ -246,6 +246,7 @@ enum {
 - (id)   initWithCoder:(NSCoder*)decoder;
 - (void) encodeWithCoder:(NSCoder*)encoder;
 - (NSMutableDictionary*) serializeToDictionary;
+- (BOOL) checkFromSerialization:(NSMutableDictionary*) dict;
 - (void) loadFromSerialization:(NSMutableDictionary*)settingsDict;
 
 @end

--- a/Source/Objects/Custom Hardware/SNO+/CAEN/SNOCaenModel.m
+++ b/Source/Objects/Custom Hardware/SNO+/CAEN/SNOCaenModel.m
@@ -1302,8 +1302,16 @@ NSString* SNOCaenModelContinuousModeChanged              = @"SNOCaenModelContinu
     /* Checks if the current model state is the same as the settings in the
      * dictionary. Returns FALSE if the settings are the same, TRUE otherwise.
      *
-     * This is used to check if we need to reload the caen settings. If so, we
-     * need to resync instead of restarting. */
+     * This is used to check if we need to reload the caen settings at the
+     * start of a run. According to the documentation, the following registers
+     * can't be changed while the acquisition is running:
+     *
+     *   - buffer organization
+     *   - custom size
+     *   - channel enable mask
+     *
+     * But to make life easier, we just check if any setting needs to be
+     * changed and if so, resync the run. */
     if ([self channelConfigMask]     != [[dict objectForKey:@"CAEN_channelConfigMask"] unsignedShortValue]) return TRUE;
     if ([self eventSize]             != [[dict objectForKey:@"CAEN_eventSize"] intValue]) return TRUE;
     if ([self customSize]            != [[dict objectForKey:@"CAEN_customSize"] unsignedLongValue]) return TRUE;

--- a/Source/Objects/Custom Hardware/SNO+/CAEN/SNOCaenModel.m
+++ b/Source/Objects/Custom Hardware/SNO+/CAEN/SNOCaenModel.m
@@ -1269,7 +1269,6 @@ NSString* SNOCaenModelContinuousModeChanged              = @"SNOCaenModelContinu
 
 - (NSDictionary*) serializeToDictionary
 {
-
     // Dump current CAEN settings into dictionary.
     // Returns NULL if there was any error.
     NSMutableDictionary* CAENStateDict = [NSMutableDictionary dictionaryWithCapacity:1];
@@ -1296,11 +1295,36 @@ NSString* SNOCaenModelContinuousModeChanged              = @"SNOCaenModelContinu
         NSLogColor([NSColor redColor], @"CAEN: settings couldn't be saved. error: %@ reason: %@ \n", [err name], [err reason]);
         return NULL;
     }
-
 }
 
-- (void) loadFromSerialization:(NSMutableDictionary*)settingsDict {
+- (BOOL) checkFromSerialization:(NSMutableDictionary*) dict
+{
+    /* Checks if the current model state is the same as the settings in the
+     * dictionary. Returns FALSE if the settings are the same, TRUE otherwise.
+     *
+     * This is used to check if we need to reload the caen settings. If so, we
+     * need to resync instead of restarting. */
+    if ([self channelConfigMask]     != [[dict objectForKey:@"CAEN_channelConfigMask"] unsignedShortValue]) return TRUE;
+    if ([self eventSize]             != [[dict objectForKey:@"CAEN_eventSize"] intValue]) return TRUE;
+    if ([self customSize]            != [[dict objectForKey:@"CAEN_customSize"] unsignedLongValue]) return TRUE;
+    if ([self isCustomSize]          != [[dict objectForKey:@"CAEN_isCustomSize"] boolValue]) return TRUE;
+    if ([self acquisitionMode]       != [[dict objectForKey:@"CAEN_acquisitionMode"] unsignedShortValue]) return TRUE;
+    if ([self countAllTriggers]      != [[dict objectForKey:@"CAEN_countAllTriggers"] boolValue]) return TRUE;
+    if ([self triggerSourceMask]     != [[dict objectForKey:@"CAEN_triggerSourceMask"] unsignedLongValue]) return TRUE;
+    if ([self coincidenceLevel]      != [[dict objectForKey:@"CAEN_coincidenceLevel"] unsignedShortValue]) return TRUE;
+    if ([self triggerOutMask]        != [[dict objectForKey:@"CAEN_triggerOutMask"] unsignedLongValue]) return TRUE;
+    if ([self postTriggerSetting]    != [[dict objectForKey:@"CAEN_postTriggerSetting"] unsignedLongValue]) return TRUE;
+    if ([self frontPanelControlMask] != [[dict objectForKey:@"CAEN_frontPanelControlMask"] unsignedLongValue]) return TRUE;
+    if ([self enabledMask]           != [[dict objectForKey:@"CAEN_enabledMask"] unsignedShortValue]) return TRUE;
+    for (int i = 0; i < kNumCaenChannelDacs; i++) {
+        if ([self dac:i] != [[dict objectForKey:[NSString stringWithFormat:@"%@_%i",@"CAEN_dac",i]] unsignedShortValue]) return TRUE;
+    }
 
+    return FALSE;
+}
+
+- (void) loadFromSerialization:(NSMutableDictionary*)settingsDict
+{
     [self setChannelConfigMask:[[settingsDict objectForKey:[self getStandardRunKeyForField:@"channelConfigMask"]] unsignedShortValue]];
     [self setEventSize:[[settingsDict objectForKey:[self getStandardRunKeyForField:@"eventSize"]] intValue]];
     [self setCustomSize:[[settingsDict objectForKey:[self getStandardRunKeyForField:@"customSize"]] unsignedLongValue]];
@@ -1316,7 +1340,6 @@ NSString* SNOCaenModelContinuousModeChanged              = @"SNOCaenModelContinu
     for (int idac=0; idac<kNumCaenChannelDacs; ++idac) {
         [self setDac:idac withValue:[[settingsDict objectForKey:[NSString stringWithFormat:@"%@_%i",[self getStandardRunKeyForField:@"dac"],idac]] unsignedShortValue]];
     }
-
 }
 
 - (NSString*) getStandardRunKeyForField:(NSString*)aField

--- a/Source/Objects/Custom Hardware/SNO+/CAEN/SNOCaenModel.m
+++ b/Source/Objects/Custom Hardware/SNO+/CAEN/SNOCaenModel.m
@@ -1300,7 +1300,7 @@ NSString* SNOCaenModelContinuousModeChanged              = @"SNOCaenModelContinu
 - (BOOL) checkFromSerialization:(NSMutableDictionary*) dict
 {
     /* Checks if the current model state is the same as the settings in the
-     * dictionary. Returns FALSE if the settings are the same, TRUE otherwise.
+     * dictionary. Returns NO if the settings are the same, YES otherwise.
      *
      * This is used to check if we need to reload the caen settings at the
      * start of a run. According to the documentation, the following registers
@@ -1312,23 +1312,23 @@ NSString* SNOCaenModelContinuousModeChanged              = @"SNOCaenModelContinu
      *
      * But to make life easier, we just check if any setting needs to be
      * changed and if so, resync the run. */
-    if ([self channelConfigMask]     != [[dict objectForKey:@"CAEN_channelConfigMask"] unsignedShortValue]) return TRUE;
-    if ([self eventSize]             != [[dict objectForKey:@"CAEN_eventSize"] intValue]) return TRUE;
-    if ([self customSize]            != [[dict objectForKey:@"CAEN_customSize"] unsignedLongValue]) return TRUE;
-    if ([self isCustomSize]          != [[dict objectForKey:@"CAEN_isCustomSize"] boolValue]) return TRUE;
-    if ([self acquisitionMode]       != [[dict objectForKey:@"CAEN_acquisitionMode"] unsignedShortValue]) return TRUE;
-    if ([self countAllTriggers]      != [[dict objectForKey:@"CAEN_countAllTriggers"] boolValue]) return TRUE;
-    if ([self triggerSourceMask]     != [[dict objectForKey:@"CAEN_triggerSourceMask"] unsignedLongValue]) return TRUE;
-    if ([self coincidenceLevel]      != [[dict objectForKey:@"CAEN_coincidenceLevel"] unsignedShortValue]) return TRUE;
-    if ([self triggerOutMask]        != [[dict objectForKey:@"CAEN_triggerOutMask"] unsignedLongValue]) return TRUE;
-    if ([self postTriggerSetting]    != [[dict objectForKey:@"CAEN_postTriggerSetting"] unsignedLongValue]) return TRUE;
-    if ([self frontPanelControlMask] != [[dict objectForKey:@"CAEN_frontPanelControlMask"] unsignedLongValue]) return TRUE;
-    if ([self enabledMask]           != [[dict objectForKey:@"CAEN_enabledMask"] unsignedShortValue]) return TRUE;
+    if ([self channelConfigMask]     != [[dict objectForKey:@"CAEN_channelConfigMask"] unsignedShortValue]) return YES;
+    if ([self eventSize]             != [[dict objectForKey:@"CAEN_eventSize"] intValue]) return YES;
+    if ([self customSize]            != [[dict objectForKey:@"CAEN_customSize"] unsignedLongValue]) return YES;
+    if ([self isCustomSize]          != [[dict objectForKey:@"CAEN_isCustomSize"] boolValue]) return YES;
+    if ([self acquisitionMode]       != [[dict objectForKey:@"CAEN_acquisitionMode"] unsignedShortValue]) return YES;
+    if ([self countAllTriggers]      != [[dict objectForKey:@"CAEN_countAllTriggers"] boolValue]) return YES;
+    if ([self triggerSourceMask]     != [[dict objectForKey:@"CAEN_triggerSourceMask"] unsignedLongValue]) return YES;
+    if ([self coincidenceLevel]      != [[dict objectForKey:@"CAEN_coincidenceLevel"] unsignedShortValue]) return YES;
+    if ([self triggerOutMask]        != [[dict objectForKey:@"CAEN_triggerOutMask"] unsignedLongValue]) return YES;
+    if ([self postTriggerSetting]    != [[dict objectForKey:@"CAEN_postTriggerSetting"] unsignedLongValue]) return YES;
+    if ([self frontPanelControlMask] != [[dict objectForKey:@"CAEN_frontPanelControlMask"] unsignedLongValue]) return YES;
+    if ([self enabledMask]           != [[dict objectForKey:@"CAEN_enabledMask"] unsignedShortValue]) return YES;
     for (int i = 0; i < kNumCaenChannelDacs; i++) {
-        if ([self dac:i] != [[dict objectForKey:[NSString stringWithFormat:@"%@_%i",@"CAEN_dac",i]] unsignedShortValue]) return TRUE;
+        if ([self dac:i] != [[dict objectForKey:[NSString stringWithFormat:@"%@_%i",@"CAEN_dac",i]] unsignedShortValue]) return YES;
     }
 
-    return FALSE;
+    return NO;
 }
 
 - (void) loadFromSerialization:(NSMutableDictionary*)settingsDict


### PR DESCRIPTION
This commit adds a check when the user starts a run to see if the CAEN settings for the new run are different than the current settings. If so, the run is resynced instead of doing a continuous run start.