### PR TITLE
Allow non-experts to set triggers to nominal in a maintenance run

### DIFF
--- a/Source/Objects/Custom Hardware/SNO+/XL3/XL3_LinkController.m
+++ b/Source/Objects/Custom Hardware/SNO+/XL3/XL3_LinkController.m
@@ -859,12 +859,12 @@ static NSDictionary* xl3Ops;
 
 - (void) hvTriggerStatusChanged:(NSNotification*)aNote
 {
-    BOOL lockedOrNotRunningMaintenance = [gSecurity runInProgressButNotType:eMaintenanceRunType orIsLocked:ORXL3Lock];
+    BOOL notRunningOrInMaintenance = isNotRunningOrIsInMaintenance();
 
     if ([model isTriggerON]) {
         [hvATriggerStatusField setStringValue:@"ON"];
         [hvBTriggerStatusField setStringValue:@"ON"];
-        [loadNominalSettingsButton setEnabled:!lockedOrNotRunningMaintenance];
+        [loadNominalSettingsButton setEnabled:notRunningOrInMaintenance];
         [hvTriggersButton setState:NSOnState];
     } else {
         [hvATriggerStatusField setStringValue:@"OFF"];


### PR DESCRIPTION
tested on teststand 