### PR TITLE
update the mapping between crates and channels on the MTCA+ at run starts

### DIFF
--- a/Source/Objects/Custom Hardware/SNO+/MTC/ORMTCModel.h
+++ b/Source/Objects/Custom Hardware/SNO+/MTC/ORMTCModel.h
@@ -270,6 +270,7 @@
 - (void) loadMTCXilinx;
 - (void) loadTubRegister;
 
+- (void) loadMTCACrateMapping;
 - (void) mtcatResetMtcat:(unsigned char) mtcat;
 - (void) mtcatResetAll;
 - (void) mtcatLoadCrateMasks;

--- a/Source/Objects/Custom Hardware/SNO+/MTC/ORMTCModel.m
+++ b/Source/Objects/Custom Hardware/SNO+/MTC/ORMTCModel.m
@@ -242,7 +242,8 @@ tubRegister;
         /* Setup MTCA Thresholds */
         [self loadTheMTCADacs];
 
-        /* Load the crate to channel mapping on the MTCAs from the database. */
+        /* Update the mapping between crates and channels on the front of the
+         * MTCA+s from the detector state database. */
         [self loadMTCACrateMapping];
 
         /* Setup MTCA relays */

--- a/Source/Objects/Custom Hardware/SNO+/MTC/ORMTCModel.m
+++ b/Source/Objects/Custom Hardware/SNO+/MTC/ORMTCModel.m
@@ -1960,9 +1960,15 @@ tubRegister;
 
 - (void) loadMTCACrateMapping
 {
-    /* Sends a command to the MTC server to update the crate mapping from the
-     * database. */
-    [mtc okCommand:"load_mtca_crate_mapping"];
+    /* Sends a command to the MTC server to update the mapping between crates
+     * and channels on the MTCA+s from the detector state database. */
+    @try {
+        [mtc okCommand:"load_mtca_crate_mapping"];
+    } @catch (NSException* e) {
+        NSLogColor([NSColor redColor], @"failed to update the MTCA+ crate mappings: %@\n", [e reason]);
+        [e raise];
+    }
+    NSLog(@"Successfully updated the MTCA+ crate mappings\n");
 }
 
 - (void) mtcatResetMtcat:(unsigned char) mtcat

--- a/Source/Objects/Custom Hardware/SNO+/MTC/ORMTCModel.m
+++ b/Source/Objects/Custom Hardware/SNO+/MTC/ORMTCModel.m
@@ -242,6 +242,9 @@ tubRegister;
         /* Setup MTCA Thresholds */
         [self loadTheMTCADacs];
 
+        /* Load the crate to channel mapping on the MTCAs from the database. */
+        [self loadMTCACrateMapping];
+
         /* Setup MTCA relays */
         [self mtcatLoadCrateMasks];
 
@@ -1952,6 +1955,13 @@ tubRegister;
 		NSLog(@"Failed to load Tub serial register\n");
 		[localException raise];
 	}
+}
+
+- (void) loadMTCACrateMapping
+{
+    /* Sends a command to the MTC server to update the crate mapping from the
+     * database. */
+    [mtc okCommand:"load_mtca_crate_mapping"];
 }
 
 - (void) mtcatResetMtcat:(unsigned char) mtcat


### PR DESCRIPTION
This commit updates the MTC model to send a command to update the mapping between crates and channels on the MTCA+s at the start of every run.