### PR TITLE
ECA modes

### DIFF
--- a/Source/Experiments/SNOP/ECAPatterns.h
+++ b/Source/Experiments/SNOP/ECAPatterns.h
@@ -29,6 +29,18 @@ NSMutableArray* eca_pattern_hcrates();
 #define NCRATES 19
 #define NCARDS 16
 
+NSString* getECAPatternName(int pattern){
+
+    NSArray *pattern_names = [NSArray arrayWithObjects:@"Double Beta",
+                                                       @"Solar",
+                                                       @"Crates",
+                                                       @"Penn Style",
+                                                       @"Channels",
+                                                       @"Half Crates", nil];
+    return pattern_names[pattern];
+    
+}
+
 int getECAPatternNSteps(int pattern){
 
     int nsteps[6] = {8, 32, 19, 9, 32, 38};

--- a/Source/Experiments/SNOP/ECARun.h
+++ b/Source/Experiments/SNOP/ECARun.h
@@ -73,7 +73,7 @@
 - (BOOL) isFinished;
 - (BOOL) isFinishing;
 - (void) stop;
-- (bool) setECASettings:(NSNotification*)aNote;
+- (bool) setECASettings;
 - (void) launchECAThread:(NSNotification*)aNote;
 - (void) doECAs;
 - (BOOL) doPedestals;

--- a/Source/Experiments/SNOP/ECARun.h
+++ b/Source/Experiments/SNOP/ECARun.h
@@ -30,8 +30,6 @@
     NSArray *anXL3Model;
     NSArray *aFECModel;
     //Previous run
-    NSString *previousSR;
-    NSString *previousSRVersion;
     bool start_eca_run;
     int prev_coarsedelay;
     int prev_finedelay;

--- a/Source/Experiments/SNOP/ECARun.h
+++ b/Source/Experiments/SNOP/ECARun.h
@@ -9,6 +9,10 @@
 
 #import <Foundation/Foundation.h>
 
+#define ECAMODE_DEDICATED 0
+#define ECAMODE_SUPERNOVA 1
+#define ECAMODE_PHYSICS 2
+
 @interface ECARun : NSObject {
 
 @private
@@ -18,6 +22,7 @@
     int ECA_tslope_pattern;
     int ECA_nevents;
     NSNumber* ECA_rate;
+    int ECA_mode;
 
     //Other objects
     id anMTCModel;
@@ -25,46 +30,73 @@
     NSArray *anXL3Model;
     NSArray *aFECModel;
     //Previous run
+    NSString *previousSR_campaign;
+    NSString *previousSRVersion_campaign;
+    bool start_new_run_campaign;
     NSString *previousSR;
     NSString *previousSRVersion;
-    bool start_eca_run;
     bool start_new_run;
+    bool start_eca_run;
+    bool eca_campaign_running;
     int prev_coarsedelay;
     int prev_finedelay;
     uint16_t prev_pedwidth;
+    uint32_t prev_gtmask;
+    uint32_t prev_pedmask;
 
     //ECA thread
     NSThread *ECAThread;
     bool isFinishing;
+    bool isFinished;
+    int ECA_currentStep;
+    int ECA_currentPoint;
+    double ECA_currentDelay;
+
 }
 
+- (int) ECA_mode;
+- (NSString*) ECA_mode_string;
 - (int) ECA_pattern;
+- (NSString*) ECA_pattern_string;
 - (NSString*) ECA_type;
 - (int) ECA_tslope_pattern;
 - (int) ECA_nevents;
 - (NSNumber*) ECA_rate;
+- (int) ECA_nsteps;
+- (int) ECA_currentStep;
+- (int) ECA_currentPoint;
+- (int) ECA_currentDelay;
 - (double) ECA_subruntime;
+- (void) setECA_mode:(int)aValue;
 - (void) setECA_pattern:(int)aValue;
 - (void) setECA_type:(NSString*)aValue;
 - (void) setECA_tslope_pattern:(int)aValue;
 - (void) setECA_nevents:(int)aValue;
 - (void) setECA_rate:(NSNumber*)aValue;
+- (void) setECA_currentStep:(int)aValue;
+- (void) setECA_currentPoint:(int)aValue;
+- (void) setECA_currentDelay:(double)aValue;
+- (BOOL) isCampaignRunning;
 - (BOOL) isExecuting;
 - (BOOL) isFinished;
 - (BOOL) isFinishing;
+- (void) startCampaign;
+- (void) startCampaignThread;
 - (void) start;
 - (void) stop;
 - (void) registerNotificationObservers;
-- (void) setPulserRate:(NSNotification*)aNote;
+- (void) setECASettings:(NSNotification*)aNote;
 - (void) launchECAThread:(NSNotification*)aNote;
 - (void) doECAs;
 - (BOOL) doPedestals;
 - (BOOL) doTSlopes;
-- (void) changePedestalMask:(NSMutableArray*)pedestal_mask;
+- (void) changePedestalMask:(NSMutableArray*)aPedestal_mask;
 - (BOOL) triggersOFF;
+- (BOOL) loadTriggersWithCrateMask:(NSMutableArray*)aPedestal_mask;
 - (BOOL) triggersON;
 
 //Notifications
+extern NSString* ORECAStatusChangedNotification;
 extern NSString* ORECARunChangedNotification;
 extern NSString* ORECARunStartedNotification;
 extern NSString* ORECARunFinishedNotification;

--- a/Source/Experiments/SNOP/ECARun.h
+++ b/Source/Experiments/SNOP/ECARun.h
@@ -30,14 +30,9 @@
     NSArray *anXL3Model;
     NSArray *aFECModel;
     //Previous run
-    NSString *previousSR_campaign;
-    NSString *previousSRVersion_campaign;
-    bool start_new_run_campaign;
     NSString *previousSR;
     NSString *previousSRVersion;
-    bool start_new_run;
     bool start_eca_run;
-    bool eca_campaign_running;
     int prev_coarsedelay;
     int prev_finedelay;
     uint16_t prev_pedwidth;
@@ -76,16 +71,11 @@
 - (void) setECA_currentStep:(int)aValue;
 - (void) setECA_currentPoint:(int)aValue;
 - (void) setECA_currentDelay:(double)aValue;
-- (BOOL) isCampaignRunning;
 - (BOOL) isExecuting;
 - (BOOL) isFinished;
 - (BOOL) isFinishing;
-- (void) startCampaign;
-- (void) startCampaignThread;
-- (void) start;
 - (void) stop;
-- (void) registerNotificationObservers;
-- (void) setECASettings:(NSNotification*)aNote;
+- (bool) setECASettings:(NSNotification*)aNote;
 - (void) launchECAThread:(NSNotification*)aNote;
 - (void) doECAs;
 - (BOOL) doPedestals;

--- a/Source/Experiments/SNOP/ECARun.m
+++ b/Source/Experiments/SNOP/ECARun.m
@@ -7,6 +7,7 @@
 //
 
 #import "ECARun.h"
+#import "ORRunModel.h"
 #import "SNOPModel.h"
 #import "ORMTCModel.h"
 #import "ORXL3Model.h"
@@ -319,10 +320,10 @@ NSString* ORECARunFinishedNotification = @"ORECARunFinishedNotification";
 #endif
 
         /* Set the required ECA bits in the run type word */
-        objs = [[(ORAppDelegate*)[NSApp delegate] document] collectObjectsOfClass:NSClassFromString(@"SNOPModel")];
+        objs = [[(ORAppDelegate*)[NSApp delegate] document] collectObjectsOfClass:NSClassFromString(@"ORRunModel")];
         if ([objs count]) {
-            aSNOPModel = [objs objectAtIndex:0];
-            unsigned long runTypeWord = [aSNOPModel runTypeWord];
+            ORRunModel *aRunModel = [objs objectAtIndex:0];
+            unsigned long runTypeWord = [aRunModel runType];
             runTypeWord &= ~(kECAPedestalRun & kECATSlopeRun); //Unset ECA bits
             if ([ECA_type isEqualTo:@"PDST"]) {
                 runTypeWord |= kECAPedestalRun;
@@ -334,7 +335,7 @@ NSString* ORECARunFinishedNotification = @"ORECARunFinishedNotification";
                 //You should never get here
                 NSLogColor([NSColor redColor], @"ECA: Unknown ECA run type. The current run won't be flag as ECA run!");
             }
-            [aSNOPModel setRunTypeWord:runTypeWord];
+            [aRunModel setRunType:runTypeWord];
         }
 
     }

--- a/Source/Experiments/SNOP/ECARun.m
+++ b/Source/Experiments/SNOP/ECARun.m
@@ -170,7 +170,6 @@ NSString* ORECARunFinishedNotification = @"ORECARunFinishedNotification";
         //Load hardcoded values if requested
         if([[aSNOPModel standardRunVersion] isEqualToString:@"ECA_PDST_STANDARD"]){
             //Pedestal run
-            [self setECA_mode:ECAMODE_SUPERNOVA];
             [self setECA_type:ECA_PDST_TYPE];
             [self setECA_rate:[NSNumber numberWithInt:ECA_PDST_RATE]];
             [self setECA_pattern:ECA_PDST_PATTERN];
@@ -178,7 +177,6 @@ NSString* ORECARunFinishedNotification = @"ORECARunFinishedNotification";
         }
         else if([[aSNOPModel standardRunVersion] isEqualToString:@"ECA_TSLP_STANDARD"]){
             //Time Slope run
-            [self setECA_mode:ECAMODE_SUPERNOVA];
             [self setECA_type:ECA_TSLP_TYPE];
             [self setECA_rate:[NSNumber numberWithInt:ECA_TSLP_RATE]];
             [self setECA_pattern:ECA_TSLP_PATTERN];

--- a/Source/Experiments/SNOP/ECARun.m
+++ b/Source/Experiments/SNOP/ECARun.m
@@ -136,7 +136,7 @@ NSString* ORECARunFinishedNotification = @"ORECARunFinishedNotification";
             [previousSR_campaign release];
             [previousSRVersion_campaign release];
             eca_campaign_running = FALSE;
-            [[NSNotificationCenter defaultCenter] postNotificationName:ORECAStatusChangedNotification object: self userInfo: nil];
+            [[NSNotificationCenter defaultCenter] postNotificationOnMainThreadWithName:ORECAStatusChangedNotification object: self userInfo: nil];
             return;
         }
 
@@ -159,7 +159,9 @@ NSString* ORECARunFinishedNotification = @"ORECARunFinishedNotification";
             [previousSR_campaign release];
             [previousSRVersion_campaign release];
             eca_campaign_running = FALSE;
-            [[NSNotificationCenter defaultCenter] postNotificationName:ORECAStatusChangedNotification object: self userInfo: nil];
+            dispatch_sync(dispatch_get_main_queue(), ^{
+                [[NSNotificationCenter defaultCenter] postNotificationName:ORECAStatusChangedNotification object: self userInfo: nil];
+            });
             return;
         }
 
@@ -176,7 +178,9 @@ NSString* ORECARunFinishedNotification = @"ORECARunFinishedNotification";
         [previousSRVersion_campaign release];
         eca_campaign_running = FALSE;
 
-        [[NSNotificationCenter defaultCenter] postNotificationName:ORECAStatusChangedNotification object: self userInfo: nil];
+        dispatch_sync(dispatch_get_main_queue(), ^{
+            [[NSNotificationCenter defaultCenter] postNotificationName:ORECAStatusChangedNotification object: self userInfo: nil];
+        });
 
     }
 
@@ -259,7 +263,7 @@ NSString* ORECARunFinishedNotification = @"ORECARunFinishedNotification";
     NSDictionary *userInfo = [NSDictionary dictionaryWithObjectsAndKeys:
                               @"waiting for ECA run to finish", @"Reason",
                               nil];
-    [[NSNotificationCenter defaultCenter] postNotificationName:ORAddRunStateChangeWait object: self userInfo: userInfo];
+    [[NSNotificationCenter defaultCenter] postNotificationOnMainThreadWithName:ORAddRunStateChangeWait object: self userInfo: userInfo];
 
     /*Set Thread to be cancelled. Only the thread itself can exit.
      This is done by checking the 'cancel' condition within the
@@ -330,6 +334,10 @@ NSString* ORECARunFinishedNotification = @"ORECARunFinishedNotification";
             else if ([ECA_type isEqualTo:@"TSLP"]) {
                 runTypeWord |= kECATSlopeRun;
             }
+            else {
+                //You should never get here
+                NSLogColor([NSColor redColor], @"ECA: Unknown ECA run type. The current run won't be flag as ECA run!");
+            }
             [aSNOPModel setRunTypeWord:runTypeWord];
         }
 
@@ -349,7 +357,7 @@ NSString* ORECARunFinishedNotification = @"ORECARunFinishedNotification";
         [ECAThread release];
         ECAThread = [[NSThread alloc] initWithTarget:self selector:@selector(doECAs) object:nil];
         [ECAThread start];
-        [[NSNotificationCenter defaultCenter] postNotificationName:ORECARunStartedNotification object:self];
+        [[NSNotificationCenter defaultCenter] postNotificationOnMainThreadWithName:ORECARunStartedNotification object:self];
 
     }
 
@@ -359,7 +367,7 @@ NSString* ORECARunFinishedNotification = @"ORECARunFinishedNotification";
 {
     @autoreleasepool {
 
-        [[NSNotificationCenter defaultCenter] postNotificationName:ORECAStatusChangedNotification object: self userInfo: nil];
+        [[NSNotificationCenter defaultCenter] postNotificationOnMainThreadWithName:ORECAStatusChangedNotification object: self userInfo: nil];
 
         /* Get models */
         //MTC model
@@ -517,7 +525,7 @@ NSString* ORECARunFinishedNotification = @"ORECARunFinishedNotification";
             });
         }
 
-        [[NSNotificationCenter defaultCenter] postNotificationName:ORECAStatusChangedNotification object: self userInfo: nil];
+        [[NSNotificationCenter defaultCenter] postNotificationOnMainThreadWithName:ORECAStatusChangedNotification object: self userInfo: nil];
 
     }//end autoreleasepool
 
@@ -841,7 +849,7 @@ NSString* ORECARunFinishedNotification = @"ORECARunFinishedNotification";
 - (void) setECA_pattern:(int)aValue
 {
     ECA_pattern = aValue;
-    [[NSNotificationCenter defaultCenter] postNotificationName:ORECARunChangedNotification object:self];
+    [[NSNotificationCenter defaultCenter] postNotificationOnMainThreadWithName:ORECARunChangedNotification object:self];
 }
 
 - (int)ECA_nsteps
@@ -857,7 +865,7 @@ NSString* ORECARunFinishedNotification = @"ORECARunFinishedNotification";
 - (void)setECA_currentStep:(int)aValue
 {
     ECA_currentStep = aValue;
-    [[NSNotificationCenter defaultCenter] postNotificationName:ORECAStatusChangedNotification object:self];
+    [[NSNotificationCenter defaultCenter] postNotificationOnMainThreadWithName:ORECAStatusChangedNotification object:self];
 }
 
 - (int)ECA_currentPoint
@@ -868,7 +876,7 @@ NSString* ORECARunFinishedNotification = @"ORECARunFinishedNotification";
 - (void)setECA_currentPoint:(int)aValue
 {
     ECA_currentPoint = aValue;
-    [[NSNotificationCenter defaultCenter] postNotificationName:ORECAStatusChangedNotification object:self];
+    [[NSNotificationCenter defaultCenter] postNotificationOnMainThreadWithName:ORECAStatusChangedNotification object:self];
 }
 
 - (int)ECA_currentDelay
@@ -879,7 +887,7 @@ NSString* ORECARunFinishedNotification = @"ORECARunFinishedNotification";
 - (void)setECA_currentDelay:(double)aValue
 {
     ECA_currentDelay = aValue;
-    [[NSNotificationCenter defaultCenter] postNotificationName:ORECAStatusChangedNotification object:self];
+    [[NSNotificationCenter defaultCenter] postNotificationOnMainThreadWithName:ORECAStatusChangedNotification object:self];
 }
 
 - (NSString*)ECA_type
@@ -894,7 +902,7 @@ NSString* ORECARunFinishedNotification = @"ORECARunFinishedNotification";
         NSString* temp = ECA_type;
         ECA_type = [aValue retain];
         [temp release];
-        [[NSNotificationCenter defaultCenter] postNotificationName:ORECARunChangedNotification object:self];
+        [[NSNotificationCenter defaultCenter] postNotificationOnMainThreadWithName:ORECARunChangedNotification object:self];
     }
 }
 
@@ -906,7 +914,7 @@ NSString* ORECARunFinishedNotification = @"ORECARunFinishedNotification";
 - (void) setECA_tslope_pattern:(int)aValue
 {
     ECA_tslope_pattern = aValue;
-    [[NSNotificationCenter defaultCenter] postNotificationName:ORECARunChangedNotification object:self];
+    [[NSNotificationCenter defaultCenter] postNotificationOnMainThreadWithName:ORECARunChangedNotification object:self];
 }
 
 - (int)ECA_nevents
@@ -918,7 +926,7 @@ NSString* ORECARunFinishedNotification = @"ORECARunFinishedNotification";
 {
     if(aValue <= 0) aValue = 1;
     ECA_nevents = aValue;
-    [[NSNotificationCenter defaultCenter] postNotificationName:ORECARunChangedNotification object:self];
+    [[NSNotificationCenter defaultCenter] postNotificationOnMainThreadWithName:ORECARunChangedNotification object:self];
 }
 
 - (NSNumber*)ECA_rate
@@ -947,7 +955,7 @@ NSString* ORECARunFinishedNotification = @"ORECARunFinishedNotification";
         ECA_rate = [[NSNumber alloc] initWithDouble:new_ECA_rate];
         [ECA_rate_limit release];
         [temp release];
-        [[NSNotificationCenter defaultCenter] postNotificationName:ORECARunChangedNotification object:self];
+        [[NSNotificationCenter defaultCenter] postNotificationOnMainThreadWithName:ORECARunChangedNotification object:self];
     }
 }
 
@@ -977,7 +985,7 @@ NSString* ORECARunFinishedNotification = @"ORECARunFinishedNotification";
 -(void) setECA_mode:(int)aValue
 {
     ECA_mode = aValue;
-    [[NSNotificationCenter defaultCenter] postNotificationName:ORECARunChangedNotification object:self];
+    [[NSNotificationCenter defaultCenter] postNotificationOnMainThreadWithName:ORECARunChangedNotification object:self];
 }
 
 

--- a/Source/Experiments/SNOP/ECARun.m
+++ b/Source/Experiments/SNOP/ECARun.m
@@ -188,6 +188,14 @@ NSString* ORECARunFinishedNotification = @"ORECARunFinishedNotification";
 
 - (void) start
 {
+
+    /* Method called when an user request a single ECA run by
+     clicking the corresponding button. Start a new ECA run and 
+     set a flag to enable running of 'launchECAThread'. This will 
+     be called when the run is about to start. This is done in this 
+     way since we need to ensure that the ECAThread is launched AFTER 
+     run stop, to not cancel the Thread. */
+
     if([ECAThread isExecuting]){
         //Do nothing
         NSLogColor([NSColor redColor], @"ECA Run already ongoing!\n");
@@ -241,10 +249,6 @@ NSString* ORECARunFinishedNotification = @"ORECARunFinishedNotification";
             [previousSRVersion release];
         }
 
-        /* Enable the action of method 'launchECAThread' which
-         is called when the run is about to start. This is done
-         in this way since we need to ensure that the ECAThread
-         is launched AFTER run stop, to not cancel the Thread. */
         start_eca_run = TRUE;
         isFinished = FALSE;
 
@@ -354,6 +358,7 @@ NSString* ORECARunFinishedNotification = @"ORECARunFinishedNotification";
         [ECAThread release];
         ECAThread = [[NSThread alloc] initWithTarget:self selector:@selector(doECAs) object:nil];
         [ECAThread start];
+        //[ECAThread autorelease];
         [[NSNotificationCenter defaultCenter] postNotificationOnMainThreadWithName:ORECARunStartedNotification object:self];
 
     }

--- a/Source/Experiments/SNOP/ECARun.m
+++ b/Source/Experiments/SNOP/ECARun.m
@@ -102,6 +102,10 @@ NSString* ORECARunFinishedNotification = @"ORECARunFinishedNotification";
     /* Set ECA parameters based on the run type word and
      * harcoded settings needed for the ECA algorithm */
 
+    NSException* ECAException = [NSException
+                                exceptionWithName:@"ECASettings"
+                                reason:@"ECA settings not set"
+                                userInfo:nil];
     @try{
         isFinished = NO;
         start_eca_run = NO;
@@ -110,7 +114,7 @@ NSString* ORECARunFinishedNotification = @"ORECARunFinishedNotification";
         NSArray* objs = [[(ORAppDelegate*)[NSApp delegate] document] collectObjectsOfClass:NSClassFromString(@"SNOPModel")];
         if (![objs count]) {
             NSLogColor([NSColor redColor], @"setECASettings: SNO+ control not found.\n");
-            return false;
+            @throw ECAException;
         }
         aSNOPModel = [objs objectAtIndex:0];
 
@@ -134,14 +138,14 @@ NSString* ORECARunFinishedNotification = @"ORECARunFinishedNotification";
         objs = [[(ORAppDelegate*)[NSApp delegate] document] collectObjectsOfClass:NSClassFromString(@"ORRunModel")];
         if (![objs count]) {
             NSLogColor([NSColor redColor], @"setECASettings: Run control not found.\n");
-            return false;
+            @throw ECAException;
         }
         ORRunModel *aRunModel = [objs objectAtIndex:0];
         unsigned long runTypeWord = [aRunModel runType];
         //Set whether PDST or TSLP
         if( (runTypeWord & kECAPedestalRun) && (runTypeWord & kECATSlopeRun) ){
             NSLogColor([NSColor redColor], @"setECAsettings: Both PDST and TSLP bits checked in the run type word. Don't know what to do!.\n");
-            return false;
+            @throw ECAException;
         }
         else if( runTypeWord & (kECAPedestalRun) ){
             [self setECA_type:@"PDST"];
@@ -151,7 +155,7 @@ NSString* ORECARunFinishedNotification = @"ORECARunFinishedNotification";
         }
         else{
             NSLogColor([NSColor redColor], @"setECAsettings: not an ECA run.\n");
-            return false;
+            @throw ECAException;
         }
         //Set mode
         if( runTypeWord & (kECARun) ){
@@ -165,7 +169,7 @@ NSString* ORECARunFinishedNotification = @"ORECARunFinishedNotification";
         }
         else{
             NSLogColor([NSColor redColor], @"setECAsettings: Not a valid run for ECA_mode.\n");
-            return false;
+            @throw ECAException;
         }
         //Load hardcoded values if requested
         if([[aSNOPModel standardRunVersion] isEqualToString:@"ECA_PDST_STANDARD"]){
@@ -187,7 +191,7 @@ NSString* ORECARunFinishedNotification = @"ORECARunFinishedNotification";
         }
         else{
             NSLogColor([NSColor redColor], @"setECASettings: Unknown standard run version.\n");
-            return false;
+            @throw ECAException;
         }
         /* Set pulser rate:
          * If we starting an ECA run we have to set the pulser
@@ -195,7 +199,7 @@ NSString* ORECARunFinishedNotification = @"ORECARunFinishedNotification";
         objs = [[(ORAppDelegate*)[NSApp delegate] document] collectObjectsOfClass:NSClassFromString(@"ORMTCModel")];
         if (![objs count]) {
             NSLogColor([NSColor redColor], @"setECASettings: MTC not found.\n");
-            return false;
+            @throw ECAException;
         }
         anMTCModel = [objs objectAtIndex:0];
         [anMTCModel setGtMask:( [anMTCModel gtMask] | MTC_EXT_8_MASK )];
@@ -220,8 +224,8 @@ NSString* ORECARunFinishedNotification = @"ORECARunFinishedNotification";
         return true;
     }
     @catch(...){
-        return false;
         isFinished = YES;
+        return false;
     }
 }
 

--- a/Source/Experiments/SNOP/ECARun.m
+++ b/Source/Experiments/SNOP/ECARun.m
@@ -202,9 +202,6 @@ NSString* ORECARunFinishedNotification = @"ORECARunFinishedNotification";
     @try {
         anMTCModel = [objs objectAtIndex:0];
         [anMTCModel setPgtRate:[[self ECA_rate] floatValue]];
-//#ifndef __TESTING__
-//        [anMTCModel loadPulserRateToHardware];
-//#endif
 
         /* Enable Pedestals */
         [anMTCModel setIsPedestalEnabledInCSR:TRUE];
@@ -212,10 +209,6 @@ NSString* ORECARunFinishedNotification = @"ORECARunFinishedNotification";
         /* Enable Pedestal and GT crate mask for all the crates */
         [anMTCModel setGTCrateMask: (prev_gtmask | 0x7FFFF) ];
         [anMTCModel setPedCrateMask: (prev_pedmask | 0x7FFFF) ];
-//#ifndef __TESTING__
-//        [anMTCModel loadGTCrateMaskToHardware];
-//        [anMTCModel loadPedestalCrateMaskToHardware];
-//#endif
     }
     @catch (...) {
         goto err;

--- a/Source/Experiments/SNOP/ECARun.m
+++ b/Source/Experiments/SNOP/ECARun.m
@@ -168,7 +168,6 @@ NSString* ORECARunFinishedNotification = @"ORECARunFinishedNotification";
         //Rollover to previous run, if any.
         if(start_new_run_campaign){
             dispatch_sync(dispatch_get_main_queue(), ^{
-                [aSNOPModel setResync:YES];
                 [aSNOPModel startStandardRun:previousSR_campaign withVersion:previousSRVersion_campaign];
             });
         }
@@ -225,15 +224,12 @@ NSString* ORECARunFinishedNotification = @"ORECARunFinishedNotification";
         BOOL runstarted = FALSE;
         switch (ECA_mode){
             case ECAMODE_DEDICATED:
-                [aSNOPModel setResync:YES];
                 runstarted = [aSNOPModel startStandardRun:@"ECA" withVersion:@"DEFAULT"];
                 break;
             case ECAMODE_SUPERNOVA:
-                [aSNOPModel setResync:YES];
                 runstarted = [aSNOPModel startStandardRun:@"SUPERNOVA" withVersion:@"DEFAULT"];
                 break;
             case ECAMODE_PHYSICS:
-                [aSNOPModel setResync:YES];
                 runstarted = [aSNOPModel startStandardRun:@"PHYSICS" withVersion:@"DEFAULT"];
                 break;
         }
@@ -505,7 +501,6 @@ NSString* ORECARunFinishedNotification = @"ORECARunFinishedNotification";
         if(start_new_run){
             dispatch_sync(dispatch_get_main_queue(), ^{
                 [[NSNotificationCenter defaultCenter] postNotificationName:ORReleaseRunStateChangeWait object:self];
-                [aSNOPModel setResync:YES];
                 [aSNOPModel startStandardRun:previousSR withVersion:previousSRVersion];
                 //Don't leak memory
                 [previousSR release];

--- a/Source/Experiments/SNOP/SNOP.xib
+++ b/Source/Experiments/SNOP/SNOP.xib
@@ -25,6 +25,7 @@
                 <outlet property="detectorState" destination="rCO-DX-2zv" id="Rep-KK-iKb"/>
                 <outlet property="ecaNEventsTextField" destination="Fze-hD-1jb" id="bwp-QM-cS5"/>
                 <outlet property="ecaPulserRate" destination="Unf-wm-WPb" id="8ED-iU-RaC"/>
+                <outlet property="ecaStatusMatrix" destination="kKV-Je-r50" id="0o3-bo-Jjm"/>
                 <outlet property="elapsedTimeField" destination="3771" id="ZCv-hI-YYv"/>
                 <outlet property="globalxl3Mode" destination="4194" id="4216"/>
                 <outlet property="hvStatusMatrix" destination="2830" id="2912"/>
@@ -107,7 +108,6 @@
                 <outlet property="standardRunThreshLabels" destination="002-Sr-nUh" id="UPB-Ij-RiI"/>
                 <outlet property="standardRunVersionPopupMenu" destination="6EN-vd-XcM" id="Rqc-CS-eNT"/>
                 <outlet property="startRunButton" destination="1253" id="XdY-Mu-6m6"/>
-                <outlet property="startSingleECAButton" destination="HH6-Ln-TL1" id="ugo-Qh-JRM"/>
                 <outlet property="stopNhitMonitorButton" destination="eEC-cV-Yui" id="v9K-Qp-Zvc"/>
                 <outlet property="stopRunButton" destination="1258" id="PGc-XS-Wt7"/>
                 <outlet property="tabView" destination="101" id="332"/>
@@ -3208,27 +3208,8 @@
                                                         <rect key="frame" x="10" y="33" width="283" height="601"/>
                                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                         <subviews>
-                                                            <button id="S4L-A4-8QE">
-                                                                <rect key="frame" x="54" y="498" width="174" height="38"/>
-                                                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                                                <buttonCell key="cell" type="bevel" title="Start ECA Campaign" bezelStyle="regularSquare" imagePosition="overlaps" alignment="center" enabled="NO" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="bte-vs-Ygr">
-                                                                    <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                                                    <font key="font" metaFont="system"/>
-                                                                </buttonCell>
-                                                            </button>
-                                                            <button id="HH6-Ln-TL1">
-                                                                <rect key="frame" x="54" y="3" width="174" height="38"/>
-                                                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                                                <buttonCell key="cell" type="bevel" title="Start Single ECA Run" bezelStyle="regularSquare" imagePosition="overlaps" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="GKp-tL-RiI">
-                                                                    <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                                                    <font key="font" metaFont="system"/>
-                                                                </buttonCell>
-                                                                <connections>
-                                                                    <action selector="startECASingleRunAction:" target="-2" id="dlT-KO-XLf"/>
-                                                                </connections>
-                                                            </button>
                                                             <box autoresizesSubviews="NO" title="ECA run status" borderType="line" id="OD6-Xe-TQT">
-                                                                <rect key="frame" x="18" y="284" width="246" height="209"/>
+                                                                <rect key="frame" x="18" y="329" width="246" height="209"/>
                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                 <view key="contentView">
                                                                     <rect key="frame" x="1" y="1" width="244" height="193"/>
@@ -3435,7 +3416,7 @@
                                                                 <color key="fillColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                                             </box>
                                                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="Tbe-27-6Si">
-                                                                <rect key="frame" x="80" y="150" width="49" height="17"/>
+                                                                <rect key="frame" x="79" y="266" width="49" height="17"/>
                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Pattern" id="MPu-pQ-1Xq">
                                                                     <font key="font" metaFont="system"/>
@@ -3444,7 +3425,7 @@
                                                                 </textFieldCell>
                                                             </textField>
                                                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="akO-sD-Vdf">
-                                                                <rect key="frame" x="24" y="125" width="105" height="17"/>
+                                                                <rect key="frame" x="23" y="241" width="105" height="17"/>
                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Calibration type" id="MXc-Jt-Rqa">
                                                                     <font key="font" metaFont="system"/>
@@ -3453,7 +3434,7 @@
                                                                 </textFieldCell>
                                                             </textField>
                                                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="NcN-o1-TaW">
-                                                                <rect key="frame" x="17" y="100" width="112" height="17"/>
+                                                                <rect key="frame" x="16" y="216" width="112" height="17"/>
                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Number of points" id="LZl-g7-aEl">
                                                                     <font key="font" metaFont="system"/>
@@ -3462,7 +3443,7 @@
                                                                 </textFieldCell>
                                                             </textField>
                                                             <textField verticalHuggingPriority="750" id="Fze-hD-1jb">
-                                                                <rect key="frame" x="133" y="72" width="96" height="22"/>
+                                                                <rect key="frame" x="132" y="188" width="96" height="22"/>
                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" alignment="center" title="200" drawsBackground="YES" id="peA-v0-vb1">
                                                                     <font key="font" metaFont="system"/>
@@ -3474,7 +3455,7 @@
                                                                 </connections>
                                                             </textField>
                                                             <textField verticalHuggingPriority="750" id="Unf-wm-WPb">
-                                                                <rect key="frame" x="133" y="47" width="96" height="22"/>
+                                                                <rect key="frame" x="132" y="163" width="96" height="22"/>
                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" alignment="center" title="10" placeholderString="rate" drawsBackground="YES" id="EjV-KE-y6o">
                                                                     <font key="font" metaFont="system"/>
@@ -3486,7 +3467,7 @@
                                                                 </connections>
                                                             </textField>
                                                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="zoV-Cr-HaI">
-                                                                <rect key="frame" x="13" y="75" width="116" height="17"/>
+                                                                <rect key="frame" x="12" y="191" width="116" height="17"/>
                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Number of events" id="D5S-Pu-CgN">
                                                                     <font key="font" metaFont="system"/>
@@ -3495,7 +3476,7 @@
                                                                 </textFieldCell>
                                                             </textField>
                                                             <popUpButton verticalHuggingPriority="750" id="V5O-ay-jfT">
-                                                                <rect key="frame" x="132" y="120" width="100" height="26"/>
+                                                                <rect key="frame" x="131" y="236" width="100" height="26"/>
                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                 <popUpButtonCell key="cell" type="push" title="PDST" bezelStyle="rounded" alignment="center" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="gFF-EJ-tqR" id="42x-As-8Mn">
                                                                     <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
@@ -3512,7 +3493,7 @@
                                                                 </connections>
                                                             </popUpButton>
                                                             <textField verticalHuggingPriority="750" id="u1v-fA-9yA">
-                                                                <rect key="frame" x="133" y="97" width="96" height="22"/>
+                                                                <rect key="frame" x="132" y="213" width="96" height="22"/>
                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" enabled="NO" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" alignment="center" title="50" drawsBackground="YES" id="GJu-5I-rtz">
                                                                     <font key="font" metaFont="system"/>
@@ -3524,7 +3505,7 @@
                                                                 </connections>
                                                             </textField>
                                                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="tAZ-wL-7yS">
-                                                                <rect key="frame" x="232" y="50" width="57" height="17"/>
+                                                                <rect key="frame" x="231" y="166" width="57" height="17"/>
                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Hz" id="JP6-KP-sku">
                                                                     <font key="font" metaFont="system"/>
@@ -3533,7 +3514,7 @@
                                                                 </textFieldCell>
                                                             </textField>
                                                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="kQN-k1-hnW">
-                                                                <rect key="frame" x="7" y="50" width="122" height="17"/>
+                                                                <rect key="frame" x="6" y="166" width="122" height="17"/>
                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Pulser rate for ECA" id="kD3-tX-LcF">
                                                                     <font key="font" metaFont="system"/>
@@ -3541,47 +3522,8 @@
                                                                     <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                 </textFieldCell>
                                                             </textField>
-                                                            <box autoresizesSubviews="NO" title="ECA Mode" borderType="line" id="etj-Jr-2FP">
-                                                                <rect key="frame" x="73" y="179" width="136" height="101"/>
-                                                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                                                <view key="contentView">
-                                                                    <rect key="frame" x="1" y="1" width="134" height="85"/>
-                                                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                                                                    <subviews>
-                                                                        <matrix verticalHuggingPriority="750" allowsEmptySelection="NO" autorecalculatesCellSize="YES" id="914-8e-zIf">
-                                                                            <rect key="frame" x="9" y="9" width="117" height="70"/>
-                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                            <size key="cellSize" width="115" height="18"/>
-                                                                            <size key="intercellSpacing" width="4" height="2"/>
-                                                                            <buttonCell key="prototype" type="radio" title="Radio" imagePosition="left" alignment="left" enabled="NO" inset="2" id="HkL-z3-dYJ">
-                                                                                <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
-                                                                                <font key="font" metaFont="system"/>
-                                                                            </buttonCell>
-                                                                            <cells>
-                                                                                <column>
-                                                                                    <buttonCell type="radio" title="Dedicated run" imagePosition="left" alignment="left" enabled="NO" state="on" tag="1" inset="2" id="mG6-oq-08V">
-                                                                                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
-                                                                                        <font key="font" metaFont="system"/>
-                                                                                    </buttonCell>
-                                                                                    <buttonCell type="radio" title="Supernova-live" imagePosition="left" alignment="left" enabled="NO" inset="2" id="LRw-sm-UdK">
-                                                                                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
-                                                                                        <font key="font" metaFont="system"/>
-                                                                                    </buttonCell>
-                                                                                    <buttonCell type="radio" title="Physics-live" imagePosition="left" alignment="left" enabled="NO" inset="2" id="bSR-L1-nOz">
-                                                                                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
-                                                                                        <font key="font" metaFont="system"/>
-                                                                                    </buttonCell>
-                                                                                </column>
-                                                                            </cells>
-                                                                        </matrix>
-                                                                    </subviews>
-                                                                </view>
-                                                                <color key="borderColor" white="0.0" alpha="0.41999999999999998" colorSpace="calibratedWhite"/>
-                                                                <color key="fillColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
-                                                            </box>
                                                             <popUpButton verticalHuggingPriority="750" id="dBJ-eI-bEw">
-                                                                <rect key="frame" x="133" y="145" width="143" height="26"/>
+                                                                <rect key="frame" x="132" y="261" width="143" height="26"/>
                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                 <popUpButtonCell key="cell" type="push" title="SNO style" bezelStyle="rounded" alignment="center" lineBreakMode="truncatingTail" state="on" borderStyle="border" inset="2" selectedItem="C35-6s-QyJ" id="TcK-ue-FCD">
                                                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
@@ -3609,6 +3551,15 @@
                                                                     <action selector="ecaPatternChangedAction:" target="-2" id="FqQ-u2-fhJ"/>
                                                                 </connections>
                                                             </popUpButton>
+                                                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="rrf-Ch-JlZ">
+                                                                <rect key="frame" x="93" y="299" width="97" height="17"/>
+                                                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                                <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Single ECA run" id="EuQ-yg-Zkp">
+                                                                    <font key="font" metaFont="system"/>
+                                                                    <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                                    <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                </textFieldCell>
+                                                            </textField>
                                                         </subviews>
                                                     </view>
                                                 </tabViewItem>

--- a/Source/Experiments/SNOP/SNOP.xib
+++ b/Source/Experiments/SNOP/SNOP.xib
@@ -3349,9 +3349,6 @@
                                                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                                                     <font key="font" metaFont="system"/>
                                                                 </buttonCell>
-                                                                <connections>
-                                                                    <action selector="startECASingleRunAction:" target="-2" id="F0u-G0-32q"/>
-                                                                </connections>
                                                             </button>
                                                             <box verticalHuggingPriority="750" title="Box" boxType="separator" titlePosition="noTitle" id="aXs-eZ-20t">
                                                                 <rect key="frame" x="6" y="544" width="270" height="5"/>

--- a/Source/Experiments/SNOP/SNOPController.h
+++ b/Source/Experiments/SNOP/SNOPController.h
@@ -128,7 +128,11 @@
     IBOutlet NSTextField *ecaNEventsTextField;
     IBOutlet NSTextField *ecaPulserRate;
     IBOutlet NSButton *startSingleECAButton;
-    
+    IBOutlet NSButton *startECACampaignButton;
+    IBOutlet NSMatrix *ecaModeButton;
+    IBOutlet NSMatrix *ecaStatusMatrix;
+
+
     //Server settings
     IBOutlet NSComboBox *orcaDBIPAddressPU;
     IBOutlet NSComboBox *debugDBIPAddressPU;

--- a/Source/Experiments/SNOP/SNOPController.h
+++ b/Source/Experiments/SNOP/SNOPController.h
@@ -127,9 +127,6 @@
     IBOutlet NSTextField *TSlopePatternTextField;
     IBOutlet NSTextField *ecaNEventsTextField;
     IBOutlet NSTextField *ecaPulserRate;
-    IBOutlet NSButton *startSingleECAButton;
-    IBOutlet NSButton *startECACampaignButton;
-    IBOutlet NSMatrix *ecaModeButton;
     IBOutlet NSMatrix *ecaStatusMatrix;
 
 

--- a/Source/Experiments/SNOP/SNOPController.m
+++ b/Source/Experiments/SNOP/SNOPController.m
@@ -731,6 +731,8 @@ snopGreenColor;
 
 - (IBAction) startRunAction:(id)sender
 {
+    [self endEditing];
+
     /* Action when the user clicks on the Start or Restart Button. */
     unsigned long dbruntypeword = 0;
 
@@ -1936,24 +1938,17 @@ err:
     [ecaPulserRate setObjectValue:[[model anECARun] ECA_rate]];
 
     if([[aNotification name] isEqualTo:ORECARunStartedNotification]) {
-        [startSingleECAButton setEnabled:false];
-        [startECACampaignButton setEnabled:false];
-        [ecaModeButton setEnabled:false];
         [ECApatternPopUpButton setEnabled:false];
         [ECAtypePopUpButton setEnabled:false];
         [ecaNEventsTextField setEnabled:false];
         [ecaPulserRate setEnabled:false];
     }
     else if([[aNotification name] isEqualTo:ORECARunFinishedNotification]){
-        [startSingleECAButton setEnabled:true];
-        [startECACampaignButton setEnabled:true];
-        [ecaModeButton setEnabled:true];
         [ECApatternPopUpButton setEnabled:true];
         [ECAtypePopUpButton setEnabled:true];
         [ecaNEventsTextField setEnabled:true];
         [ecaPulserRate setEnabled:true];
     }
-    [ecaModeButton selectCellAtRow:[[model anECARun] ECA_mode] column:0];
 
 }
 
@@ -1964,10 +1959,7 @@ err:
 
     //Status
     NSString * ecaStatusLabel = @"Not running";
-    if ([theECARun isCampaignRunning]){
-        ecaStatusLabel = @"Running Campaign";
-    }
-    else if ([theECARun isFinished]){
+    if ([theECARun isFinished]){
         ecaStatusLabel = @"Not running";
     }
     else if ([theECARun isExecuting]){
@@ -2023,22 +2015,6 @@ err:
 - (IBAction)ecaPulserRateAction:(id)sender
 {
     [[model anECARun] setECA_rate:[ecaPulserRate objectValue]];
-}
-
-- (IBAction)ecaModeAction:(id)sender
-{
-    [[model anECARun] setECA_mode:[ecaModeButton selectedRow]];
-}
-
-- (IBAction)startECACampaignAction:(id)sender
-{
-    [model startECACampaign];
-}
-
-- (IBAction)startECASingleRunAction:(id)sender
-{
-    [self endEditing];
-    [model startECARunInParallel];
 }
 
 //STANDARD RUNS

--- a/Source/Experiments/SNOP/SNOPController.m
+++ b/Source/Experiments/SNOP/SNOPController.m
@@ -791,10 +791,6 @@ snopGreenColor;
         [theELLIEModel stopSmellieRun];
     }
 
-    //Make sure we don't start a new run
-    [model setNextStandardRunType:nil];
-    [model setNextStandardRunVersion:nil];
-
 err:
     {
         [model stopRun];

--- a/Source/Experiments/SNOP/SNOPController.m
+++ b/Source/Experiments/SNOP/SNOPController.m
@@ -1960,8 +1960,6 @@ err:
 - (void) ECAStatusChanged:(NSNotification*)aNotification
 {
 
-dispatch_async(dispatch_get_main_queue(), ^{
-
     ECARun *theECARun = [model anECARun];
 
     //Status
@@ -1995,8 +1993,6 @@ dispatch_async(dispatch_get_main_queue(), ^{
     [[ecaStatusMatrix cellAtRow:7 column:0] setStringValue:ecaPointLabel];
     //Delay
     [[ecaStatusMatrix cellAtRow:8 column:0] setDoubleValue:[theECARun ECA_currentDelay]];
-
-});
 
 }
 

--- a/Source/Experiments/SNOP/SNOPController.m
+++ b/Source/Experiments/SNOP/SNOPController.m
@@ -791,6 +791,10 @@ snopGreenColor;
         [theELLIEModel stopSmellieRun];
     }
 
+    //Make sure we don't start a new run
+    [model setNextStandardRunType:nil];
+    [model setNextStandardRunVersion:nil];
+
 err:
     {
         [model stopRun];

--- a/Source/Experiments/SNOP/SNOPModel.h
+++ b/Source/Experiments/SNOP/SNOPModel.h
@@ -103,8 +103,6 @@ BOOL isNotRunningOrIsInMaintenance();
     NSString* standardRunVersion;
     NSString* lastStandardRunType;
     NSString* lastStandardRunVersion;
-    NSString* nextStandardRunType;
-    NSString* nextStandardRunVersion;
     NSNumber* standardRunTableVersion;
 
     bool rolloverRun;
@@ -238,8 +236,6 @@ BOOL isNotRunningOrIsInMaintenance();
 - (void) runNhitMonitor;
 - (void) stopNhitMonitor;
 
-- (int) startMode;
-
 #pragma mark ¥¥orcascript helpers
 - (void) zeroPedestalMasks;
 - (void) hvMasterTriggersOFF;
@@ -252,7 +248,6 @@ BOOL isNotRunningOrIsInMaintenance();
 - (void) runStarted:(NSNotification*)aNote;
 - (void) runAboutToStop:(NSNotification*)aNote;
 - (void) runStopped:(NSNotification*)aNote;
-- (void) runPostStopped:(NSNotification*)aNote;
 
 - (void) _waitForBuffers;
 
@@ -310,10 +305,6 @@ BOOL isNotRunningOrIsInMaintenance();
 - (void) setStandardRunType:(NSString*)aValue;
 - (NSString*) standardRunVersion;
 - (void) setStandardRunVersion:(NSString*)aValue;
-- (NSString*) nextStandardRunType;
-- (void) setNextStandardRunType:(NSString*)aValue;
-- (NSString*) nextStandardRunVersion;
-- (void) setNextStandardRunVersion:(NSString*)aValue;
 - (NSString*) lastStandardRunType;
 - (void) setLastStandardRunType:(NSString*)aValue;
 - (NSString*) lastStandardRunVersion;

--- a/Source/Experiments/SNOP/SNOPModel.h
+++ b/Source/Experiments/SNOP/SNOPModel.h
@@ -252,6 +252,7 @@ BOOL isNotRunningOrIsInMaintenance();
 - (void) runStarted:(NSNotification*)aNote;
 - (void) runAboutToStop:(NSNotification*)aNote;
 - (void) runStopped:(NSNotification*)aNote;
+- (void) runPostStopped:(NSNotification*)aNote;
 
 - (void) _waitForBuffers;
 

--- a/Source/Experiments/SNOP/SNOPModel.h
+++ b/Source/Experiments/SNOP/SNOPModel.h
@@ -335,6 +335,7 @@ BOOL isNotRunningOrIsInMaintenance();
 -(ECARun*) anECARun;
 
 -(void) startECARunInParallel;
+-(void) startECACampaign;
 
 // Standard runs functions
 -(BOOL) refreshStandardRunsFromDB;

--- a/Source/Experiments/SNOP/SNOPModel.h
+++ b/Source/Experiments/SNOP/SNOPModel.h
@@ -103,6 +103,8 @@ BOOL isNotRunningOrIsInMaintenance();
     NSString* standardRunVersion;
     NSString* lastStandardRunType;
     NSString* lastStandardRunVersion;
+    NSString* nextStandardRunType;
+    NSString* nextStandardRunVersion;
     NSNumber* standardRunTableVersion;
 
     bool rolloverRun;
@@ -141,7 +143,7 @@ BOOL isNotRunningOrIsInMaintenance();
     RedisClient *xl3_server;
 
     int state;
-    int start;
+    int startMode;
     bool resync;
     bool waitingForBuffers;     // flag indicates we are waiting for our buffers to empty
 
@@ -236,6 +238,8 @@ BOOL isNotRunningOrIsInMaintenance();
 - (void) runNhitMonitor;
 - (void) stopNhitMonitor;
 
+- (int) startMode;
+
 #pragma mark ¥¥orcascript helpers
 - (void) zeroPedestalMasks;
 - (void) hvMasterTriggersOFF;
@@ -305,6 +309,10 @@ BOOL isNotRunningOrIsInMaintenance();
 - (void) setStandardRunType:(NSString*)aValue;
 - (NSString*) standardRunVersion;
 - (void) setStandardRunVersion:(NSString*)aValue;
+- (NSString*) nextStandardRunType;
+- (void) setNextStandardRunType:(NSString*)aValue;
+- (NSString*) nextStandardRunVersion;
+- (void) setNextStandardRunVersion:(NSString*)aValue;
 - (NSString*) lastStandardRunType;
 - (void) setLastStandardRunType:(NSString*)aValue;
 - (NSString*) lastStandardRunVersion;
@@ -333,9 +341,6 @@ BOOL isNotRunningOrIsInMaintenance();
 
 // ECA
 -(ECARun*) anECARun;
-
--(void) startECARunInParallel;
--(void) startECACampaign;
 
 // Standard runs functions
 -(BOOL) refreshStandardRunsFromDB;

--- a/Source/Experiments/SNOP/SNOPModel.m
+++ b/Source/Experiments/SNOP/SNOPModel.m
@@ -1091,7 +1091,7 @@ err:
 {
     ORRunModel *run = [aNote object];
 
-    uint32_t run_type = [self runTypeWord];
+    uint32_t run_type = [run runType];
     uint32_t run_number = [run runNumber];
     uint32_t source_mask = 0; /* needs to come from the MANIP system */
 
@@ -1110,8 +1110,8 @@ err:
     if (start != ROLLOVER_START) {
         [self setLastStandardRunType:[self standardRunType]];
         [self setLastStandardRunVersion:[self standardRunVersion]];
-        [self setLastRunTypeWord:[self runTypeWord]];
-        NSString* _lastRunTypeWord = [NSString stringWithFormat:@"0x%X",(int)[self runTypeWord]];
+        [self setLastRunTypeWord:run_type];
+        NSString* _lastRunTypeWord = [NSString stringWithFormat:@"0x%X",(int)run_type];
         [self setLastRunTypeWordHex:_lastRunTypeWord]; //FIXME: revisit if we go over 32 bits
     }
 
@@ -2462,7 +2462,7 @@ static NSComparisonResult compareXL3s(ORXL3Model *xl3_1, ORXL3Model *xl3_2, void
 - (void) setRunTypeWord:(unsigned long)aValue
 {
     runTypeWord = aValue;
-    [[NSNotificationCenter defaultCenter] postNotificationName:ORSNOPRunTypeWordChangedNotification object: nil];
+    [[NSNotificationCenter defaultCenter] postNotificationName:ORSNOPRunTypeWordChangedNotification object: self];
 }
 
 - (unsigned long) lastRunTypeWord

--- a/Source/Experiments/SNOP/SNOPModel.m
+++ b/Source/Experiments/SNOP/SNOPModel.m
@@ -1091,7 +1091,7 @@ err:
 {
     ORRunModel *run = [aNote object];
 
-    uint32_t run_type = [run runType];
+    uint32_t run_type = [self runTypeWord];
     uint32_t run_number = [run runNumber];
     uint32_t source_mask = 0; /* needs to come from the MANIP system */
 
@@ -2462,7 +2462,7 @@ static NSComparisonResult compareXL3s(ORXL3Model *xl3_1, ORXL3Model *xl3_2, void
 - (void) setRunTypeWord:(unsigned long)aValue
 {
     runTypeWord = aValue;
-    [[NSNotificationCenter defaultCenter] postNotificationName:ORSNOPRunTypeWordChangedNotification object: self];
+    [[NSNotificationCenter defaultCenter] postNotificationName:ORSNOPRunTypeWordChangedNotification object: nil];
 }
 
 - (unsigned long) lastRunTypeWord
@@ -2573,6 +2573,14 @@ static NSComparisonResult compareXL3s(ORXL3Model *xl3_1, ORXL3Model *xl3_2, void
 - (void) startECARunInParallel
 {
     [anECARun start];
+
+}
+
+- (void) startECACampaign
+{
+
+    [anECARun startCampaign];
+    
 }
 
 - (BOOL) startStandardRun:(NSString*)_standardRun withVersion:(NSString*)_standardRunVersion

--- a/Source/Experiments/SNOP/SNOPModel.m
+++ b/Source/Experiments/SNOP/SNOPModel.m
@@ -476,11 +476,6 @@ tellieRunFiles = _tellieRunFiles;
     return xl3Host;
 }
 
-- (int) startMode
-{
-    return startMode;
-}
-
 - (id) initWithCoder:(NSCoder*)decoder
 {
     self = [super initWithCoder:decoder];
@@ -530,8 +525,6 @@ tellieRunFiles = _tellieRunFiles;
     [self setLastRunTypeWordHex:[decoder decodeObjectForKey:@"SNOPlastRunTypeWordHex"]];
     [self setStandardRunType:[decoder decodeObjectForKey:@"SNOPStandardRunType"]];
     [self setStandardRunVersion:[decoder decodeObjectForKey:@"SNOPStandardRunVersion"]];
-    [self setNextStandardRunType:nil];
-    [self setNextStandardRunVersion:nil];
 
     //ECA
     [anECARun setECA_pattern:[decoder decodeIntForKey:@"SNOPECApattern"]];
@@ -742,11 +735,6 @@ tellieRunFiles = _tellieRunFiles;
                        object : nil];
 
     [notifyCenter addObserver : self
-                     selector : @selector(runPostStopped:)
-                         name : ORRunFinalCallNotification
-                       object : nil];
-
-    [notifyCenter addObserver : self
                      selector : @selector(subRunStarted:)
                          name : ORRunStartSubRunNotification
                        object : nil];
@@ -819,21 +807,17 @@ tellieRunFiles = _tellieRunFiles;
 
     switch (state) {
     case STOPPED:
-        NSLogColor([NSColor redColor], @"runInitialization: COLD_START.\n");
         startMode = COLD_START;
         break;
     case RUNNING:
         if (rolloverRun) {
-            NSLogColor([NSColor redColor], @"runInitialization: ROLLOVER_START.\n");
             startMode = ROLLOVER_START;
             rolloverRun = NO;
         } else {
-            NSLogColor([NSColor redColor], @"runInitialization: CONTINUOUS_START.\n");
             startMode = CONTINUOUS_START;
         }
         break;
     default:
-        NSLogColor([NSColor redColor], @"runInitialization: COLD_START.\n");
         startMode = COLD_START;
     }
 
@@ -1066,7 +1050,7 @@ err:
     /* Load the ECA settings if it's an ECA run
      * This will set MTC settings for correct ECA running, so 
      * we want this to be done before loading settings in HW. */
-    [[self anECARun] setECASettings:nil];
+    [[self anECARun] setECASettings];
 
     switch (startMode) {
     case COLD_START:
@@ -1289,21 +1273,6 @@ err:
         break;
     }
 
-}
-
-- (void) runPostStopped:(NSNotification*)aNote
-{
-    /* Automatic start of scheduled standard run.
-     * This doesn't work properly since this function is not called when
-     * the run is completely stopped and there exist a race condition in
-     * the restartRun method. Will leave this here as a placeholder for
-     * when it's fixed. */
-    if(nextStandardRunType != nil && nextStandardRunVersion != nil){
-        //[self startStandardRun:nextStandardRunType withVersion:nextStandardRunVersion];
-        [self setNextStandardRunType:nil];
-        [self setNextStandardRunVersion:nil];
-    }
-    
 }
 
 - (void) subRunStarted:(NSNotification*)aNote
@@ -2595,28 +2564,6 @@ static NSComparisonResult compareXL3s(ORXL3Model *xl3_1, ORXL3Model *xl3_2, void
 {
     [lastStandardRunVersion autorelease];//MAH -- strings should be handled like this
     lastStandardRunVersion = [aValue copy];
-}
-
-- (NSString*)nextStandardRunType
-{
-    return nextStandardRunType;
-}
-
-- (void) setNextStandardRunType:(NSString *)aValue
-{
-    [nextStandardRunType autorelease];
-    nextStandardRunType = [aValue copy];
-}
-
-- (NSString*) nextStandardRunVersion
-{
-    return nextStandardRunVersion;
-}
-
-- (void) setNextStandardRunVersion:(NSString *)aValue
-{
-    [nextStandardRunVersion autorelease];
-    nextStandardRunVersion = [aValue copy];
 }
 
 - (NSNumber*) standardRunTableVersion

--- a/Source/Experiments/SNOP/SNOPModel.m
+++ b/Source/Experiments/SNOP/SNOPModel.m
@@ -814,17 +814,21 @@ tellieRunFiles = _tellieRunFiles;
 
     switch (state) {
     case STOPPED:
+        NSLogColor([NSColor redColor], @"runInitialization: COLD_START.\n");
         startMode = COLD_START;
         break;
     case RUNNING:
         if (rolloverRun) {
+            NSLogColor([NSColor redColor], @"runInitialization: ROLLOVER_START.\n");
             startMode = ROLLOVER_START;
             rolloverRun = NO;
         } else {
+            NSLogColor([NSColor redColor], @"runInitialization: CONTINUOUS_START.\n");
             startMode = CONTINUOUS_START;
         }
         break;
     default:
+        NSLogColor([NSColor redColor], @"runInitialization: COLD_START.\n");
         startMode = COLD_START;
     }
 

--- a/Source/Experiments/SNOP/SNOPModel.m
+++ b/Source/Experiments/SNOP/SNOPModel.m
@@ -1054,9 +1054,9 @@ err:
         goto err;
     }
 
-    /* Load the ECA settings in case it's an ECA run */
-    /* This will set MTC settings so we want this to be done
-     * before loading the GT mask below.*/
+    /* Load the ECA settings if it's an ECA run
+     * This will set MTC settings for correct ECA running, so 
+     * we want this to be done before loading settings in HW. */
     if( ![[self anECARun] setECASettings:NULL] ){
         NSLogColor([NSColor redColor], @"runAboutToStart: ECA settings not set.\n");
     };

--- a/Source/Experiments/SNOP/SNOPModel.m
+++ b/Source/Experiments/SNOP/SNOPModel.m
@@ -1047,11 +1047,6 @@ err:
         goto err;
     }
 
-    /* Load the ECA settings if it's an ECA run
-     * This will set MTC settings for correct ECA running, so 
-     * we want this to be done before loading settings in HW. */
-    [[self anECARun] setECASettings];
-
     switch (startMode) {
     case COLD_START:
         @try {
@@ -2842,6 +2837,11 @@ err:
         [caenModel loadFromSerialization:runSettings];
         //Load TUBii settings
         [tubiiModel loadFromSerialization:runSettings];
+
+        /* Load the ECA settings if it's an ECA run
+         * This will set MTC settings for correct ECA running, so
+         * we want this to be done before loading settings in HW. */
+        [[self anECARun] setECASettings];
 
         NSLog(@"Standard run %@ (%@) settings loaded. \n",runTypeName,runVersion);
         return true;

--- a/Source/Objects/Custom Hardware/SNO+/XL3/ORXL3Model.h
+++ b/Source/Objects/Custom Hardware/SNO+/XL3/ORXL3Model.h
@@ -365,9 +365,9 @@ enum {
 - (void) loadNominalSettings;
 - (void) _loadTriggersAndSequencers;
 - (void) loadTriggersAndSequencers;
-- (void) disableTriggers;
 - (void) loadTriggers;
 - (void) loadTriggersWithCrateMask:(NSArray*)XL3Mask;
+- (void) disableTriggers;
 - (void) loadSequencers;
 - (void) selectCards:(unsigned long) selectBits;
 - (void) deselectCards;

--- a/Source/Objects/Custom Hardware/SNO+/XL3/ORXL3Model.h
+++ b/Source/Objects/Custom Hardware/SNO+/XL3/ORXL3Model.h
@@ -366,7 +366,7 @@ enum {
 - (void) _loadTriggersAndSequencers;
 - (void) loadTriggersAndSequencers;
 - (void) loadTriggers;
-- (void) disableTriggers;
+- (void) loadTriggersWithCrateMask:(NSArray*)XL3Mask;
 - (void) loadSequencers;
 - (void) selectCards:(unsigned long) selectBits;
 - (void) deselectCards;

--- a/Source/Objects/Custom Hardware/SNO+/XL3/ORXL3Model.h
+++ b/Source/Objects/Custom Hardware/SNO+/XL3/ORXL3Model.h
@@ -365,6 +365,7 @@ enum {
 - (void) loadNominalSettings;
 - (void) _loadTriggersAndSequencers;
 - (void) loadTriggersAndSequencers;
+- (void) disableTriggers;
 - (void) loadTriggers;
 - (void) loadTriggersWithCrateMask:(NSArray*)XL3Mask;
 - (void) loadSequencers;

--- a/Source/Objects/Custom Hardware/SNO+/XL3/ORXL3Model.m
+++ b/Source/Objects/Custom Hardware/SNO+/XL3/ORXL3Model.m
@@ -1870,6 +1870,21 @@ void SwapLongBlock(void* p, int32_t n)
         withObject:nil];
 }
 
+- (void) disableTriggers
+{
+    /* Disable channel triggers. This
+     * function will block and so should only be called on a separate thread.
+     * This function will raise an exception if any error occurs. */
+
+    NSMutableArray* trigger_crate_mask = [NSMutableArray array];
+    for(int islot=0;islot<16;islot++){
+        [trigger_crate_mask insertObject:@0x0 atIndex:islot];
+    }
+
+    [self loadTriggersWithCrateMask:trigger_crate_mask];
+    
+}
+
 - (void) loadTriggers
 {
     /* Loads the current GUI channel trigger settings to the hardware. This

--- a/Source/Objects/Custom Hardware/SNO+/XL3/ORXL3Model.m
+++ b/Source/Objects/Custom Hardware/SNO+/XL3/ORXL3Model.m
@@ -1870,41 +1870,75 @@ void SwapLongBlock(void* p, int32_t n)
         withObject:nil];
 }
 
-- (void) disableTriggers
-{
-    /* Disable channel triggers. This
-     * function will block and so should only be called on a separate thread.
-     * This function will raise an exception if any error occurs. */
-
-    NSMutableArray* trigger_crate_mask = [NSMutableArray array];
-    for(int islot=0;islot<16;islot++){
-        [trigger_crate_mask insertObject:@0x0 atIndex:islot];
-    }
-
-    [self loadTriggersWithCrateMask:trigger_crate_mask];
-    
-}
-
 - (void) loadTriggers
 {
     /* Loads the current GUI channel trigger settings to the hardware. This
      * function will block and so should only be called on a separate thread.
      * This function will raise an exception if any error occurs. */
+    int slot, dbNum, channel;
+    char payload[XL3_PAYLOAD_SIZE];
+    ORFec32Model *fec;
 
-    NSMutableArray* trigger_crate_mask = [NSMutableArray array];
-    for(int islot=0;islot<16;islot++){
-        [trigger_crate_mask insertObject:@0xFFFFFFFF atIndex:islot];
+    memset(&payload, 0, sizeof(payload));
+
+    MultiSetCrateTriggersArgs *args = (MultiSetCrateTriggersArgs *) payload;
+
+    args->slotMask = 0;
+
+    for (slot = 0; slot < 16; slot++) {
+        args->tr100Masks[slot] = 0;
+        args->tr20Masks[slot] = 0;
     }
 
-    [self loadTriggersWithCrateMask:trigger_crate_mask];
-    
+    for (slot = 0; slot < 16; slot++) {
+        fec = [[OROrderedObjManager for:[self guardian]] objectInSlot:16-slot];
+
+        if (!fec) continue;
+
+        args->slotMask |= 1 << slot;
+
+        if ([self isTriggerON]) {
+            for (dbNum = 0; dbNum < 4; dbNum++) {
+                if (![fec dcPresent:dbNum]) continue;
+
+                for (channel = 0; channel < 8; channel++) {
+                    if ([fec trigger100nsEnabled: (dbNum*8 + channel)]) {
+                        args->tr100Masks[slot] |= 1 << (dbNum*8+channel);
+                    }
+
+                    if ([fec trigger20nsEnabled: (dbNum*8 + channel)]) {
+                        args->tr20Masks[slot] |= 1 << (dbNum*8+channel);
+                    }
+                }
+            }
+        }
+    }
+
+    /* Convert args to network byte order. */
+    args->slotMask = htonl(args->slotMask);
+
+    for (slot = 0; slot < 16; slot++) {
+        args->tr100Masks[slot] = htonl(args->tr100Masks[slot]);
+        args->tr20Masks[slot] = htonl(args->tr20Masks[slot]);
+    }
+
+    [[self xl3Link] sendCommand:MULTI_SET_CRATE_TRIGGERS_ID withPayload:payload expectResponse:YES];
+
+    MultiSetCrateTriggersResults *results = (MultiSetCrateTriggersResults *) payload;
+
+    if (ntohl(results->errorMask)) {
+        NSException *e = [NSException exceptionWithName:@"loadTriggersError"
+                          reason:@"failed to load channel triggers"
+                          userInfo:nil];
+        [e raise];
+    }
 }
 
 - (void) loadTriggersWithCrateMask:(NSMutableArray*)aXL3Mask
 {
     /* Loads to the hardware an AND of the current GUI channel trigger settings
-     * and a given mask. This function will block and so should only be called 
-     * on a separate thread. This function will raise an exception if any error 
+     * and a given mask. This function will block and so should only be called
+     * on a separate thread. This function will raise an exception if any error
      * occurs. */
     int slot, dbNum, channel;
     char payload[XL3_PAYLOAD_SIZE];
@@ -1968,6 +2002,48 @@ void SwapLongBlock(void* p, int32_t n)
         NSException *e = [NSException exceptionWithName:@"loadTriggersError"
                                                  reason:@"failed to load channel triggers"
                                                userInfo:nil];
+        [e raise];
+    }
+}
+
+- (void) disableTriggers
+{
+    /* Turns off all channel level triggers. This function does *not* update
+     * the GUI so once this function is called, the GUI will most likely be in
+     * an inconsistent state. This can be useful in certain situations like ECA
+     * runs where you want to disable channel triggers but then load them back
+     * at the end of the run. This function will block until the operation
+     * completes. This function will raise an exception if any error occurs. */
+    int slot;
+    char payload[XL3_PAYLOAD_SIZE];
+
+    memset(&payload, 0, sizeof(payload));
+
+    MultiSetCrateTriggersArgs *args = (MultiSetCrateTriggersArgs *) payload;
+
+    args->slotMask = [self getSlotsPresent];
+
+    for (slot = 0; slot < 16; slot++) {
+        args->tr100Masks[slot] = 0;
+        args->tr20Masks[slot] = 0;
+    }
+
+    /* Convert args to network byte order. */
+    args->slotMask = htonl(args->slotMask);
+
+    for (slot = 0; slot < 16; slot++) {
+        args->tr100Masks[slot] = htonl(args->tr100Masks[slot]);
+        args->tr20Masks[slot] = htonl(args->tr20Masks[slot]);
+    }
+
+    [[self xl3Link] sendCommand:MULTI_SET_CRATE_TRIGGERS_ID withPayload:payload expectResponse:YES];
+
+    MultiSetCrateTriggersResults *results = (MultiSetCrateTriggersResults *) payload;
+
+    if (ntohl(results->errorMask)) {
+        NSException *e = [NSException exceptionWithName:@"loadTriggersError"
+                          reason:@"failed to load channel triggers"
+                          userInfo:nil];
         [e raise];
     }
 }


### PR DESCRIPTION
Supersedes #390. Changes are:
- Remove 'Start Single ECA' and campaign mode
- Select ECA from the SR dropdown menu to start an ECA. There are 2 different modes:
-- User settings: load the settings in the GUI
-- ECA standard: load hardcoded values
- The ECA mode is taken from the run type word (ECA, Supernova or Physics)
- The ECA type is taken from the run type word (PDST or TSLP)
- I didn't figure out how to schedule a new SR after the ECA so now the run doesn't stop when the ECA routine is done. It's up to the user to go to the next run.
- I left a place holder for a scheduler of a next SR. This doesn't work as is, since there is a race condition: runStopped and runPostStopped are not guaranteed to run when the run is fully stop, 'restartRun' is sometimes called while the run is stopping and ORCA doesn't handle this properly. Maybe there is a way to circumvent this, but I didn't figure that out and at this point it's out of the scope of this PR.