### PR TITLE
Smellie run structure

### DIFF
--- a/Source/Experiments/SNOP/SNOPModel.m
+++ b/Source/Experiments/SNOP/SNOPModel.m
@@ -2413,9 +2413,7 @@ static NSComparisonResult compareXL3s(ORXL3Model *xl3_1, ORXL3Model *xl3_2, void
     [runFiles release];
     
     [self setSmellieDocUploaded:YES];
-    dispatch_sync(dispatch_get_main_queue(), ^{
-        [[NSNotificationCenter defaultCenter] postNotificationName:@"SmellieRunFilesLoaded" object:self];
-    });
+    [[NSNotificationCenter defaultCenter] postNotificationName:@"SmellieRunFilesLoaded" object:self];
 }
 
 - (void) getTellieRunFiles

--- a/Source/Experiments/SNOP/SNOPModel.m
+++ b/Source/Experiments/SNOP/SNOPModel.m
@@ -2386,7 +2386,7 @@ static NSComparisonResult compareXL3s(ORXL3Model *xl3_1, ORXL3Model *xl3_2, void
     }
 
     ELLIEModel* anELLIEModel = [ellieModels objectAtIndex:0];
-    NSString *requestString = [NSString stringWithFormat:@"_design/smellieMainQuery/_view/pullEllieRunHeaders?startkey=2"];
+    NSString *requestString = [NSString stringWithFormat:@"_design/smellieMainQuery/_view/pullEllieRunHeaders?startkey=3"];
 
     // This line calls [self couchDBresult], which in turn calls [self parseSmellieRunFileDocs] where the
     // [self smellieRunFiles] property variable gets set.
@@ -2413,7 +2413,9 @@ static NSComparisonResult compareXL3s(ORXL3Model *xl3_1, ORXL3Model *xl3_2, void
     [runFiles release];
     
     [self setSmellieDocUploaded:YES];
-    [[NSNotificationCenter defaultCenter] postNotificationOnMainThreadWithName:@"SmellieRunFilesLoaded" object:self];
+    dispatch_sync(dispatch_get_main_queue(), ^{
+        [[NSNotificationCenter defaultCenter] postNotificationName:@"SmellieRunFilesLoaded" object:self];
+    });
 }
 
 - (void) getTellieRunFiles

--- a/Source/Objects/Custom Hardware/SNO+/ELLIE/ELLIEModel.h
+++ b/Source/Objects/Custom Hardware/SNO+/ELLIE/ELLIEModel.h
@@ -69,7 +69,6 @@
     // Run threads
     NSThread* _tellieThread;
     NSThread* _smellieThread;
-
     NSThread* _tellieTransitionThread;
     NSThread* _smellieTransitionThread;
 }
@@ -173,11 +172,6 @@
 
 -(void)setSmellieSuperkMasterMode:(NSNumber*)intensity withRepRate:(NSNumber*)rate withWavelengthLow:(NSNumber*)wavelengthLow withWavelengthHi:(NSNumber*)wavelengthHi withFibreInput:(NSNumber*)fibreInChan withFibreOutput:(NSNumber*)fibreOutChan withNPulses:(NSNumber*)noPulses withGainVoltage:(NSNumber *)gain;
 
--(NSMutableArray*)getSmellieRunLaserArray:(NSDictionary*)smellieSettings;
--(NSMutableArray*)getSmellieRunFibreArray:(NSDictionary*)smellieSettings;
--(NSMutableArray*)getSmellieRunIntensityArray:(NSDictionary*)smellieSettings forLaser:(NSString*)laser;
--(NSMutableArray*)getSmellieRunGainArray:(NSDictionary*)smellieSettings forLaser:(NSString*)laser;
--(NSMutableArray*)getSmellieLowEdgeWavelengthArray:(NSDictionary*)smellieSettings;
 -(void) startSmellieRunInBackground:(NSDictionary*)smellieSettings;
 -(void) startInterlockThread;
 -(void) killKeepAlive:(NSNotification*)aNote;
@@ -190,7 +184,7 @@
 
 // SMELLIE database interactions
 -(void) pushInitialSmellieRunDocument;
--(void) updateSmellieRunDocument:(NSDictionary*)subRunDoc;
+-(void) updateSmellieRunDocument:(NSArray*)subRunArray;
 -(void) fetchCurrentSmellieConfig;
 -(void) parseCurrentConfigVersion:(id)aResult;
 -(void) fetchConfigurationFile:(NSNumber*)currentVersion;

--- a/Source/Objects/Custom Hardware/SNO+/ELLIE/ELLIEModel.m
+++ b/Source/Objects/Custom Hardware/SNO+/ELLIE/ELLIEModel.m
@@ -1973,9 +1973,7 @@ err:
 
     ////////////////////////////////////////////
     // Tell run control it can stop waiting (this is a spawned thread so use dispatch_sync)
-    dispatch_sync(dispatch_get_main_queue(), ^{
-        [[NSNotificationCenter defaultCenter] postNotificationName:ORReleaseRunStateChangeWait object:self];
-    });
+    [[NSNotificationCenter defaultCenter] postNotificationOnMainThreadWithName:ORReleaseRunStateChangeWait object:self];
     
     //////////////////////////////////////////
     // HANDLE RUN ROLLOVERS
@@ -2011,7 +2009,7 @@ err:
 
     [pool release];
     return;
-        
+
 err:
 {
     // Tell run control it can stop waiting


### PR DESCRIPTION
This PR updates the SMELLIE run structure such that hardware settings are loaded directly from a couchdb 'run plan' document on a sub-run to sub-run basis. ORCA no longer does any interpretation of database documents, it simply executes them explicitly.

This new method allows significantly greater flexibility in run design, which is all handled off-line by SMELLIE experts. 

Has been tested on both the detector and the surface teststand.
