### PR TITLE
fix memory leak in SessionDB

### DIFF
--- a/Source/Experiments/SNOP/SessionDB.m
+++ b/Source/Experiments/SNOP/SessionDB.m
@@ -41,11 +41,11 @@ sessionKey = _sessionKey;
 {
     [connection disconnect];
 
-    [_username dealloc];
-    [_password dealloc];
-    [_dbname dealloc];
-    [_address dealloc];
-    [_sessionKey dealloc];
+    [_username release];
+    [_password release];
+    [_dbname release];
+    [_address release];
+    [_sessionKey release];
 
     [super dealloc];
 }

--- a/Source/Experiments/SNOP/SessionDB.m
+++ b/Source/Experiments/SNOP/SessionDB.m
@@ -1,5 +1,5 @@
 //
-//  SessionDB.h
+//  SessionDB.m
 //  Orca
 //
 //  Created by Andy Mastbaum on Mon Nov 20, 2017.
@@ -40,6 +40,13 @@ sessionKey = _sessionKey;
 - (void) dealloc
 {
     [connection disconnect];
+
+    [_username dealloc];
+    [_password dealloc];
+    [_dbname dealloc];
+    [_address dealloc];
+    [_sessionKey dealloc];
+
     [super dealloc];
 }
 


### PR DESCRIPTION
Release instance vars copied by synthesized properties inside `SessionDB dealloc` before `[super dealloc]`. I think this should correct the leak noticed by Mark (though I'm not 100% sure what the analysis was that found it, and Instruments is being super crashy).