### PR TITLE
Modal alert when missing run ID from DB

### DIFF
--- a/Source/Experiments/SNOP/SNOPModel.m
+++ b/Source/Experiments/SNOP/SNOPModel.m
@@ -881,6 +881,14 @@ err:
 
     [runControl setRunNumber:0xffffffff - 1];
 
+    /* Pop up warning indicating that the default run number is being used. */
+    NSAlert* alert = [[[NSAlert alloc] init] autorelease];
+    [alert addButtonWithTitle:@"OK"];
+    [alert setMessageText:@"Error getting the run number from the database. Using default run number."];
+    [alert setInformativeText:@"Correct this immediately, as data may be lost."];
+    [alert setAlertStyle:NSWarningAlertStyle];
+    [alert runModal];
+
     [[NSNotificationCenter defaultCenter] postNotificationName:ORReleaseRunStateChangeWait object: self];
 
     return;


### PR DESCRIPTION
Pop up a modal warning when unable to fetch the next run number from the database. This is in addition to the existing warning printed to the log.

![screenshot 2018-01-10 15 17 44](https://user-images.githubusercontent.com/677057/34797702-e294baca-f61e-11e7-9259-776babd489b5.png)

Closes #168 