### PR TITLE
Orca alarm when missing run ID from DB

### DIFF
--- a/Source/Experiments/SNOP/SNOPModel.h
+++ b/Source/Experiments/SNOP/SNOPModel.h
@@ -51,6 +51,7 @@ BOOL isNotRunningOrIsInMaintenance();
 @interface SNOPModel: ORExperimentModel <snotDbDelegate>
 {
     SessionDB* sessionDB;
+    ORAlarm* defaultRunAlarm;
 
     NSString* _orcaDBUserName;
     NSString* _orcaDBPassword;

--- a/Source/Experiments/SNOP/SNOPModel.m
+++ b/Source/Experiments/SNOP/SNOPModel.m
@@ -505,6 +505,9 @@ tellieRunFiles = _tellieRunFiles;
     [_smellieRunFiles release];
     [_tellieRunFiles release];
     [_tellieRunNameLabel release];
+
+    [defaultRunAlarm clearAlarm];
+    [defaultRunAlarm dealloc];
     [super dealloc];
 }
 
@@ -632,6 +635,8 @@ tellieRunFiles = _tellieRunFiles;
     ORXL3Model *xl3;
     TUBiiModel *tubii;
     int i;
+
+    [defaultRunAlarm clearAlarm];
 
     objs = [[(ORAppDelegate*)[NSApp delegate] document]
          collectObjectsOfClass:NSClassFromString(@"ORMTCModel")];
@@ -882,10 +887,12 @@ err:
     [runControl setRunNumber:0xffffffff - 1];
 
     /* Post an Orca alarm indicating that the default run number is being used. */
-    ORAlarm* defaultRunAlarm = [[ORAlarm alloc] initWithName:[NSString stringWithFormat:@"Using default run number"]
-                                                    severity:kImportantAlarm];
-    [defaultRunAlarm setAdditionalInfoString:@"Correct this immediately, as data may be lost."];
-    [defaultRunAlarm setSticky:YES];
+    if (!defaultRunAlarm) {
+        defaultRunAlarm = [[ORAlarm alloc] initWithName:[NSString stringWithFormat:@"Using default run number"]
+                                               severity:kImportantAlarm];
+        [defaultRunAlarm setAdditionalInfoString:@"Correct this immediately, as data may be lost."];
+        [defaultRunAlarm setSticky:YES];
+    }
     [defaultRunAlarm setAcknowledged:NO];
     [defaultRunAlarm postAlarm];
 

--- a/Source/Experiments/SNOP/SNOPModel.m
+++ b/Source/Experiments/SNOP/SNOPModel.m
@@ -881,6 +881,14 @@ err:
 
     [runControl setRunNumber:0xffffffff - 1];
 
+    /* Post an Orca alarm indicating that the default run number is being used. */
+    ORAlarm* defaultRunAlarm = [[ORAlarm alloc] initWithName:[NSString stringWithFormat:@"Using default run number"]
+                                                    severity:kImportantAlarm];
+    [defaultRunAlarm setAdditionalInfoString:@"Correct this immediately, as data may be lost."];
+    [defaultRunAlarm setSticky:YES];
+    [defaultRunAlarm setAcknowledged:NO];
+    [defaultRunAlarm postAlarm];
+
     [[NSNotificationCenter defaultCenter] postNotificationName:ORReleaseRunStateChangeWait object: self];
 
     return;


### PR DESCRIPTION
Post an Orca alarm when unable to fetch the next run number from the database. This is in addition to the existing warning printed to the log, but meant to be more attention-grabbing (but non-blocking).

Example of the alarm dialog window, with the detail drawer expanded:
![screenshot 2018-02-05 10 42 10](https://user-images.githubusercontent.com/677057/35817098-141b884c-0a62-11e8-8ce7-903bb3407249.png)
An audible beep also sounds periodically until the alarm is acknowledged.
