### PR TITLE
TELLIE: Add checkbox for tuning runs

### DIFF
--- a/Source/Objects/Custom Hardware/SNO+/ELLIE/ELLIEController.h
+++ b/Source/Objects/Custom Hardware/SNO+/ELLIE/ELLIEController.h
@@ -62,8 +62,9 @@
     IBOutlet NSPopUpButton *tellieExpertFibreSelectPb;
     IBOutlet NSPopUpButton *tellieExpertOperationModePb; //Operation mode (master or slave)
     
+    IBOutlet NSButtonCell *tellieExpertTuningCb;
     IBOutlet NSTextField *tellieExpertValidationStatusTf;
-    
+
     IBOutlet NSButton *tellieExpertFireButton;
     IBOutlet NSButton *tellieExpertStopButton;
     IBOutlet NSButton *tellieExpertValidateSettingsButton;
@@ -143,6 +144,7 @@
 -(void)registerNotificationObservers;
 -(void)awakeFromNib;
 -(void)updateServerSettings:(NSNotification *)aNote;
+-(void)updateTuningRunCB:(NSNotification *)aNote;
 -(BOOL)isNumeric:(NSString *)s;
 -(void)fetchConfigurationFile:(NSNotification *)aNote;
 
@@ -163,6 +165,7 @@
 -(IBAction)tellieExpertAutoFillAction:(id)sender;
 -(IBAction)tellieExpertFibreNameAction:(NSPopUpButton *)sender;
 -(IBAction)tellieExpertModeAction:(NSPopUpButton *)sender;
+-(IBAction)tellieExpertTuningAction:(id)sender;
 
 //Vaidation functions
 -(NSString*)validateGeneralTellieNode:(NSString *)currentText;

--- a/Source/Objects/Custom Hardware/SNO+/ELLIE/ELLIEController.m
+++ b/Source/Objects/Custom Hardware/SNO+/ELLIE/ELLIEController.m
@@ -69,7 +69,7 @@
 	[super updateWindow];
 }
 
-- (void) updateServerSettings: (NSNotification *) aNote
+- (void) updateServerSettings:(NSNotification *)aNote
 {
     [tellieHostTf setStringValue:[model tellieHost]];
     [telliePortTf setStringValue:[model telliePort]];
@@ -79,6 +79,11 @@
 
     [interlockHostTf setStringValue:[model interlockHost]];
     [interlockPortTf setStringValue:[model interlockPort]];
+}
+
+- (void) updateTuningRunCB:(NSNotification *)aNote
+{
+    [tellieExpertTuningCb setState:[model tuningRun]];
 }
 
 - (IBAction) serverSettingsChanged:(id)sender {
@@ -115,6 +120,11 @@
     [notifyCenter addObserver : self
                      selector : @selector(updateServerSettings:)
                          name : @"ELLIEServerSettingsChanged"
+                        object: nil];
+
+    [notifyCenter addObserver : self
+                     selector : @selector(updateTuningRunCB:)
+                         name : @"ELLIETuningButtonChanged"
                         object: nil];
 
     [notifyCenter addObserver : self
@@ -395,6 +405,10 @@
 
 -(IBAction)tellieExpertModeAction:(NSPopUpButton *)sender{
     [tellieExpertFireButton setEnabled:NO];
+}
+
+- (IBAction)tellieExpertTuningAction:(id)sender {
+    [model setTuningRun:[NSNumber numberWithInteger:[tellieExpertTuningCb state]]];
 }
 
 - (IBAction)tellieExpertAutoFillAction:(id)sender {

--- a/Source/Objects/Custom Hardware/SNO+/ELLIE/ELLIEModel.h
+++ b/Source/Objects/Custom Hardware/SNO+/ELLIE/ELLIEModel.h
@@ -58,8 +58,9 @@
     BOOL _tellieMultiFlag;
     BOOL _maintenanceRollOver;
     BOOL _smellieStopButton;
+    NSNumber* _tuningRun;
 
-    //tellie settings
+    //amellie settings
     NSMutableDictionary* _amellieFireParameters;
     NSMutableDictionary* _amellieFibreMapping;
     NSMutableDictionary* _amellieNodeMapping;
@@ -119,6 +120,7 @@
 @property (nonatomic,retain) NSThread* smellieTransitionThread;
 @property (nonatomic,assign) BOOL maintenanceRollOver;
 @property (nonatomic,assign) BOOL smellieStopButton;
+@property (nonatomic,retain) NSNumber* tuningRun;
 
 
 -(id) init;

--- a/Source/Objects/Custom Hardware/SNO+/ELLIE/ELLIEModel.m
+++ b/Source/Objects/Custom Hardware/SNO+/ELLIE/ELLIEModel.m
@@ -192,7 +192,7 @@ NSString* ORSMELLIEEmergencyStop = @"ORSMELLIEEmergencyStop";
         [smellieFlaggingCli release];
         [interlockCli release];
 
-        // Force the tuningRun flag (and checkbox) to be zero (i.e. run rollovers at end of sequence by default)
+        // Force the tuningRun flag (and checkbox) to be zero (i.e. run rolls over at end of T/AMELLIE sequence by default)
         [self setTuningRun:[NSNumber numberWithInteger:0]];
     }
     return self;
@@ -1386,7 +1386,6 @@ err:
 
     // Only roll over if this is NOT a tuning run.
     if(![[self tuningRun] boolValue]){
-        NSLog(@"[TELLIE]: Got inside run rollover\n");
         ///////////////
         //Add run control object
         NSArray*  runModels = [[(ORAppDelegate*)[NSApp delegate] document] collectObjectsOfClass:NSClassFromString(@"ORRunModel")];

--- a/Source/Objects/Custom Hardware/SNO+/ELLIE/ELLIEModel.m
+++ b/Source/Objects/Custom Hardware/SNO+/ELLIE/ELLIEModel.m
@@ -134,6 +134,8 @@ NSString* ORSMELLIEEmergencyStop = @"ORSMELLIEEmergencyStop";
 @synthesize maintenanceRollOver = _maintenanceRollOver;
 @synthesize smellieStopButton = _smellieStopButton;
 
+@synthesize tuningRun = _tuningRun;
+
 /*********************************************************/
 /*                  Class control methods                */
 /*********************************************************/
@@ -189,6 +191,9 @@ NSString* ORSMELLIEEmergencyStop = @"ORSMELLIEEmergencyStop";
         [smellieCli release];
         [smellieFlaggingCli release];
         [interlockCli release];
+
+        // Force the tuningRun flag (and checkbox) to be zero (i.e. run rollovers at end of sequence by default)
+        [self setTuningRun:[NSNumber numberWithInteger:0]];
     }
     return self;
 }
@@ -280,6 +285,8 @@ NSString* ORSMELLIEEmergencyStop = @"ORSMELLIEEmergencyStop";
     // Threads
     [_smellieTransitionThread release];
     [_tellieTransitionThread release];
+
+    [_tuningRun release];
 
     [super dealloc];
 }
@@ -1377,16 +1384,20 @@ err:
         [NSThread sleepForTimeInterval:0.1];
     }
 
-    ///////////////
-    //Add run control object
-    NSArray*  runModels = [[(ORAppDelegate*)[NSApp delegate] document] collectObjectsOfClass:NSClassFromString(@"ORRunModel")];
-    if(![runModels count]){
-        NSLogColor([NSColor redColor], @"[T/AMELLIE]: Couldn't find ORRunModel please add one to the experiment\n");
-        goto err;
+    // Only roll over if this is NOT a tuning run.
+    if(![[self tuningRun] boolValue]){
+        NSLog(@"[TELLIE]: Got inside run rollover\n");
+        ///////////////
+        //Add run control object
+        NSArray*  runModels = [[(ORAppDelegate*)[NSApp delegate] document] collectObjectsOfClass:NSClassFromString(@"ORRunModel")];
+        if(![runModels count]){
+            NSLogColor([NSColor redColor], @"[T/AMELLIE]: Couldn't find ORRunModel please add one to the experiment\n");
+            goto err;
+        }
+        ORRunModel* runControl = [runModels objectAtIndex:0];
+        // Roll over the run.
+        [runControl performSelectorOnMainThread:@selector(restartRun) withObject:nil waitUntilDone:YES];
     }
-    ORRunModel* runControl = [runModels objectAtIndex:0];
-    // Roll over the run.
-    [runControl performSelectorOnMainThread:@selector(restartRun) withObject:nil waitUntilDone:YES];
 
 err:{
     // Tell run control it can stop the run.
@@ -2717,6 +2728,18 @@ err:
 
     [[self interlockClient] setHost:host];
     [[NSNotificationCenter defaultCenter] postNotificationName:@"ELLIEServerSettingsChanged" object:self];
+}
+
+- (void) setTuningRun:(NSNumber *)tuningRun
+{
+    // Set the host for the interlock server XMLRPC client.
+    if (tuningRun == [self tuningRun]) return;
+
+    [tuningRun retain];
+    [_tuningRun release];
+    _tuningRun = tuningRun;
+
+    [[NSNotificationCenter defaultCenter] postNotificationName:@"ELLIETuningRunChanged" object:self];
 }
 
 -(BOOL)pingTellie

--- a/Source/Objects/Custom Hardware/SNO+/ELLIE/ellie.xib
+++ b/Source/Objects/Custom Hardware/SNO+/ELLIE/ellie.xib
@@ -49,6 +49,8 @@
                 <outlet property="tellieExpertOpTViewItem" destination="1122" id="1379"/>
                 <outlet property="tellieExpertOperationModePb" destination="fCF-HW-P1M" id="SCf-yc-vpe"/>
                 <outlet property="tellieExpertStopButton" destination="1207" id="1390"/>
+                <outlet property="tellieExpertTuning" destination="1" id="36p-q6-KG8"/>
+                <outlet property="tellieExpertTuningCb" destination="UKS-br-kMc" id="kyD-Pw-mnu"/>
                 <outlet property="tellieExpertValidateSettingsButton" destination="1206" id="fLS-Bc-uBD"/>
                 <outlet property="tellieExpertValidationStatusTf" destination="1205" id="gzZ-6M-LW3"/>
                 <outlet property="tellieFibreDelayTf" destination="6hn-XS-e2a" id="Ifu-Ap-6EO"/>
@@ -814,6 +816,18 @@
                                                                                     <color key="borderColor" white="0.0" alpha="0.41999999999999998" colorSpace="calibratedWhite"/>
                                                                                     <color key="fillColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                                                                 </box>
+                                                                                <button id="KnK-bH-jqv">
+                                                                                    <rect key="frame" x="383" y="392" width="87" height="18"/>
+                                                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                                                    <animations/>
+                                                                                    <buttonCell key="cell" type="check" title="Tuning run" bezelStyle="regularSquare" imagePosition="left" inset="2" id="UKS-br-kMc">
+                                                                                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                                                        <font key="font" metaFont="system"/>
+                                                                                        <connections>
+                                                                                            <action selector="tellieExpertTuningAction:" target="-2" id="Iy7-ak-kel"/>
+                                                                                        </connections>
+                                                                                    </buttonCell>
+                                                                                </button>
                                                                             </subviews>
                                                                             <animations/>
                                                                         </view>

--- a/Source/Objects/Custom Hardware/SNO+/ELLIE/ellie.xib
+++ b/Source/Objects/Custom Hardware/SNO+/ELLIE/ellie.xib
@@ -107,7 +107,7 @@
                                     <rect key="frame" x="10" y="33" width="606" height="628"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
-                                        <tabView type="bottomTabsBezelBorder" initialItem="17" id="15">
+                                        <tabView appearanceType="aqua" type="bottomTabsBezelBorder" initialItem="17" id="15">
                                             <rect key="frame" x="39" y="17" width="541" height="585"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <animations/>
@@ -817,10 +817,10 @@
                                                                                     <color key="fillColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                                                                 </box>
                                                                                 <button id="KnK-bH-jqv">
-                                                                                    <rect key="frame" x="383" y="392" width="87" height="18"/>
+                                                                                    <rect key="frame" x="383" y="379" width="87" height="37"/>
                                                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                                     <animations/>
-                                                                                    <buttonCell key="cell" type="check" title="Tuning run" bezelStyle="regularSquare" imagePosition="left" inset="2" id="UKS-br-kMc">
+                                                                                    <buttonCell key="cell" type="check" title="Tuning run" bezelStyle="regularSquare" imagePosition="below" alignment="center" inset="2" id="UKS-br-kMc">
                                                                                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                                                         <font key="font" metaFont="system"/>
                                                                                         <connections>


### PR DESCRIPTION
This feature allows an operator to flag 'tuning runs' while TELLIE channels are being tuned for PCA intensity settings. To date the group has observed these settings drift on the day-week scale, so tuning is a more regular occurrence than originally expected. 

When the flag is active the run won't roll over at the end of the requested flash sequence. This should help us stop burning through so many runs (which I think nearline and processing don't respond very well to). 

