### PR TITLE
SMELLIE Crash fix

### DIFF
--- a/Source/Objects/Custom Hardware/SNO+/ELLIE/ELLIEModel.m
+++ b/Source/Objects/Custom Hardware/SNO+/ELLIE/ELLIEModel.m
@@ -1937,6 +1937,19 @@ err:{
     [self setMaintenanceRollOver:YES]; // Asssume we roll over by default.
     [self setSmellieStopButton:NO]; // Had the stop button been pressed?
 
+    /////////////////////
+    // Define some static variables
+    int counter=0;
+    NSString* laser;
+    NSString* fibre;
+    NSNumber* wavelengthLowEdge;
+    NSNumber* wavelengthHighEdge;
+    NSNumber* intensity;
+    NSNumber* gain;
+    NSNumber* rate = [NSNumber numberWithInt:[[smellieSettings objectForKey:@"trigger_frequency"] integerValue]];
+    NSNumber* nTriggers = [NSNumber numberWithInt:[[smellieSettings objectForKey:@"triggers_per_loop"] integerValue]];
+    NSMutableArray* fireSettingsArray = [NSMutableArray arrayWithCapacity:51];
+
     //////////////
     //   GET TUBii & RunControl MODELS
     //////////////
@@ -2006,19 +2019,6 @@ err:{
     dispatch_sync(dispatch_get_main_queue(), ^{
         [[NSNotificationCenter defaultCenter] postNotificationName:ORELLIEFlashing object:self];
     });
-
-    /////////////////////
-    // Define some static variables
-    int counter=0;
-    NSString* laser;
-    NSString* fibre;
-    NSNumber* wavelengthLowEdge;
-    NSNumber* wavelengthHighEdge;
-    NSNumber* intensity;
-    NSNumber* gain;
-    NSNumber* rate = [NSNumber numberWithInt:[[smellieSettings objectForKey:@"trigger_frequency"] integerValue]];
-    NSNumber* nTriggers = [NSNumber numberWithInt:[[smellieSettings objectForKey:@"triggers_per_loop"] integerValue]];
-    NSMutableArray* fireSettingsArray = [NSMutableArray arrayWithCapacity:51];
 
     //////////////////////
     // BEGIN LOOPING!


### PR DESCRIPTION
Resolves issue #495. Crash was happening at line 2164. I couldn't initially reproduce in local testing as the run control wasn't running, so the fireSettingsArray wasn't being checked in my local version.

This PR moves the declaration of that variable to before the first goto to make absolutely sure the object is properly constructed - not just some random memory address on the stack. I put in the check at line 2163 in mind of catching this case, but hadn't considered that the compiler might assign the memory without putting the correct object type there. I guess this is why people don't like goto's :(