### PR TITLE
Change allowed values for TELLIE triggerdelay to any positive integer

### DIFF
--- a/Source/Objects/Custom Hardware/SNO+/ELLIE/ELLIEController.m
+++ b/Source/Objects/Custom Hardware/SNO+/ELLIE/ELLIEController.m
@@ -1488,23 +1488,12 @@
 {
     NSScanner* scanner = [NSScanner scannerWithString:currentText];
     int triggerDelayNumber = [currentText intValue];
-    //5ns discrete steps, so again, adjustment needed if user enters e.g. 1.0 ns)
-    int minimumNumberTriggerDelaySteps = 5;     //in ns
-    int minimumTriggerDelay = 0;                //in ns
-    int maxmiumTriggerDelay = 1275;             //in ns
-    int triggerDelayRemainder = (triggerDelayNumber  % minimumNumberTriggerDelaySteps);
-    
-    NSString* msg = @"[ELLIE_VALIDATION]: Valid trigger delay settings: 0-1275ns in steps of 5ns.\n";
+
+    NSString* msg = @"[ELLIE_VALIDATION]: Trigger delay must be a positive integer\n";
     if (![scanner scanInt:nil]){
         NSLog(msg);
         return msg;
-    } else if(triggerDelayNumber  > maxmiumTriggerDelay){
-        NSLog(msg);
-        return msg;
-    } else if (triggerDelayNumber  < minimumTriggerDelay){
-        NSLog(msg);
-        return msg;
-    } else if (triggerDelayRemainder != 0){
+    } else if (triggerDelayNumber < 0){
         NSLog(msg);
         return msg;
     }


### PR DESCRIPTION
I've had a request to update the allowed range of values for the TELLIE trigger delay. Values are currently allowed in the 0-1275 ns range in 5ns steps. This is the based on the specs of the delay chip on the TELLIE hardware. However, since the group expect to be running in slave mode (through TUBii) they have asked that I replace this check with a positive integer check. They have specifically asked that it have no defined top end. 