### PR TITLE
Force notifications which touch GUI elements onto main thread

### DIFF
--- a/Source/Objects/Custom Hardware/SNO+/ELLIE/ELLIEController.h
+++ b/Source/Objects/Custom Hardware/SNO+/ELLIE/ELLIEController.h
@@ -203,7 +203,8 @@
 - (IBAction)telliePing:(id)sender;
 - (IBAction)smelliePing:(id)sender;
 - (IBAction)interlockPing:(id)sender;
-- (IBAction)tubiiPing:(id)sender;
+- (void)tubiiPing;
+- (IBAction)tubiiPingAction:(id)sender;
 - (IBAction)tubiiRestart:(id)sender;
 - (IBAction)serverSettingsChanged:(id)sender;
 -(void)killInterlock:(NSNotification *)aNote;

--- a/Source/Objects/Custom Hardware/SNO+/ELLIE/ELLIEController.m
+++ b/Source/Objects/Custom Hardware/SNO+/ELLIE/ELLIEController.m
@@ -1585,22 +1585,18 @@
     }
     TUBiiModel* theTubiiModel = [tubiiModels objectAtIndex:0];
     if([[theTubiiModel keepAliveThread] isExecuting]){
-        NSString* response = @"TUBii keep alive thread is already active, restarting.\n";
+        NSString* response = @"TUBii keep alive thread is already active.\n";
         [tubiiThreadResponseTf setStringValue:response];
-        // This method will cancel the thread, causing a break statement to
-        // be called, ending a while loop. Once outside the loop the memory
-        // is tidied up and the user is promped (via a pop-up box) to
-        // re-activate the thread.
-        [theTubiiModel killKeepAlive:nil];
     } else {
         NSString* response = @"TUBii keep alive thread is getting a cold start.\n";
         [tubiiThreadResponseTf setStringValue:response];
         [theTubiiModel activateKeepAlive];
+        // Send a ping after a short delay
+        [self performSelector:@selector(tubiiPing) withObject:self afterDelay:1];
     }
-    [self tubiiPing:self];
 }
 
-- (IBAction)tubiiPing:(id)sender {
+-(void)tubiiPing{
     //////////////
     //Get a Tubii object
     NSArray*  tubiiModels = [[(ORAppDelegate*)[NSApp delegate] document] collectObjectsOfClass:NSClassFromString(@"TUBiiModel")];
@@ -1609,7 +1605,7 @@
         return;
     }
     TUBiiModel* theTubiiModel = [tubiiModels objectAtIndex:0];
-
+    
     // If ping was requested by note, wait to see if keep alive inits OK.
     if([[theTubiiModel keepAliveThread] isExecuting]){
         NSString* response = @"TUBii keep alive thread is active.\n";
@@ -1618,6 +1614,10 @@
     } else {
         [self tubiiDied:nil];
     }
+}
+
+- (IBAction)tubiiPingAction:(id)sender {
+    [self tubiiPing];
 }
 
 -(void)tubiiDied:(NSNotification*)note{

--- a/Source/Objects/Custom Hardware/SNO+/ELLIE/ELLIEController.m
+++ b/Source/Objects/Custom Hardware/SNO+/ELLIE/ELLIEController.m
@@ -314,7 +314,7 @@
     
     [tellieGeneralFireButton setEnabled:NO];
     [tellieGeneralStopButton setEnabled:YES];
-    [[NSNotificationCenter defaultCenter] postNotificationName:ORTELLIERunStartNotification object:nil userInfo:[self guiFireSettings]];
+    [[NSNotificationCenter defaultCenter] postNotificationOnMainThreadWithName:ORTELLIERunStartNotification object:nil userInfo:[self guiFireSettings]];
     [tellieGeneralValidationStatusTf setStringValue:@""];
 }
 
@@ -328,7 +328,7 @@
     }
     
     [tellieExpertStopButton setEnabled:YES];
-    [[NSNotificationCenter defaultCenter] postNotificationName:ORTELLIERunStartNotification object:nil userInfo:[self guiFireSettings]];
+    [[NSNotificationCenter defaultCenter] postNotificationOnMainThreadWithName:ORTELLIERunStartNotification object:nil userInfo:[self guiFireSettings]];
     [tellieExpertFireButton setEnabled:NO];
     [tellieExpertValidationStatusTf setStringValue:@""];
 }
@@ -548,7 +548,7 @@
 
     [amellieFireButton setEnabled:NO];
     [amellieStopButton setEnabled:YES];
-    [[NSNotificationCenter defaultCenter] postNotificationName:ORAMELLIERunStartNotification object:nil userInfo:[self guiFireSettings]];
+    [[NSNotificationCenter defaultCenter] postNotificationOnMainThreadWithName:ORAMELLIERunStartNotification object:nil userInfo:[self guiFireSettings]];
     [amellieValidationStatusTf setStringValue:@""];
 }
 

--- a/Source/Objects/Custom Hardware/SNO+/ELLIE/ELLIEController.m
+++ b/Source/Objects/Custom Hardware/SNO+/ELLIE/ELLIEController.m
@@ -314,7 +314,7 @@
     
     [tellieGeneralFireButton setEnabled:NO];
     [tellieGeneralStopButton setEnabled:YES];
-    [[NSNotificationCenter defaultCenter] postNotificationOnMainThreadWithName:ORTELLIERunStartNotification object:nil userInfo:[self guiFireSettings]];
+    [[NSNotificationCenter defaultCenter] postNotificationName:ORTELLIERunStartNotification object:nil userInfo:[self guiFireSettings]];
     [tellieGeneralValidationStatusTf setStringValue:@""];
 }
 
@@ -328,7 +328,7 @@
     }
     
     [tellieExpertStopButton setEnabled:YES];
-    [[NSNotificationCenter defaultCenter] postNotificationOnMainThreadWithName:ORTELLIERunStartNotification object:nil userInfo:[self guiFireSettings]];
+    [[NSNotificationCenter defaultCenter] postNotificationName:ORTELLIERunStartNotification object:nil userInfo:[self guiFireSettings]];
     [tellieExpertFireButton setEnabled:NO];
     [tellieExpertValidationStatusTf setStringValue:@""];
 }
@@ -548,7 +548,7 @@
 
     [amellieFireButton setEnabled:NO];
     [amellieStopButton setEnabled:YES];
-    [[NSNotificationCenter defaultCenter] postNotificationOnMainThreadWithName:ORAMELLIERunStartNotification object:nil userInfo:[self guiFireSettings]];
+    [[NSNotificationCenter defaultCenter] postNotificationName:ORAMELLIERunStartNotification object:nil userInfo:[self guiFireSettings]];
     [amellieValidationStatusTf setStringValue:@""];
 }
 

--- a/Source/Objects/Custom Hardware/SNO+/ELLIE/ELLIEModel.m
+++ b/Source/Objects/Custom Hardware/SNO+/ELLIE/ELLIEModel.m
@@ -980,11 +980,15 @@ err:
         }
     }
 
+    ////////////////////////
+    // Check keep alive is running.
+    if(![[theTubiiModel keepAliveThread] isExecuting]){
+        NSLog(@"The keep alive thread between ORCA and TUBii was inactive. Relaunching.\n");
+        [theTubiiModel activateKeepAlive];
+    }
+
     ///////////////////////
     // Check trigger is being sent to asyncronus port of the MTC/D (EXT_A)
-    if([[theTubiiModel keepAliveThread] isCancelled]){
-        [theTubiiModel restartKeepAlive:nil];
-    }
     NSUInteger asyncTrigMask;
     @try{
         asyncTrigMask = [theTubiiModel asyncTrigMask];
@@ -1988,6 +1992,13 @@ err:{
         NSLogColor([NSColor redColor], @"[SMELLIE] SMELLIE bit is not masked into the run type word\n");
         NSLogColor([NSColor redColor], @"[SMELLIE]: Please load the SMELLIE standard run type.\n");
         goto err;
+    }
+
+    ////////////////////////
+    // Check keep alive is running.
+    if(![[theTubiiModel keepAliveThread] isExecuting]){
+        NSLog(@"The keep alive thread between ORCA and TUBii was inactive. Relaunching.\n");
+        [theTubiiModel activateKeepAlive];
     }
 
     ///////////////////////

--- a/Source/Objects/Custom Hardware/SNO+/ELLIE/ellie.xib
+++ b/Source/Objects/Custom Hardware/SNO+/ELLIE/ellie.xib
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="6751" systemVersion="15G1004" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="6751" systemVersion="13F1603" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
     <dependencies>
         <deployment version="1060" identifier="macosx"/>
         <development version="5100" identifier="xcode"/>
@@ -2142,7 +2142,7 @@
                                                             <font key="font" metaFont="system"/>
                                                         </buttonCell>
                                                         <connections>
-                                                            <action selector="tubiiPing:" target="-2" id="UBr-wE-SJ0"/>
+                                                            <action selector="tubiiPingAction:" target="-2" id="DVB-bt-JFD"/>
                                                         </connections>
                                                     </button>
                                                 </subviews>

--- a/Source/Objects/Custom Hardware/SNO+/RedisClient/RedisClient.m
+++ b/Source/Objects/Custom Hardware/SNO+/RedisClient/RedisClient.m
@@ -15,6 +15,9 @@
 
 - (void) setTimeout: (long) _timeout
 {
+    /*
+     Timeout should be specified in ms using a long unsigned integer
+    */
     @synchronized(self) {
         timeout = _timeout;
         if (context) {

--- a/Source/Objects/Custom Hardware/SNO+/TUBii/TUBiiModel.h
+++ b/Source/Objects/Custom Hardware/SNO+/TUBii/TUBiiModel.h
@@ -224,7 +224,6 @@ struct TUBiiState { //A struct that allows users of TUBiiModel to get/set all of
                                CounterInhibitOn: (bool) Inhibit;
 -(void)activateKeepAlive;
 -(void)pulseKeepAlive:(id)passed;
--(void)restartKeepAlive:(NSNotification*)aNote;
 -(void)killKeepAlive:(NSNotification*)aNote;
 @end
 

--- a/Source/Objects/Custom Hardware/SNO+/TUBii/TUBiiModel.m
+++ b/Source/Objects/Custom Hardware/SNO+/TUBii/TUBiiModel.m
@@ -962,28 +962,13 @@ NSString* ORTubiiSettingsChangedNotification    = @"ORTubiiSettingsChangedNotifi
         counter = counter + 1;
     }
 
-    NSLog(@"[TUBii]: Stopped sending keep-alive to TUBii - ELLIE pulses will be shut off\n");
-
-    // This thread should always be running. If it's died, post a note to get it automatically restarted.
-    [[NSNotificationCenter defaultCenter] postNotificationOnMainThreadWithName:@"TUBiiKeepAliveDied" object:nil];
+    NSLogColor([NSColor redColor],@"[TUBii]: Stopped sending keep-alive to TUBii\n");
+    NSLogColor([NSColor redColor],@"[TUBii]: Unless you restart this process the ELLIE systems will not be able to trigger through TUBii. If you'd like to restart at a later time please do so from the servers tab of the ELLIE gui\n");
 
     // release memory
     [pool release];
 }
 
--(void)restartKeepAlive:(NSNotification*)aNote{
-    /*
-     If the keep alive has died, as a user to re-start it.
-     */
-
-    BOOL restart = ORRunAlertPanel(@"The keep alive pulse to TUBii has died.",
-                                   @"Unless you restart this process the ELLIE systems will not be able to trigger through TUBii. If you'd like to restart at a later time please do so from the servers tab of the ELLIE gui",
-                                    @"Restart",
-                                    @"Cancel",nil);
-    if(restart){
-        [self activateKeepAlive];
-    }
-}
 
 -(void)killKeepAlive:(NSNotification*)aNote
 {

--- a/Source/Objects/Custom Hardware/SNO+/TUBii/TUBiiModel.m
+++ b/Source/Objects/Custom Hardware/SNO+/TUBii/TUBiiModel.m
@@ -965,7 +965,7 @@ NSString* ORTubiiSettingsChangedNotification    = @"ORTubiiSettingsChangedNotifi
     NSLog(@"[TUBii]: Stopped sending keep-alive to TUBii - ELLIE pulses will be shut off\n");
 
     // This thread should always be running. If it's died, post a note to get it automatically restarted.
-    [[NSNotificationCenter defaultCenter] postNotificationName:@"TUBiiKeepAliveDied" object:nil];
+    [[NSNotificationCenter defaultCenter] postNotificationOnMainThreadWithName:@"TUBiiKeepAliveDied" object:nil];
 
     // release memory
     [pool release];
@@ -975,6 +975,7 @@ NSString* ORTubiiSettingsChangedNotification    = @"ORTubiiSettingsChangedNotifi
     /*
      If the keep alive has died, as a user to re-start it.
      */
+
     BOOL restart = ORRunAlertPanel(@"The keep alive pulse to TUBii has died.",
                                    @"Unless you restart this process the ELLIE systems will not be able to trigger through TUBii. If you'd like to restart at a later time please do so from the servers tab of the ELLIE gui",
                                     @"Restart",

--- a/Source/Objects/Custom Hardware/SNO+/TUBii/TUBiiModel.m
+++ b/Source/Objects/Custom Hardware/SNO+/TUBii/TUBiiModel.m
@@ -89,6 +89,7 @@ NSString* ORTubiiSettingsChangedNotification    = @"ORTubiiSettingsChangedNotifi
         connection = [[RedisClient alloc] init]; // Connection must be allocated before port and host name are set
         portNumber = TUBII_DEFAULT_PORT;
         strHostName = [[NSString alloc]initWithUTF8String:TUBII_DEFAULT_IP];
+        [connection setTimeout:2];
     }
     return self;
 }

--- a/Source/Objects/Custom Hardware/SNO+/TUBii/TUBiiModel.m
+++ b/Source/Objects/Custom Hardware/SNO+/TUBii/TUBiiModel.m
@@ -89,8 +89,8 @@ NSString* ORTubiiSettingsChangedNotification    = @"ORTubiiSettingsChangedNotifi
         connection = [[RedisClient alloc] init]; // Connection must be allocated before port and host name are set
         portNumber = TUBII_DEFAULT_PORT;
         strHostName = [[NSString alloc]initWithUTF8String:TUBII_DEFAULT_IP];
-        // This is being extended in an attempt to resolve the issues with ORPHANs
-        // from missing TUBii information at run rollovers.
+        // Timeout is extended from 1s to 2s in an attempt to prevent the
+        // latency from remote shift stations causing timeouts
         [connection setTimeout:2000];
     }
     return self;
@@ -144,8 +144,8 @@ NSString* ORTubiiSettingsChangedNotification    = @"ORTubiiSettingsChangedNotifi
 
         //Connection must be made before port and host name are set.
         connection = [[RedisClient alloc] initWithHostName:strHostName withPort:portNumber];
-        // This is being extended in an attempt to resolve the issues with ORPHANs
-        // from missing TUBii information at run rollovers.
+        // Timeout is extended from 1s to 2s in an attempt to prevent the
+        // latency from remote shift stations causing timeouts
         [connection setTimeout:2000];
     }
     return self;

--- a/Source/Objects/Custom Hardware/SNO+/TUBii/TUBiiModel.m
+++ b/Source/Objects/Custom Hardware/SNO+/TUBii/TUBiiModel.m
@@ -167,11 +167,6 @@ NSString* ORTubiiSettingsChangedNotification    = @"ORTubiiSettingsChangedNotifi
                        object : nil];
 
     [notifyCenter addObserver : self
-                     selector : @selector(restartKeepAlive:)
-                         name : @"TUBiiKeepAliveDied"
-                       object : nil];
-
-    [notifyCenter addObserver : self
                      selector : @selector(killKeepAlive:)
                          name : @"TELLIEEmergencyStop"
                        object : nil];

--- a/Source/Objects/Custom Hardware/SNO+/TUBii/TUBiiModel.m
+++ b/Source/Objects/Custom Hardware/SNO+/TUBii/TUBiiModel.m
@@ -89,7 +89,9 @@ NSString* ORTubiiSettingsChangedNotification    = @"ORTubiiSettingsChangedNotifi
         connection = [[RedisClient alloc] init]; // Connection must be allocated before port and host name are set
         portNumber = TUBII_DEFAULT_PORT;
         strHostName = [[NSString alloc]initWithUTF8String:TUBII_DEFAULT_IP];
-        [connection setTimeout:2];
+        // This is being extended in an attempt to resolve the issues with ORPHANs
+        // from missing TUBii information at run rollovers.
+        [connection setTimeout:2000];
     }
     return self;
 }
@@ -142,7 +144,9 @@ NSString* ORTubiiSettingsChangedNotification    = @"ORTubiiSettingsChangedNotifi
 
         //Connection must be made before port and host name are set.
         connection = [[RedisClient alloc] initWithHostName:strHostName withPort:portNumber];
-        [connection setTimeout:2];
+        // This is being extended in an attempt to resolve the issues with ORPHANs
+        // from missing TUBii information at run rollovers.
+        [connection setTimeout:2000];
     }
     return self;
 }

--- a/Source/Objects/Custom Hardware/SNO+/TUBii/TUBiiModel.m
+++ b/Source/Objects/Custom Hardware/SNO+/TUBii/TUBiiModel.m
@@ -142,6 +142,7 @@ NSString* ORTubiiSettingsChangedNotification    = @"ORTubiiSettingsChangedNotifi
 
         //Connection must be made before port and host name are set.
         connection = [[RedisClient alloc] initWithHostName:strHostName withPort:portNumber];
+        [connection setTimeout:2];
     }
     return self;
 }


### PR DESCRIPTION
This PR is an attempt fix the CRUS crash observed recently at Sussex. Debugging by Martti suggests the issue was [line 978](https://github.com/snoplus/orca/blob/master/Source/Objects/Custom%20Hardware/SNO%2B/TUBii/TUBiiModel.m#L978) of the TUBii model. This should be resolved by posting the note which calls this method on the main thread. 

It may be that #499 was also due to the *ellieFireAction methods in the ELLIEController not posting to the main thread. These notes are picked up in the SNOPController and the resulting method calls make minor GUI changes (activate / deactivate buttons). This PR also addresses those cases. 