### PR TITLE
CRSU debugging: empty strings 

### DIFF
--- a/Source/Objects/Custom Hardware/SNO+/Fec32/ORFec32Controller.m
+++ b/Source/Objects/Custom Hardware/SNO+/Fec32/ORFec32Controller.m
@@ -546,7 +546,11 @@
 
 - (void) commentsChanged:(NSNotification*)aNote
 {
-	[commentsTextField setStringValue: [model comments]];
+    if (![model comments]){
+        [commentsTextField setStringValue: @""];
+    } else {
+        [commentsTextField setStringValue: [model comments]];
+    }
 }
 
 - (void) checkGlobalSecurity
@@ -623,7 +627,11 @@
 
 - (void) boardIdChanged:(NSNotification*)aNote
 {
-	[boardIdField setStringValue:[model boardID]];
+    if(![model boardID]){
+        [boardIdField setStringValue: @""];
+    } else {
+        [boardIdField setStringValue:[model boardID]];
+    }
 }
 
 - (void) cmosChanged:(NSNotification*)aNote

--- a/Source/Objects/Custom Hardware/SNO+/SNOCrate/ORSNOCrateController.m
+++ b/Source/Objects/Custom Hardware/SNO+/SNOCrate/ORSNOCrateController.m
@@ -115,7 +115,13 @@
 	[[self window] setTitle:[NSString stringWithFormat:@"%@",[model identifier]]];
 	[memBaseAddressField setIntValue:[model memoryBaseAddress]];
 	[regBaseAddressField setIntValue:[model registerBaseAddress]];
-	[iPBaseAddressField setStringValue:[model iPAddress]];
+	
+    if (![model iPAddress]){
+        [iPBaseAddressField setStringValue: @""];
+    } else {
+        [iPBaseAddressField setStringValue:[model iPAddress]];
+    }
+    
 	[crateNumberField setIntValue:[model crateNumber]];
 }
 


### PR DESCRIPTION
Simple fix to insert an empty string whenever an empty variable is passed back. 
Not critical, but was throwing assertion failures in Xcode when testing. 
This might be also present at other places, these were found during short test on teststand.