### PR TITLE
Fix TUBii orphans

### DIFF
--- a/Source/Objects/Custom Hardware/SNO+/TUBii/TUBiiModel.h
+++ b/Source/Objects/Custom Hardware/SNO+/TUBii/TUBiiModel.h
@@ -151,7 +151,6 @@ struct TUBiiState { //A struct that allows users of TUBiiModel to get/set all of
 - (void) makeMainController;
 - (void) encodeWithCoder:(NSCoder *)aCoder;
 - (void) dealloc;
-- (void) awakeAfterDocumentLoaded;
 - (BOOL) solitaryObject;
 
 - (float) ConvertBitsToValue:(NSUInteger)bits NBits: (int) nBits MinVal: (float) minVal MaxVal: (float) maxVal;

--- a/Source/Objects/Custom Hardware/SNO+/TUBii/TUBiiModel.m
+++ b/Source/Objects/Custom Hardware/SNO+/TUBii/TUBiiModel.m
@@ -104,6 +104,8 @@ NSString* ORTubiiSettingsChangedNotification    = @"ORTubiiSettingsChangedNotifi
 #pragma mark •••Archival
 - (id) initWithCoder:(NSCoder *)aCoder {
     self = [super initWithCoder:aCoder];
+    [self registerNotificationObservers];
+    [self activateKeepAlive];
     if (self) {
         //  Initialize model member variables
         currentModelState.smellieRate = 0;
@@ -168,25 +170,9 @@ NSString* ORTubiiSettingsChangedNotification    = @"ORTubiiSettingsChangedNotifi
     NSNotificationCenter* notifyCenter = [NSNotificationCenter defaultCenter];
 
     [notifyCenter addObserver : self
-                     selector : @selector(runAboutToStart:)
-                         name : ORRunAboutToStartNotification
-                       object : nil];
-
-    [notifyCenter addObserver : self
                      selector : @selector(killKeepAlive:)
                          name : @"TELLIEEmergencyStop"
                        object : nil];
-}
-- (void) runAboutToStart: (NSNotification*) aNone {
-    [self setDataReadout:NO];
-    [self ResetFifo]; //Maybe take this out eventually? I'm not sure
-    [self setDataReadout:YES];
-}
-
-- (void) awakeAfterDocumentLoaded
-{
-    [self registerNotificationObservers];
-    [self activateKeepAlive];
 }
 
 #pragma mark •••Network Communication
@@ -952,7 +938,7 @@ NSString* ORTubiiSettingsChangedNotification    = @"ORTubiiSettingsChangedNotifi
             break;
         }
         
-        [NSThread sleepForTimeInterval:0.5];
+        [NSThread sleepForTimeInterval:5.0];
 
         // This is a very long running thread need to relase the pool every so often
         if(counter == 1000){
@@ -965,6 +951,9 @@ NSString* ORTubiiSettingsChangedNotification    = @"ORTubiiSettingsChangedNotifi
 
     NSLogColor([NSColor redColor],@"[TUBii]: Stopped sending keep-alive to TUBii\n");
     NSLogColor([NSColor redColor],@"[TUBii]: Unless you restart this process the ELLIE systems will not be able to trigger through TUBii. If you'd like to restart at a later time please do so from the servers tab of the ELLIE gui\n");
+
+    // Update the servers tab of the ELLIE gui to denote that the keep alive is no longer active
+    [[NSNotificationCenter defaultCenter] postNotificationOnMainThreadWithName:@"TUBiiKeepAliveDied" object:self];
 
     // release memory
     [pool release];

--- a/Source/Objects/Custom Hardware/SNO+/TUBii/TUBiiModel.m
+++ b/Source/Objects/Custom Hardware/SNO+/TUBii/TUBiiModel.m
@@ -105,7 +105,6 @@ NSString* ORTubiiSettingsChangedNotification    = @"ORTubiiSettingsChangedNotifi
 - (id) initWithCoder:(NSCoder *)aCoder {
     self = [super initWithCoder:aCoder];
     [self registerNotificationObservers];
-    [self activateKeepAlive];
     if (self) {
         //  Initialize model member variables
         currentModelState.smellieRate = 0;
@@ -150,6 +149,7 @@ NSString* ORTubiiSettingsChangedNotification    = @"ORTubiiSettingsChangedNotifi
         // latency from remote shift stations causing timeouts
         [connection setTimeout:2000];
     }
+    [self activateKeepAlive];
     return self;
 }
 - (void) encodeWithCoder:(NSCoder *)aCoder{


### PR DESCRIPTION
This PR removes the problem runAboutToStart function from the TUBii model and moves the registration of notification observers to initWithCoder. 

A single line is also added to the keepAliveFunction so the ELLIE gui properly updates when the keepAlive is no longer running. The time between pulses is also increase to 5s in order to avoid 'flooding' the TUBii server with more request then are required. I checked with @icoulter and the server itself expects a ping every 30s, so this is still well within tolerance. 

@tlatorre-uchicago, if it's possible it might be a good idea to test this on the detector later when you're deploying the new servers. 