### PR TITLE
Only push one TELLIE couchdb document per run

### DIFF
--- a/Source/Objects/Custom Hardware/SNO+/ELLIE/ELLIEModel.m
+++ b/Source/Objects/Custom Hardware/SNO+/ELLIE/ELLIEModel.m
@@ -1072,7 +1072,7 @@ err:
 
     ///////////////
     // Now set-up is done, push initial run document
-    if([runControl isRunning]){
+    if([runControl isRunning] && ([runControl subRunNumber] == 0)){
         @try{
             if(forTELLIE){
                 [self pushInitialTellieRunDocument];


### PR DESCRIPTION
The TELLIE 'Tuning Run' tick box was added in #494. This PR updates the flash sequence logic such that only one couchdb document is generated for a run when this box is checked. 

That single document will contain the hardware settings sent to the TELLIE hardware (and PIN diode readback) for each sub-run contained within a 'Tuning Run'. 