### PR TITLE
Prevent tubii run start exception from bubbling up

### DIFF
--- a/Source/Objects/Custom Hardware/SNO+/TUBii/TUBiiModel.m
+++ b/Source/Objects/Custom Hardware/SNO+/TUBii/TUBiiModel.m
@@ -178,9 +178,16 @@ NSString* ORTubiiSettingsChangedNotification    = @"ORTubiiSettingsChangedNotifi
                        object : nil];
 }
 - (void) runAboutToStart: (NSNotification*) aNone {
-    [self setDataReadout:NO];
-    [self ResetFifo]; //Maybe take this out eventually? I'm not sure
-    [self setDataReadout:YES];
+    @try {
+        [self setDataReadout:NO];
+        [self ResetFifo]; //Maybe take this out eventually? I'm not sure
+        [self setDataReadout:YES];
+    } @catch (NSException *exception) {
+        // Need to catch the exception here and not let it bubble up.
+        // Else the run will not actually start. And TUBii isn't of high enough
+        // priority to stop a run start.
+        NSLogColor([NSColor redColor], @"Could not start tubii data readout: Exception: %@ Reason: %@\n", [exception name],[exception reason]);
+    }
 }
 
 - (void) awakeAfterDocumentLoaded


### PR DESCRIPTION
When starting a run tubii's runAboutToStart function gets called and if it raises an uncaught exception the run will be prevented from starting. I think we don't in general want this to be the case so this commit just catches and warns about any exceptions that occur instead of letting them stop the run from starting. Fixes #505 