### PR TITLE
clean up two problematic log messages

### DIFF
--- a/Source/Experiments/SNOP/NHitMonitor.m
+++ b/Source/Experiments/SNOP/NHitMonitor.m
@@ -706,6 +706,10 @@ err:
         NSLog(@"nhit_20_lb   threshold is %.2f nhit\n", threshold_n20_lb);
     }
 
+    NSLog(@"Note these thresholds were calculated by Orca and might be incorrect.");
+    NSLog(@"The results of the nearline nhit monitor process are available at the end of the run.");
+    NSLog(@"They can be found on the monitoring page. Under the Detector tab, select NHit Monitor.");
+
     NSDictionary *userInfo = @{@"n100_lo": @(threshold_n100_lo),
                                @"n100_med": @(threshold_n100_med),
                                @"n100_hi": @(threshold_n100_hi),

--- a/Source/Objects/Misc Objects/PostgreSQL/ORPQModel.m
+++ b/Source/Objects/Misc Objects/PostgreSQL/ORPQModel.m
@@ -992,15 +992,6 @@ static NSString* ORPQModelInConnector 	= @"ORPQModelInConnector";
     {
         NSLog(@"Loaded %@ DB: PMTHV(%d), FEC(%d), Crate(%d), MTC(%d), CAEN(%d)\n", [delegate dataBaseName],
               detDB->pmthvLoaded, detDB->fecLoaded, detDB->crateLoaded, detDB->mtcLoaded, detDB->caenLoaded);
-        if (countBadNhit100Enabled || countBadNhit20Enabled) {
-            NSLogColor([NSColor redColor], @"Warning!  Some bad channels have triggers enabled:\n");
-            if (countBadNhit100Enabled) NSLogColor([NSColor redColor], @"  - %d bad channels with NHIT100 enabled\n", countBadNhit100Enabled);
-            if (countBadNhit20Enabled)  NSLogColor([NSColor redColor], @"  - %d bad channels with NHIT20 enabled\n", countBadNhit20Enabled);
-        } else if (countBadSequencerEnabled || countBadThresholdNotMax) {
-            NSLog(@"Note!  Some bad channels are enabled:\n");
-        }
-        if (countBadSequencerEnabled) NSLog(@"  - %d bad channels with sequencer enabled\n", countBadSequencerEnabled);
-        if (countBadThresholdNotMax)  NSLog(@"  - %d bad channels with threshold not set to max\n", countBadThresholdNotMax);
         return detDB;
     } else {
         [detDB release];


### PR DESCRIPTION
- The nhit monitor results from Orca might be wrong, so add a message that points to the monitoring page. However, I left the current Orca print out, since it provides immediate feedback, which can be useful. 
- Orca does not talk to the channel database, so the message about "bad channels with triggers enabled" is both wrong and confusing. The detector state check does this, Orca really doesn't need these messages. 