### PR TITLE
Add sub_run_number to TELLIE / AMELLIE run docs

### DIFF
--- a/Source/Objects/Custom Hardware/SNO+/ELLIE/ELLIEModel.m
+++ b/Source/Objects/Custom Hardware/SNO+/ELLIE/ELLIEModel.m
@@ -1172,6 +1172,7 @@ err:
         [valuesToFillPerSubRun setDictionary:fireCommands];
         [valuesToFillPerSubRun setObject:noShots forKey:@"number_of_shots"];
         [valuesToFillPerSubRun setObject:photonOutput forKey:@"photons"];
+        [valuesToFillPerSubRun setObject:[NSNumber numberWithInt:[runControl subRunNumber]] forKey:@"sub_run_number"];
         
         NSLog(@"%@: Firing fibre %@: %d pulses, %1.0f Hz\n", prefix, [fireCommands objectForKey:@"fibre"], [noShots integerValue], rate);
         


### PR DESCRIPTION
A one line change to add the sub-run number to the TELLIE / AMELLIE couchdb docs